### PR TITLE
fix(merge): restore branch files and guard .First() calls

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/BatchImageConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/BatchImageConverterConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using ImageMagick;
 
 namespace Argumentum.AssetConverter
@@ -21,7 +22,7 @@ namespace Argumentum.AssetConverter
         public double Modulation { get; set; } = 200;
 
 
-        public void Apply()
+        public async Task Apply()
         {
             var objSourceDir = new DirectoryInfo(SourcePath);
             var objTargetDir = new DirectoryInfo(DestPath);
@@ -32,7 +33,7 @@ namespace Argumentum.AssetConverter
                     BatchImagePngToCnykJpegsInternal(objSourceDir, objTargetDir);
                     break;
                 case BatchImageOperation.ModulateHue:
-                    BatchImageModulate(objSourceDir, objTargetDir);
+					await BatchImageModulate(objSourceDir, objTargetDir).ConfigureAwait(false);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -42,7 +43,7 @@ namespace Argumentum.AssetConverter
 
         }
 
-        private void BatchImageModulate(DirectoryInfo sourceDir, DirectoryInfo targetDir)
+        private async Task BatchImageModulate(DirectoryInfo sourceDir, DirectoryInfo targetDir)
         {
             foreach (var sourceFile in sourceDir.GetFiles())
             {
@@ -54,7 +55,7 @@ namespace Argumentum.AssetConverter
                         ImageHelper.Modulate(image, Modulation);
 
                         var targetFile = new FileInfo(Path.Combine(targetDir.ToString(), sourceFile.Name));
-                        image.Write(targetFile);
+                        await image.WriteAsync(targetFile).ConfigureAwait(false);
                         
                         Logger.LogSuccess($"Image Converted: {targetFile.Directory?.Name}\\{targetFile.Name}");
 

--- a/Generation/Converters/Argumentum.AssetConverter/ConverterMode.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/ConverterMode.cs
@@ -1,11 +1,24 @@
-﻿namespace Argumentum.AssetConverter
+﻿using System;
+
+namespace Argumentum.AssetConverter
 {
-    public enum ConverterMode
-    {
-		WebBasedImageGeneration,
-		BatchImageProcessor,
-        Mindmapper,
-        Dnn2sxc,
-        DatasetUpdater
-    }
+	[Flags]
+	public enum ConverterMode
+	{
+		None = 0,
+		BatchImageProcessor = 1 << 0, // 1
+		WebBasedImageGeneration = 1 << 1, // 2
+		Mindmapper = 1 << 2, // 4
+		Dnn2sxc = 1 << 3, // 8
+		DatasetUpdater = 1 << 4, // 16
+		OwlGenerator = 1 << 5, // 32
+		TaxonomyValidator = 1 << 6, // 64
+		OwlValidator = 1 << 7, // 128
+		CardValidator = 1 << 8, // 256
+		ContinuousValidator = 1 << 9, // 512
+		TranslationCoverage = 1 << 10, // 1024
+		ParallelismOptimizer = 1 << 11, // 2048
+		QuestPdfGeneration = 1 << 12, // 4096
+		PdfAuditor = 1 << 13, // 8192
+	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
@@ -2,11 +2,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Argumentum.AssetConverter.DatasetUpdater;
 using OpenAI.ObjectModels;
 using System.Threading;
 using OpenAI.Utilities.FunctionCalling;
@@ -22,14 +22,13 @@ public class DatasetUpdaterConfig
 
 	public bool Enabled { get; set; } = true;
 
-	public string SystemPrompt { get; set; } = Resource1.VirtuesJsonPromptSystem;
+	public string Name { get; set; } = "Dataset Update";
 
-	public bool AddPromptSample { get; set; }
-
-	public string UserPrompt { get; set; } = Resource1.VirtuesJsonPromptSampleUser;
+	public string SystemPromptPath { get; set; }
 
 
-	public string AssistantPrompt { get; set; } = Resource1.VirtuesJsonPromptSampleAssistant;
+	public List<PromptExample> DialogPrompts { get; set; } = new();
+
 
 	public string OpenAIKeyPath { get; set; } = @"G:\Mon Drive\MyIA\Argumentum\Fallacies\Gestion\OpenAI-Key.txt";
 
@@ -39,7 +38,7 @@ public class DatasetUpdaterConfig
 
 	public DivisionMode DivisionMode { get; set; }
 
-	
+
 	public int ChunkSize { get; set; } = 3;
 
 	public Char PKHierarchicalChar { get; set; } = '.';
@@ -48,264 +47,406 @@ public class DatasetUpdaterConfig
 
 	public bool UseFunctionCalling { get; set; } = false;
 
+	public string FunctionName { get; set; }
+
 	public int NbMessageCalls { get; set; } = 1;
 
-	public int SkipChunkNb { get; set; } = 30;
+	public int SkipChunkNb { get; set; } = 0;
 
-	public int TakeChunkNb { get; set; } = 0;
+	public int TakeChunkNb { get; set; } = -1;
+
+	public bool RandomizeChunks { get; set; }
+
+	public bool SelectEmptyTargets { get; set; }
 
 	public int MaxDegreeOfParallelismWebService { get; set; } = 2;
 
-	public List<string> FieldsToInclude { get; set; } = new List<string>(new[]
-	{
-		//Virtues
-		"path",
-		"family_fr",
-		"subfamily_fr",
-		"subsubfamily_fr",
-		"title_fr",
-		"description_fr",
-		"remark_fr",
-		"link_fr"
-
-		//Fallacies
-		//"path",
-		//"Famille",
-		//"Sous-Famille",
-		//"Soussousfamille",
-		//"text_fr",
-		//"desc_fr",
-		//"example_fr",
-		//"link_fr"
-
-	});
-
-	public string PrimaryField { get; set; } = "path";
-
-	public List<string> FieldsToUpdate { get; set; } = new List<string>(new[]
-	{
-		//Virtues
-		"title_fr",
-		"description_fr",
-		"remark_fr",
-		"link_fr"
-
-		//Fallacies
-		//"path",
-		//"text_fr",
-		//"desc_fr",
-		//"example_fr",
-		//"link_fr"
-	});
-
-	public DataSetInfo SourceDataset { get; set; } = new DataSetInfo()
-	{
-		Name = "Argumentum - Virtues - Taxonomy",
-		ReleaseFilePath = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Fallacies/Argumentum%20Virtues%20-%20Taxonomy.csv",
-		DebugFilePath = @"..\..\..\..\..\..\Cards\Fallacies\Argumentum Virtues - Taxonomy.csv",
-	};
-
-	public string TargetPath { get; set; } = @".\Target\Datasets\Argumentum Virtues - Taxonomy.csv";
+	public List<string> FieldsToInclude { get; set; } = new();
 
 
-	public async Task Apply(bool useDebugPath)
+	public string PrimaryField { get; set; } = "";
+
+	public List<string> FieldsToUpdate { get; set; } = new();
+
+	public string SourceDataset { get; set; }
+
+	public string TargetPath { get; set; } = "";
+
+	public bool WriteOneTargetFileByField { get; set; }
+
+	public bool CompareMode { get; set; }
+
+
+	public string CompareField { get; set; }
+	public bool AutoCompare { get; set; }
+	public string AutoCompareField { get; set; } = "";
+	public int MaxGroupItemNb { get; set; } = 30;
+
+
+	public int MaxChildren { get; set; } = 12;
+	public int NbGlobalPasses { get; set; } = 1;
+
+	public async Task Apply(AssetConverterConfig config)
 	{
 		var openAIKey = await File.ReadAllTextAsync(OpenAIKeyPath);
-		var cts = new CancellationTokenSource();
-		var token = cts.Token;
 
-		_ = Task.Run(async () =>
-		{
-			while (!token.IsCancellationRequested)
-			{
-				if (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Escape)
-				{
-					cts.Cancel();
-					Logger.Log("Cancel asked by user");
-				}
-
-				await Task.Delay(100, token);
-			}
-		}, token);
 
 
 		try
 		{
 
-			var content = await SourceDataset.GetContent(useDebugPath);
+			var cts = new CancellationTokenSource();
+			var token = cts.Token;
 
-			var resultTable = DataSetInfo.LoadCsvIntoDataTable(content, ",", PrimaryField);
-
-			// load dataset in chunks, 
-
-			var records = SourceDataset.GetDictionaryFromCsv(content, FieldsToInclude, useDebugPath);
-
-
-			List<List<Dictionary<string, object>>> recordGroups;
-
-			switch (this.DivisionMode)
+			_ = Task.Run(async () =>
 			{
-				case DivisionMode.PKHierarchicalChar:
-					
-					recordGroups = SourceDataset.GetHierarchicalRecords(records, PrimaryField, PKHierarchicalChar, PKHierarchyLevel);
-					break;
-
-				case DivisionMode.SequentialChunks:
-					recordGroups = new List<List<Dictionary<string, object>>>();
-					for (var i = 0; i < records.Count; i += ChunkSize)
-					{
-						recordGroups.Add(records.Skip(i).Take(ChunkSize).ToList());
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
-
-			
-			
-
-			//Doing short tests
-			if (SkipChunkNb > 0)
-			{
-				recordGroups = recordGroups.Skip(SkipChunkNb).ToList();
-			}
-
-			if (TakeChunkNb > 0)
-			{
-				recordGroups = recordGroups.Take(TakeChunkNb).ToList();
-			}
-
-			var answers = new ConcurrentBag<string>();
-
-			var tokenManager = new TokenManager(MaxTokensPerMinute, Model);
-
-			var parallelOptions = new ParallelOptions
-			{
-				MaxDegreeOfParallelism = MaxDegreeOfParallelismWebService,
-				CancellationToken = token
-			};
-
-				await Parallel.ForEachAsync(recordGroups, parallelOptions, async (recordGroup, ct) =>
+				while (!token.IsCancellationRequested)
 				{
-					try
+					if (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Z)
 					{
-						ct.ThrowIfCancellationRequested();
+						cts.Cancel();
+						Logger.Log("Cancel asked by user");
+					}
 
-						var chunk = SourceDataset.SplitContentIntoJsonChunks(recordGroup, int.MaxValue)[0];
+					await Task.Delay(100, token);
+				}
+			}, token);
 
-						
+			var sourceDataset = config.DataSets.First(dataset => dataset.Name == SourceDataset);
 
-						var dataPrompt = new Prompt()
+			var content = await sourceDataset.GetContent(config.UseDebugParams);
+
+			
+
+
+			var saveResults = false;
+
+			bool RecordHasEmptyTargetFields(Dictionary<string, object> dictionary)
+			{
+				foreach (var field in FieldsToUpdate)
+				{
+					if (string.IsNullOrEmpty(dictionary[field].ToString()))
+					{
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+
+			DataTable globalDataTable = DataSetInfo.LoadCsvIntoDataTable(content, ",", PrimaryField);
+			var resultDataTablesPerField = new Dictionary<string, DataTable> { };
+			resultDataTablesPerField[""] = globalDataTable;
+			List<Dictionary<string, object>> records = null;
+			for (int globalPassIndex = 0; globalPassIndex < this.NbGlobalPasses; globalPassIndex++)
+			{
+				//globalDataTable = DataSetInfo.LoadCsvIntoDataTable(content, ",", PrimaryField);
+
+
+				if (!CompareMode)
+				{
+
+					saveResults = true;
+
+					// load dataset in chunks, 
+
+					if (records == null)
+					{
+						records = sourceDataset.GetDictionaryFromCsv(content, FieldsToInclude, config.UseDebugParams);
+					}
+					
+
+					//if (SelectEmptyTargets)
+					//{
+
+
+					//	var toReturn = new List<Dictionary<string, object>>();
+
+
+					//	var emptyRecords = records.Where(RecordHasEmptyTargetFields).ToList();
+
+					//	toReturn.AddRange(emptyRecords);
+
+					//	if (DivisionMode == DivisionMode.PKHierarchicalChar)
+					//	{
+					//		var rootRecords = DataSetInfo.GetHierarchicalRecords(records, PrimaryField, PKHierarchicalChar, PKHierarchyLevel, false, MaxChildren);
+					//		foreach (var rootRecord in rootRecords.SelectMany(list => list))
+					//		{
+					//			if (!toReturn.Exists(record => record[PrimaryField] == rootRecord[PrimaryField]))
+					//			{
+					//				toReturn.Add(rootRecord);
+					//			}
+					//		}
+
+					//		foreach (var emptyRecord in emptyRecords)
+					//		{
+					//			var pkEmptyRecord = emptyRecord[PrimaryField].ToString();
+					//			var pkEmptyRecordRoot = pkEmptyRecord.Substring(0, Math.Max(0, pkEmptyRecord.LastIndexOf(PKHierarchicalChar)));
+					//			var siblings = records.Where(record => record[PrimaryField].ToString().Length == pkEmptyRecord.Length
+					//						&& record[PrimaryField].ToString().StartsWith(pkEmptyRecordRoot)).ToList();
+					//			var nonEmptySiblings = siblings.Where(record => !RecordHasEmptyTargetFields(record)).ToList();
+					//			foreach (var nonEmptySibling in nonEmptySiblings)
+					//			{
+					//				if (!toReturn.Exists(record => record[PrimaryField] == nonEmptySibling[PrimaryField]))
+					//				{
+					//					toReturn.Add(nonEmptySibling);
+					//				}
+					//			}
+					//		}
+					//	}
+
+					//	records = toReturn;
+
+					//}
+
+					List<List<Dictionary<string, object>>> recordGroups;
+
+					switch (this.DivisionMode)
+					{
+						case DivisionMode.PKHierarchicalChar:
+
+							recordGroups = DataSetInfo.GetHierarchicalRecords(records, PrimaryField, PKHierarchicalChar, PKHierarchyLevel, true, MaxChildren);
+
+							break;
+
+						case DivisionMode.SequentialChunks:
+							recordGroups = new List<List<Dictionary<string, object>>>();
+							for (var i = 0; i < records.Count; i += ChunkSize)
+							{
+								recordGroups.Add(records.Skip(i).Take(ChunkSize).ToList());
+							}
+							break;
+						default:
+							throw new ArgumentOutOfRangeException();
+					}
+
+					if (SelectEmptyTargets)
+					{
+						recordGroups = recordGroups.Where(group => group.Exists(RecordHasEmptyTargetFields)).ToList();
+					}
+
+
+
+					//Doing short tests
+					if (SkipChunkNb > 0)
+					{
+						recordGroups = recordGroups.Skip(SkipChunkNb).ToList();
+					}
+
+					if (RandomizeChunks)
+					{
+						recordGroups = recordGroups.OrderBy(x => Guid.NewGuid()).ToList();
+					}
+
+					if (TakeChunkNb >= 0)
+					{
+						recordGroups = recordGroups.Take(TakeChunkNb).ToList();
+					}
+
+					if (recordGroups.Count > 0)
+					{
+
+						recordGroups = recordGroups.Where(group => group.Count > 0).ToList();
+
+						if (MaxGroupItemNb > 0)
 						{
-							ApiKey = openAIKey,
-							Model = Model,
-							SystemPrompt = SystemPrompt,
-							
-							UserPrompt = chunk,
-							Tokenizer = tokenManager.TokenizerAction
+							for (int i = 0; i < recordGroups.Count; i++)
+							{
+								recordGroups[i] = recordGroups[i].Take(Math.Min(recordGroups[i].Count, MaxGroupItemNb)).ToList();
+							}
+						}
+
+						var answers = new ConcurrentBag<string>();
+
+						var tokenManager = new TokenManager(MaxTokensPerMinute, Model);
+
+						var parallelOptions = new ParallelOptions
+						{
+							MaxDegreeOfParallelism = MaxDegreeOfParallelismWebService,
+							CancellationToken = token
 						};
 
-						if (this.AddPromptSample)
-						{
-							dataPrompt.Example = new PromptExample()
-							{
-								UserPrompt = UserPrompt,
-								Answer = AssistantPrompt
-							};
-						}
+						var systemPrompt = await File.ReadAllTextAsync(SystemPromptPath, token);
 
-						if (UseFunctionCalling)
+						await Parallel.ForEachAsync(recordGroups, parallelOptions, async (recordGroup, ct) =>
 						{
-							var recordsUpdator = new RecordsUpdater()
-							{
-								PrimaryKeyField = PrimaryField,
-								Records = recordGroup
-							};
-							dataPrompt.Functions = FunctionCallingHelper.GetFunctionDefinitions<RecordsUpdater>().Select(definition => (definition, (object) recordsUpdator)).ToList();
-							
-						}
+							await DoChatGPTCall(ct, recordGroup, openAIKey, systemPrompt, tokenManager, token, resultDataTablesPerField, answers);
+						});
 
-						string result = "";
 
-						for (int i = 0; i < NbMessageCalls; i++)
+
+						//// Merge answers into one csv
+						//var mergedCsv =
+						//	await SourceDataset.MergeJsonResponsesIntoCsv(answers.ToList(), PrimaryField, FieldsToUpdate, ",",
+						//		false);
+
+
+					}
+
+
+				}
+				else
+				{
+					if (File.Exists(TargetPath))
+					{
+
+
+						DataTable targetTable;
+
+						if (AutoCompare)
 						{
-							ct.ThrowIfCancellationRequested();
-							Logger.Log($"Calling ChatGPT API with chunk: \n{Markup.Escape(chunk)}\n");
-
-							try
-							{
-								tokenManager.WaitForTokenAvailability();
-								result = await dataPrompt.Send(token).ConfigureAwait(false);
-								//result = chunk;
-								Logger.Log(
-									$"ChatGPT answered chunk: \n{Markup.Escape(chunk)}\n with chunk \n{Markup.Escape(result)}\n");
-								dataPrompt.UserPrompt = result;
-							}
-							catch (Exception e)
-							{
-								Logger.LogException(e);
-							}
-						}
-						List<Dictionary<string, object>> records;
-						if (UseFunctionCalling)
-						{
-							records = recordGroup;
+							targetTable = globalDataTable.Copy();
 						}
 						else
 						{
-							records = DataSetInfo.GetDictionaryRecordsFromJson(result);
+							var targetContent = await TargetPath.GetDocumentContent();
+							targetTable = DataSetInfo.LoadCsvIntoDataTable(targetContent, ",", PrimaryField);
 						}
-						
-						
 
-						lock (resultTable)
+						var differences = new List<List<DataRow>>();
+
+
+
+						for (int i = 0; i < globalDataTable.Rows.Count; i++)
 						{
-							DataSetInfo.UpdateTableFromRecords(PrimaryField, FieldsToUpdate, false, records, resultTable);
+							var originalRow = globalDataTable.Rows[i];
+
+							var originalKey = originalRow[PrimaryField].ToString();
+
+
+
+							List<DataRow> targetRows;
+							if (AutoCompare)
+							{
+								targetRows = targetTable.Select().Where(row => row[AutoCompareField].ToString() == originalRow[AutoCompareField].ToString()).ToList();
+							}
+							else
+							{
+								var targetRow = targetTable.Rows.Find(originalKey);
+								targetRows = new List<DataRow>() { targetRow };
+							}
+
+
+							List<DataRow> currentAlternative = null;
+
+							var originalValue = originalRow[CompareField];
+
+							foreach (var targetRow in targetRows)
+							{
+								if (targetRow != null)
+								{
+
+									var targetValue = targetRow[CompareField];
+									if (originalValue.ToString() != targetValue.ToString())
+									{
+										if (currentAlternative == null)
+										{
+											currentAlternative = new();
+											currentAlternative.Add(originalRow);
+											differences.Add(currentAlternative);
+										}
+										currentAlternative.Add(targetRow);
+
+									}
+								}
+							}
+
+						}
+						var checkedKeys = new HashSet<string>();
+						globalDataTable.Columns[CompareField].ReadOnly = false;
+						foreach (var difference in differences)
+						{
+							var originalAutoCompareValue = !string.IsNullOrEmpty(AutoCompareField) ? difference[0][AutoCompareField] : "";
+
+							var originalKey = difference[0][PrimaryField].ToString();
+							if (checkedKeys.Contains(originalKey))
+							{
+								continue;
+							}
+							checkedKeys.Add(originalKey);
+
+							Logger.Log($"Found {difference.Count} options for {originalAutoCompareValue} - {difference[0][PrimaryField]}");
+
+
+							var keys = new List<object>();
+							for (int i = 0; i < difference.Count; i++)
+							{
+								var differenceKey = difference[i][PrimaryField];
+								keys.Add(differenceKey);
+								checkedKeys.Add(differenceKey.ToString());
+								Logger.Log($"{i} - {differenceKey.ToString()}\n{difference[i][CompareField]}");
+							}
+
+							Logger.Log("Enter preferred Option:");
+							var optionKey = Console.ReadLine();
+							var intOptionKey = int.Parse(optionKey);
+							var selectedValue = difference[intOptionKey][CompareField];
+							foreach (var key in keys)
+							{
+								var row = globalDataTable.Rows.Find(key);
+								row[CompareField] = selectedValue;
+							}
+
 						}
 
 
-						answers.Add(result);
+						Logger.Log("Save result (y/n)?");
+						var savekey = Console.ReadKey();
+						if (savekey.KeyChar == 'y')
+						{
+							saveResults = true;
+						}
+
 					}
-					catch (OperationCanceledException)
+				}
+
+
+
+				//content = DataSetInfo.WriteDataTableToCsv(globalDataTable, ",");
+
+			}
+
+
+			if (saveResults)
+			{
+
+				foreach (var dataTable in resultDataTablesPerField)
+				{
+					var mergedCsv = DataSetInfo.WriteDataTableToCsv(dataTable.Value, ",");
+
+					var csvPath = TargetPath.Replace(".csv", $"{dataTable.Key}.csv");
+
+					// Save mergedCsv to file
+
+					if (File.Exists(csvPath))
 					{
-						Logger.Log("Operation cancelled by user.");
+						try
+						{
+							File.Delete(csvPath);
+						}
+						catch (Exception e)
+						{
+							Logger.LogException(e);
+							Console.ReadKey();
+						}
+
 					}
-				});
+
+					if (!Directory.Exists(Path.GetDirectoryName(csvPath)))
+					{
+						Directory.CreateDirectory(Path.GetDirectoryName(csvPath));
+					}
+
+					await sourceDataset.SaveContent(csvPath, mergedCsv);
 
 
-			//// Merge answers into one csv
-			//var mergedCsv =
-			//	await SourceDataset.MergeJsonResponsesIntoCsv(answers.ToList(), PrimaryField, FieldsToUpdate, ",",
-			//		false);
-
-			var mergedCsv = DataSetInfo.WriteDataTableToCsv(resultTable, ",");
-
-
-			// Save mergedCsv to file
-
-			if (File.Exists(TargetPath))
-			{
-				try
-				{
-					File.Delete(TargetPath);
+					Logger.LogSuccess("Completed ChatGPT calls and saved the output to " + csvPath);
 				}
-				catch (Exception e)
-				{
-					Logger.LogException(e);
-					Console.ReadKey();
-				}
+
 
 			}
 
-			if (!Directory.Exists(Path.GetDirectoryName(TargetPath)))
-			{
-				Directory.CreateDirectory(Path.GetDirectoryName(TargetPath));
-			}
-
-			await SourceDataset.SaveContent(TargetPath, mergedCsv);
-
-
-			Logger.Log("Completed ChatGPT calls and saved the output to " + TargetPath);
 
 		}
 		catch (Exception ex)
@@ -315,5 +456,79 @@ public class DatasetUpdaterConfig
 
 	}
 
+	private async Task DoChatGPTCall(CancellationToken ct, List<Dictionary<string, object>> recordGroup, string openAIKey, string systemPrompt,
+		TokenManager tokenManager, CancellationToken token, Dictionary<string, DataTable> resultDataTablesPerField, ConcurrentBag<string> answers)
+	{
+		try
+		{
 
+			string result = "";
+			for (int i = 0; i < NbMessageCalls; i++)
+			{
+				ct.ThrowIfCancellationRequested();
+
+				var chunk = DataSetInfo.SplitContentIntoJsonChunks(recordGroup, int.MaxValue)[0];
+
+				var dataPrompt = new Prompt()
+				{
+					ApiKey = openAIKey,
+					Model = Model,
+					SystemPrompt = systemPrompt,
+					DialogPrompts = DialogPrompts,
+					UserPrompt = chunk,
+					Tokenizer = tokenManager.TokenizerAction
+				};
+
+				if (UseFunctionCalling)
+				{
+					var recordsUpdator = new RecordsUpdater()
+					{
+						PrimaryKeyField = PrimaryField,
+						Records = recordGroup
+					};
+					dataPrompt.Functions = FunctionCallingHelper.GetToolDefinitions<RecordsUpdater>().Select(definition => (definition.Function, (object)recordsUpdator)).ToList();
+					if (!string.IsNullOrEmpty(FunctionName))
+					{
+						dataPrompt.FunctionName = FunctionName;
+					}
+				}
+
+
+				ct.ThrowIfCancellationRequested();
+				Logger.Log($"Calling ChatGPT API with chunk: \n{Markup.Escape(chunk)}\n");
+
+				try
+				{
+					tokenManager.WaitForTokenAvailability();
+					result = await dataPrompt.Send(token, Logger.LogInformation).ConfigureAwait(false);
+					//result = chunk;
+					Logger.Log(
+						$"ChatGPT answered chunk: \n{Markup.Escape(chunk)}\n with chunk \n{Markup.Escape(result)}\n");
+					dataPrompt.UserPrompt = result;
+				}
+				catch (Exception e)
+				{
+					Logger.LogException(e);
+				}
+
+				if (!UseFunctionCalling)
+				{
+					recordGroup = DataSetInfo.GetDictionaryRecordsFromJson(result);
+				}
+
+
+				lock (resultDataTablesPerField)
+				{
+					DataSetInfo.UpdateTableFromRecords(PrimaryField, FieldsToUpdate, false, recordGroup, this.WriteOneTargetFileByField, resultDataTablesPerField);
+				}
+
+			}
+
+			answers.Add(result);
+		}
+		catch (OperationCanceledException)
+		{
+			Logger.Log("Operation cancelled by user.");
+		}
+	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Prompt.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Prompt.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -25,7 +26,7 @@ public class Prompt
 
 	public string SystemPrompt { get; set; }
 
-	public PromptExample Example { get; set; }
+	public List<PromptExample> DialogPrompts { get; set; } = new();
 
 	public string UserPrompt { get; set; }
 
@@ -49,16 +50,20 @@ public class Prompt
 
 	public List<(FunctionDefinition functionDefinition, object targetObject)> Functions { get; set; }
 
+	public string FunctionName { get; set; }
 
-	public async Task<string> Send(CancellationToken cancellationToken)
+	public async Task<string> Send(CancellationToken cancellationToken, Action<string> log)
 	{
 		if (Tokenizer != null)
 		{
 			Tokenizer(SystemPrompt);
-			if (this.Example != null)
+			if (this.DialogPrompts != null)
 			{
-				Tokenizer(Example.UserPrompt);
-				Tokenizer(Example.Answer);
+				foreach (var dialogPrompt in DialogPrompts)
+				{
+					Tokenizer(dialogPrompt.UserPrompt);
+					Tokenizer(dialogPrompt.AssistantAnswer);
+				}
 			}
 			
 			Tokenizer(UserPrompt);
@@ -68,11 +73,15 @@ public class Prompt
 		{
 			ChatMessage.FromSystem(SystemPrompt)
 		};
-		if (Example != null)
+		if (this.DialogPrompts != null)
 		{
-			messages.Add(ChatMessage.FromUser(Example.UserPrompt));
-			messages.Add(ChatMessage.FromAssistant(Example.Answer));
+			foreach (var dialogPrompt in DialogPrompts)
+			{
+				messages.Add(ChatMessage.FromUser(dialogPrompt.UserPrompt));
+				messages.Add(ChatMessage.FromAssistant(dialogPrompt.AssistantAnswer));
+			}
 		}
+			
 		messages.Add(ChatMessage.FromUser(UserPrompt));
 
 		var chatCompletionCreateRequest = new ChatCompletionCreateRequest
@@ -85,7 +94,11 @@ public class Prompt
 		if (Functions != null)
 		{
 			chatCompletionCreateRequest.Tools = Functions.Select(tuple =>  ToolDefinition.DefineFunction(tuple.functionDefinition)).ToList();
-			//chatCompletionCreateRequest.ToolChoice = ToolChoice.FunctionChoice();
+			//chatCompletionCreateRequest.ChatResponseFormat = ChatCompletionCreateRequest.ResponseFormats.Json;
+			if (FunctionName != null)
+			{
+				chatCompletionCreateRequest.ToolChoice = ToolChoice.FunctionChoice(FunctionName);
+			}
 		}
 
 
@@ -100,20 +113,40 @@ public class Prompt
 			if (chatMessage.FunctionCall != null)
 			{
 				var functionCall = chatMessage.FunctionCall;
-				var result = FunctionCallingHelper.CallFunction<bool>(functionCall, Functions.First(tuple => tuple.functionDefinition.Name == functionCall.Name).targetObject);
-				chatMessage.Content = result.ToString(CultureInfo.CurrentCulture);
+				var result = CallFunction(functionCall);
+				//chatMessage.Content = result.ToString(CultureInfo.CurrentCulture);
 			}
 
-			var messageContent = chatMessage.Content;
-
-			if (Tokenizer != null)
+			if (chatMessage.ToolCalls != null && chatMessage.ToolCalls.Count > 0)
 			{
-				Tokenizer(messageContent);
-				
+				foreach (var chatMessageToolCall in chatMessage.ToolCalls)
+				{
+					var functionCall = chatMessageToolCall.FunctionCall;
+					var result = CallFunction(functionCall);
+					log($"Function call {functionCall.Name} with arguments {functionCall.Arguments}");
+				}
 			}
-			return messageContent;
+
+			if (chatMessage.Content != null)
+			{
+				var messageContent = chatMessage.Content;
+
+				if (Tokenizer != null)
+				{
+					Tokenizer(messageContent);
+
+				}
+				return messageContent;
+			}
+			return "";
 		}
 		throw new ApplicationException(completionResult.Error?.Message ?? "Unsuccessful");
 	}
 
+	private string CallFunction(FunctionCall functionCall)
+	{
+		var result = FunctionCallingHelper.CallFunction<string>(functionCall,
+			Functions.First(tuple => tuple.functionDefinition.Name == functionCall.Name).targetObject);
+		return result;
+	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/PromptExample.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/PromptExample.cs
@@ -1,11 +1,38 @@
-﻿namespace Argumentum.AssetConverter;
+﻿using System.IO;
+
+namespace Argumentum.AssetConverter;
 
 public class PromptExample
 {
+	private string _userPrompt;
+	public string UserPromptPath { get; set; }
 
-	public string UserPrompt { get; set; }
+	public string AssistantAnswerPath { get; set; }
 
-	public string Answer { get; set; }
+	public string UserPrompt
+	{
+		get
+		{
+			if (_userPrompt == null)
+			{
+				_userPrompt = File.ReadAllText(UserPromptPath);
+			}
+			return _userPrompt;
+		}
+	}
 
+	private string _assistantAnswer;
+
+	public string AssistantAnswer
+	{
+		get
+		{
+			if (_assistantAnswer == null)
+			{
+				_assistantAnswer = File.ReadAllText(AssistantAnswerPath);
+			}
+			return _assistantAnswer;
+		}
+	}
 
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/RecordsUpdater.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/RecordsUpdater.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
 using OpenAI.Utilities.FunctionCalling;
 
 namespace Argumentum.AssetConverter;
@@ -7,17 +10,63 @@ namespace Argumentum.AssetConverter;
 public class RecordsUpdater
 {
 	public string PrimaryKeyField { get; set; }
+
 	public List<Dictionary<string, object>> Records { get; set; }
 
-	[FunctionDescription("Updates a record's field given its primary key, the field's name and the new value for that field")]
-	public bool UpdateRecord(string primaryKey, string fieldName, string newValue)
+	[FunctionDescription("Updates a record's field given its primary key, the field's name and the new value for that field, returns both values separated by a line")]
+	public string UpdateRecord(string primaryKey, string fieldName, string newValue)
 	{
+		newValue = DecodeValue(newValue);
 		var targetRecord = Records.FirstOrDefault(x => x[PrimaryKeyField].ToString() == primaryKey);
 		if (targetRecord == null)
 		{
-			return false;
+			return "target record not found";
 		}
+		var existingValue = targetRecord[fieldName];
 		targetRecord[fieldName] = newValue;
-		return true;
+		return $"{existingValue}\n==>\n{newValue}";
 	}
+
+	private static string DecodeValue(string newValue)
+	{
+		newValue = Regex.Unescape(newValue);
+		newValue = HttpUtility.HtmlDecode(newValue);
+		newValue = HttpUtility.UrlDecode(newValue);
+		return newValue;
+	}
+
+	//[FunctionDescription("Given a field name to update, updates a series of 5 records given their primary keys and the new value for that field, returns lines of old and new values updated")]
+	//public string UpdateFiveRecords(string fieldName, string primaryKey1, string newValue1,
+	//	string primaryKey2, string newValue2,
+	//	string primaryKey3, string newValue3,
+	//	string primaryKey4, string newValue4,
+	//	string primaryKey5, string newValue5)
+	//{
+	//	var updates = new Dictionary<string, string>()
+	//	{
+	//		{ primaryKey1, newValue1 },
+	//		{ primaryKey2, newValue2 },
+	//		{ primaryKey3, newValue3 },
+	//		{ primaryKey4, newValue4 },
+	//		{ primaryKey5, newValue5 }
+	//	};
+	//	var toReturn = new StringBuilder();
+	//	foreach (var update in updates)
+	//	{
+	//		var targetRecord = Records.FirstOrDefault(x => x[PrimaryKeyField].ToString() == update.Key);
+	//		if (targetRecord == null)
+	//		{
+	//			toReturn.Append($"target record not found for {update.Key}");
+	//		}
+	//		else
+	//		{
+	//			var existingValue = targetRecord[fieldName];
+	//			targetRecord[fieldName] = update.Value;
+	//			toReturn.Append($"{existingValue} => {update.Value}");
+	//		}
+	//	}
+	//	return toReturn.ToString();
+	//}
+
+
 }

--- a/Generation/Converters/Argumentum.AssetConverter/Logger.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Logger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Diagnostics;
 using Spectre.Console;
 using Spectre.Console.Json;
@@ -19,6 +20,50 @@ public enum MessageType
 
 public class Logger
 {
+	private static readonly object fileLock = new object();
+
+	private static string GetLogFilePath()
+	{
+		// Commence à partir du répertoire de base de l'application (ex: .../bin/Debug/net8.0)
+		var assemblyDir = AppContext.BaseDirectory;
+		// Remonte jusqu'à trouver le répertoire racine du projet "Argumentum"
+		var projectRoot = new DirectoryInfo(assemblyDir);
+		while (projectRoot != null && !projectRoot.Name.Equals("Argumentum", StringComparison.OrdinalIgnoreCase))
+		{
+			projectRoot = projectRoot.Parent;
+		}
+
+		if (projectRoot == null)
+		{
+			// Fallback au cas où la structure de dossiers changerait
+			projectRoot = new DirectoryInfo(assemblyDir);
+		}
+
+		return Path.Combine(projectRoot.FullName, "Logs", "file_logger.log");
+	}
+
+	public static string LogFile = GetLogFilePath();
+
+	static Logger()
+	{
+		try
+		{
+			var logDirectory = Path.GetDirectoryName(LogFile);
+			if (!Directory.Exists(logDirectory))
+			{
+				Directory.CreateDirectory(logDirectory);
+			}
+
+			if (File.Exists(LogFile))
+			{
+				File.Delete(LogFile);
+			}
+		}
+		catch (Exception ex)
+		{
+			AnsiConsole.MarkupLine($"[bold red]Error during logger initialization: {ex.Message}[/]");
+		}
+	}
 
 	public static Stopwatch Stopwatch;
 
@@ -33,6 +78,21 @@ public class Logger
 		}
 
 
+		try
+		{
+			lock (fileLock)
+			{
+				var formattedMessage = message.Replace(Environment.NewLine, " ");
+				File.AppendAllText(LogFile, $"{Stopwatch.Elapsed}: [{messageType}] {formattedMessage}{Environment.NewLine}");
+			}
+		}
+		catch (Exception ex)
+		{
+			// Log initialization errors to the console to ensure they are visible
+			// as the file logger itself may be the source of the problem.
+			AnsiConsole.MarkupLine($"[bold red]Failed to write to log file '{LogFile}'. Exception: {ex.Message}[/]");
+		}
+
 		switch (messageType)
 		{
 			case MessageType.Info:
@@ -41,7 +101,7 @@ public class Logger
 				var markup = messageType == MessageType.Info ? "dim" : messageType == MessageType.Warning ? "sandybrown" : "green3";
 				if (LogInfo || messageType != MessageType.Info)
 				{
-					AnsiConsole.MarkupLine($"{Stopwatch.Elapsed}: [{markup}]{message}[/]");
+					AnsiConsole.MarkupLine($"{Stopwatch.Elapsed}: [{markup}]{Markup.Escape(message)}[/]");
 				}
 				break;
 			case MessageType.Title:
@@ -106,7 +166,19 @@ public class Logger
 	public static void LogException(Exception ex)
 	{
 		LogProblem("Execution error");
+		// Utiliser directement AnsiConsole.WriteException car le problème est résolu dans Spectre.Console 0.50.0
 		AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+		try
+		{
+			lock (fileLock)
+			{
+				File.AppendAllText(LogFile, $"{Stopwatch.Elapsed}: [EXCEPTION] {ex.ToString().Replace(Environment.NewLine, " ")}{Environment.NewLine}");
+			}
+		}
+		catch (Exception logEx)
+		{
+			AnsiConsole.MarkupLine($"[bold red]Failed to write exception to log file '{LogFile}'. Exception: {logEx.Message}[/]");
+		}
 	}
 
 	public static void LogJson(string strNewConfig)
@@ -120,5 +192,15 @@ public class Logger
 	public static void LogWarning(string message)
 	{
 		Log(message, MessageType.Warning);
+	}
+
+	public static void LogInformation(string message)
+	{
+		Log(message, MessageType.Success);
+	}
+
+	public static void LogInfoMessage(string message)
+	{
+		Log(message, MessageType.Info);
 	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -903,7 +903,12 @@ if (mapFile != null) {
 
 			foreach (var svgDoc in processedDocs)
 			{
-				var svgFreemindMap = SVGMaps.First(s => svgDoc.Key.EndsWith($".{s.DocumentName}", StringComparison.OrdinalIgnoreCase));
+				var svgFreemindMap = SVGMaps.FirstOrDefault(s => svgDoc.Key.EndsWith($".{s.DocumentName}", StringComparison.OrdinalIgnoreCase));
+				if (svgFreemindMap == null)
+				{
+					Logger.LogWarning($"No SVGMap matching processed file: {svgDoc.Key}");
+					continue;
+				}
 				await GenerateHtmlSvgWrappers(svgFreemindMap, webBasedGeneratorConfig, svgDoc.Key, () => Task.FromResult(GetSvgContent(svgDoc.Value)), language);
 			}
 

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMap.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMap.cs
@@ -81,6 +81,35 @@ namespace Argumentum.AssetConverter.Mindmapper
 		public string BUILTIN { get; set; }
 	}
 
+
+	[XmlRoot(ElementName = "arrowlink")]
+	public class Arrowlink
+	{
+		[XmlAttribute(AttributeName = "COLOR")]
+		public string Color { get; set; }
+
+		[XmlAttribute(AttributeName = "DESTINATION")]
+		public string Destination { get; set; }
+
+		[XmlAttribute(AttributeName = "ENDARROW")]
+		public string EndArrow { get; set; }
+
+		[XmlAttribute(AttributeName = "ENDINCLINATION")]
+		public string EndInclination { get; set; }
+
+		[XmlAttribute(AttributeName = "ID")]
+		public string ID { get; set; }
+
+		[XmlAttribute(AttributeName = "STARTARROW")]
+		public string StartArrow { get; set; }
+
+		[XmlAttribute(AttributeName = "STARTINCLINATION")]
+		public string StartInclination { get; set; }
+
+		// Add other attributes as needed
+	}
+
+
 	[XmlRoot(ElementName = "node")]
 	public class Node
 	{
@@ -110,6 +139,10 @@ namespace Argumentum.AssetConverter.Mindmapper
 		[XmlElement(ElementName = "font")]
 		public Font Font { get; set; }
 
+		[XmlElement(ElementName = "arrowlink")]
+		public List<Arrowlink> Arrowlinks { get; set; } = new List<Arrowlink>();
+
+
 		[XmlElement(ElementName = "node")]
 		public List<Node> Nodes { get; set; } = new List<Node>();
 
@@ -132,12 +165,19 @@ namespace Argumentum.AssetConverter.Mindmapper
 	}
 
 	[XmlRoot(ElementName = "map")]
+	[XmlInclude(typeof(FreeplaneMap))]
 	public class FreemindMap
 	{
 		[XmlElement(ElementName = "node")]
 		public Node Node { get; set; }
 
         [XmlAttribute(AttributeName = "version")]
-        public string Version { get; set; } = "1.0.1";
+        public virtual string Version { get; set; } = "1.0.1";
     }
+
+	public class FreeplaneMap : FreemindMap
+	{
+		[XmlAttribute(AttributeName = "version")]
+		public override string Version { get; set; } = "freeplane 1.11.5";
+	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
@@ -239,10 +239,10 @@ namespace Argumentum.AssetConverter.Mindmapper
 		}
 
 
-		public async Task GenerateMindMapFile(IList<Fallacy> fallacies, WebBasedGeneratorConfig webBasedGeneratorConfig, string targetDirectory, string language )
+		public async Task GenerateMindMapFile(IList<Fallacy> fallacies, AssetConverterConfig config, string targetDirectory, string language )
 		{
-			if (string.IsNullOrEmpty(language)) 
-				language=webBasedGeneratorConfig.LocalizationConfig.DefaultLanguage ;
+			if (string.IsNullOrEmpty(language))
+				language=config.LocalizationConfig.DefaultLanguage ;
 
 
 			var fileName = DocumentName;
@@ -253,17 +253,17 @@ namespace Argumentum.AssetConverter.Mindmapper
 			}
 			var documentPath = Path.Combine(targetDirectory, DocumentName);
 
-			CreateFreemindmap(fallacies, webBasedGeneratorConfig, language, documentPath, fileName);
+			CreateFreemindmap(fallacies, config, language, documentPath, fileName);
 
-			//Task.Run(async () => await ProcessSVGFiles(fallacies, fileName, webBasedGeneratorConfig, webBasedGeneratorConfig.EnableSVGPrompt)).GetAwaiter().GetResult() ;
-			await ProcessSvgFilesAsync(fallacies, fileName, webBasedGeneratorConfig,
-				webBasedGeneratorConfig.EnableSVGPrompt);
+			//Task.Run(async () => await ProcessSVGFiles(fallacies, fileName, config, config.EnableSVGPrompt)).GetAwaiter().GetResult() ;
+			await ProcessSvgFilesAsync(fallacies, fileName, config,
+				config.EnableSVGPrompt);
 		}
 
-		private void CreateFreemindmap(IList<Fallacy> fallacies, WebBasedGeneratorConfig webBasedGeneratorConfig, string language,
+		private void CreateFreemindmap(IList<Fallacy> fallacies, AssetConverterConfig config, string language,
 			string documentPath, string fileName)
 		{
-			if (File.Exists(documentPath) && !webBasedGeneratorConfig.OverwriteExistingDocs)
+			if (File.Exists(documentPath) && !config.OverwriteExistingDocs)
 			{
 				Logger.Log($"Skip existing Mindmap: {documentPath}");
 			}
@@ -272,7 +272,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 				Logger.Log($"Creating Freemind mind map {DocumentName}");
 				var freemindMap = new FreemindMap();
 				var nodesByPath = new Dictionary<string, Node>(fallacies.Count);
-				CreateFallacyNodes(freemindMap, fallacies, nodesByPath, webBasedGeneratorConfig, language);
+				CreateFallacyNodes(freemindMap, fallacies, nodesByPath, config, language);
 
 
 				SerializeMindMapAsync(freemindMap, fileName);
@@ -281,14 +281,14 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 		private void CreateFallacyNodes(FreemindMap freemindMap, IList<Fallacy> fallacies, Dictionary<string, Node> nodesByPath,
-			WebBasedGeneratorConfig webBasedGeneratorConfig, string language)
+			AssetConverterConfig config, string language)
 		{
 			foreach (var fallacy in fallacies)
 			{
 				if (string.IsNullOrEmpty(fallacy.PK)) continue;
 
 				var localPath = fallacy.Path;
-				var fallacyNode = CreateNode(fallacy, webBasedGeneratorConfig, language);
+				var fallacyNode = CreateNode(fallacy, config, language);
 				nodesByPath[localPath] = fallacyNode;
 
 				var lastDotIndex = localPath.LastIndexOf('.');
@@ -310,7 +310,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 			}
 		}
 
-		private Node CreateNode(Fallacy fallacy, WebBasedGeneratorConfig webBasedGeneratorConfig, string language)
+		private Node CreateNode(Fallacy fallacy, AssetConverterConfig config, string language)
 		{
 			var fallacyNode = new Node { TEXT = TitleFunc(fallacy) };
 			var link = LinkFunc(fallacy);
@@ -324,7 +324,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 			if (fallacy.Carte.HasValue)
 			{
-				AddCardIcon(fallacy, fallacyNode, webBasedGeneratorConfig, language);
+				AddCardIcon(fallacy, fallacyNode, config, language);
 			}
 
 			return fallacyNode;
@@ -393,18 +393,18 @@ namespace Argumentum.AssetConverter.Mindmapper
 			}
 		}
 
-		private void AddCardIcon(Fallacy fallacy, Node fallacyNode, WebBasedGeneratorConfig webBasedGeneratorConfig, string language)
+		private void AddCardIcon(Fallacy fallacy, Node fallacyNode, AssetConverterConfig config, string language)
 		{
 			fallacyNode.Icons.Add(new Icon() { BUILTIN = $"full-{fallacy.Carte}" });
 
-			if (InsertCardsThumbnails && webBasedGeneratorConfig != null)
+			if (InsertCardsThumbnails && config != null)
 			{
-				var cardSetConfig = webBasedGeneratorConfig.CardSets.FirstOrDefault(c => c.Name == this.ThumbnailsCardSetName, null);
+				var cardSetConfig = config.WebBasedGeneratorConfig.CardSets.FirstOrDefault(c => c.Name == this.ThumbnailsCardSetName, null);
 				if (cardSetConfig != null)
 				{
 					this.ThumbnailsPathFunc = objFallacy =>
 					{
-						var cardSetDirectory = ImageHelper.GetImageFolder(webBasedGeneratorConfig, this, language, ThumbnailsCardSetName);
+						var cardSetDirectory = ImageHelper.GetImageFolder(config, this, language, ThumbnailsCardSetName);
 						var imageFileName = MatchThumbnailsName(cardSetDirectory, fallacy);
 						if (string.IsNullOrEmpty(imageFileName))
 						{
@@ -412,7 +412,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 						}
 						else
 						{
-							var targetDirectory = webBasedGeneratorConfig.GetDocumentDirectory(language);
+							var targetDirectory = config.GetDocumentDirectory(language);
 							imageFileName = imageFileName.GetRelativePathFrom(targetDirectory);
 						}
 						return imageFileName;
@@ -445,7 +445,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 			Logger.LogSuccess($"Mind map {fileName} successfully generated!");
 		}
 		private async Task ProcessSvgFilesAsync(IList<Fallacy> fallacies, string fileName,
-			WebBasedGeneratorConfig webBasedGeneratorConfig, bool enableSvgUpdates)
+			AssetConverterConfig config, bool enableSvgUpdates)
 		{
 			string svgFilePath = Path.ChangeExtension(fileName, "svg");
 
@@ -454,7 +454,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 			{
 				var svgSavedFilePath = Path.ChangeExtension(svgFilePath, svgFreemindMap.DocumentName);
 				Func<Task<string>> svgLoader;
-				if (File.Exists(svgSavedFilePath) && !webBasedGeneratorConfig.OverwriteExistingDocs)
+				if (File.Exists(svgSavedFilePath) && !config.OverwriteExistingDocs)
 				{
 					Logger.Log($"Skipping existing processed SVG: {svgSavedFilePath}");
 					svgLoader = async () => await File.ReadAllTextAsync(svgSavedFilePath);
@@ -493,7 +493,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 				}
 
-				await GenerateHtmlSvgWrappers(svgFreemindMap, webBasedGeneratorConfig, svgSavedFilePath, svgLoader);
+				await GenerateHtmlSvgWrappers(svgFreemindMap, config, svgSavedFilePath, svgLoader);
 
 				
 
@@ -583,6 +583,11 @@ namespace Argumentum.AssetConverter.Mindmapper
 		private Dictionary<Fallacy, XElement> DisambiguateSvgNodes(
 			Dictionary<Fallacy, List<XElement>> fallacyToSvgNodes, IList<Fallacy> fallacies, XNamespace svgNamespace)
 		{
+			if (!fallacyToSvgNodes.Any() || !fallacyToSvgNodes.First().Value.Any())
+			{
+				Logger.LogWarning("DisambiguateSvgNodes: no SVG nodes to disambiguate");
+				return new Dictionary<Fallacy, XElement>();
+			}
 			var tempNode = fallacyToSvgNodes.First().Value.First();
 			var allNodesList = tempNode.Document.Descendants(svgNamespace + tempNode.Name.LocalName).ToList();
 			var nodeIndices = allNodesList.Select((n, i) => new { Node = n, Index = i }).ToDictionary(n => n.Node, n => n.Index);
@@ -627,6 +632,11 @@ namespace Argumentum.AssetConverter.Mindmapper
 					{
 						if (fallacyToSvgNodes.TryGetValue(parentFallacy, out List<XElement> parentSvgNodes))
 						{
+							if (parentSvgNodes.Count == 0)
+							{
+								Logger.LogProblem($"Empty SVG node list for parent of {TitleFunc(fallacy)}");
+								break;
+							}
 							if (parentSvgNodes.Count > 1)
 							{
 								Logger.LogProblem($"Could not disambiguate SVG nodes for fallacy {TitleFunc(fallacy)} because its parent {TitleFunc(fallacy)} does not have a single corresponding SVG node.");
@@ -645,10 +655,12 @@ namespace Argumentum.AssetConverter.Mindmapper
 					{
 						Logger.LogProblem($"SVG Node index for parent fallacy: {parentFallacy.Path}-{TitleFunc(parentFallacy)} of fallacy {fallacy.Path}-{TitleFunc(fallacy)} not found");
 					}
+					else if (candidateSvgNodes.Count == 0)
+					{
+						Logger.LogProblem($"No candidate SVG nodes for {TitleFunc(fallacy)}");
+					}
 					else
 					{
-
-
 						// Sort the candidate SVG nodes based on their index difference with the parent node
 						XElement closestSvgNode = candidateSvgNodes
 							.OrderBy(node => Math.Abs(nodeIndices[node] - parentIndex))
@@ -744,12 +756,12 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 
-		private static async Task GenerateHtmlSvgWrappers(SVGFreemindMap svgMap, WebBasedGeneratorConfig webBasedGeneratorConfig, string svgSavedFilePath,
+		private static async Task GenerateHtmlSvgWrappers(SVGFreemindMap svgMap, AssetConverterConfig config, string svgSavedFilePath,
 			Func<Task<string>> svgContent)
 		{
 			foreach (var htmlSvgWrapper in svgMap.HtmlWrappers)
 			{
-				var templateFilePath = webBasedGeneratorConfig.UseDebugParams()
+				var templateFilePath = config.UseDebugParams
 					? htmlSvgWrapper.TemplatePathDebug
 					: htmlSvgWrapper.TemplatePathRelease;
 
@@ -758,7 +770,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 				var htmlFileName = Path.ChangeExtension(svgSavedFilePath, $".{Path.GetFileName(templateFilePath)}");
 
 
-				if (File.Exists(htmlFileName) && !webBasedGeneratorConfig.OverwriteExistingHtmlMaps)
+				if (File.Exists(htmlFileName) && !config.OverwriteExistingHtmlMaps)
 				{
 					
 

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/SVGFreemindMap.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/SVGFreemindMap.cs
@@ -10,6 +10,13 @@ public class SVGFreemindMap : DocumentConfig, ICloneable
 
 	public bool SetSVGNodeAttributes { get; set; }
 
+	public string SvgWidth { get; set; } 
+
+	public string SvgHeight { get; set; } 
+
+
+	public string SvgViewBox { get; set; }
+
 	public bool WrapNodeByLink { get; set; }
 
 

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/CardDocumentFormat.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/CardDocumentFormat.cs
@@ -4,6 +4,7 @@ namespace Argumentum.AssetConverter
     {
         AlternateFaceAndBack,
         BackFirstOneDocPerBack,
-        PrintAndPlay
-    }
+        PrintAndPlay,
+		FacesOnly
+	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/CardSetConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/CardSetConfig.cs
@@ -12,7 +12,10 @@ namespace Argumentum.AssetConverter
 
         public string Name { get; set; }
 
+        public bool IsEnabled { get; set; } = true;
 
+
+		public string FilePattern { get; set; } = "*.csv";
 		public CardSetInfo FaceCardSetInfo { get; set; } = new CardSetInfo();
 
         public CardSetInfo BackCardSetInfo { get; set; } = new CardSetInfo();
@@ -20,7 +23,7 @@ namespace Argumentum.AssetConverter
 
 
 
-        public string GetHarvestSerializationName(WebBasedGeneratorConfig config, string language)
+        public string GetHarvestSerializationName(AssetConverterConfig config, string language)
         {
             return Path.Combine(config.GetHarvestDirectory(language), $"{Name}_harvest_{language}.json");
         }

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Localization/LocalizationConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Localization/LocalizationConfig.cs
@@ -1,4 +1,3 @@
-using HarfBuzzSharp;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,18 +17,28 @@ public class LocalizationConfig
 	public  List<DocumentLocalization> MindMapLocalization { get; set; } = new List<DocumentLocalization>();
 
 	public async Task<(CardSetPayload front, CardSetPayload back)> TranslateCardSet(CardSetConfig source,
-		(string sourceLang, string destLang) languages, WebBasedGeneratorConfig config)
+		(string sourceLang, string destLang) languages, AssetConverterConfig config)
 	{
-		
-		
-		var localization = CardSetLocalizations.First(setLocalization => setLocalization.CardSetNames.Contains(source.Name));
+
+
+		var localization = CardSetLocalizations.FirstOrDefault(setLocalization => setLocalization.CardSetNames.Contains(source.Name));
+		if (localization == null)
+		{
+			Logger.LogWarning($"No localization found for card set '{source.Name}' for language '{languages.destLang}'. Skipping translation.");
+			var front = await source.FaceCardSetInfo.GetCardSetDocument(config);
+			var back = string.IsNullOrEmpty(source.BackCardSetInfo.GetJsonFilePath(config))
+				? null
+				: await source.BackCardSetInfo.GetCardSetDocument(config);
+			return (front, back);
+		}
+
 		var frontTranslated = await localization.TranslateCardSetInfo(source.FaceCardSetInfo, true, languages, config);
 		CardSetPayload backTranslated = null;
 		if (!string.IsNullOrEmpty(source.BackCardSetInfo.GetJsonFilePath(config)))
 		{
 			backTranslated = await localization.TranslateCardSetInfo(source.BackCardSetInfo, false, languages, config);
 		}
-		 
+
 
 		return (frontTranslated, backTranslated);
 


### PR DESCRIPTION
## Summary
- Restore 14 branch files overwritten by the PR #116 merge (master versions replaced branch refactored code: `ConverterMode` [Flags] enum, `SVGFreemindMap` properties, `Arrowlink` class, DatasetUpdater API, Logger, etc.)
- Guard unprotected `.First()` calls in `ProcessSvgFilesAsync` and `DisambiguateSvgNodes` to prevent `InvalidOperationException`
- Migrate `MindMapDocumentConfig.cs` (legacy master file) API from `WebBasedGeneratorConfig` to `AssetConverterConfig`

## Test plan
- [x] Build: 0 errors (was 166 before fix)
- [x] Tests: 27/27 pass, 1 skipped (Freeplane integration)
- [x] No functional regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)