### PR TITLE
fix(ci): upgrade deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- `actions/upload-pages-artifact@v1` uses the deprecated `upload-artifact@v3` which GitHub has disabled, causing all CI runs to fail with: `This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3`
- Updated all 4 actions to latest versions (checkout v4, configure-pages v5, upload-pages-artifact v3, deploy-pages v4)

## Test plan
- [x] Workflow file syntax valid
- [ ] CI should pass on merge (GitHub Pages deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)