### PR TITLE
fix(ci): deploy only CardPen to GitHub Pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Deploy only CardPen (HTML card renderer used by the pipeline)
+          path: 'Generation/CardPen'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- The Pages workflow uploaded the entire repo (~5GB) as artifact, exceeding limits and causing all CI runs to fail
- Changed `path: '.'` to `path: 'Generation/CardPen'` — only the CardPen HTML renderer needs to be on Pages

## Test plan
- [ ] CI passes after merge
- [ ] CardPen accessible at GitHub Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)