### PR TITLE
fix(ci): remove broken Windows pseudo-symlinks before Pages upload

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,6 +32,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Clean broken symlinks
+        run: |
+          # Remove Windows pseudo-symlinks (text files containing paths)
+          # that break tar --dereference on Linux
+          find Generation/CardPen -maxdepth 1 -type f -size -100c \
+            -exec grep -lq '^[A-Z]:/' {} \; -delete 2>/dev/null || true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- CardPen directory contains Windows pseudo-symlinks (`Fallacies`, `Memo`, `Rules`, `Scenarii`) — text files with absolute Windows paths
- `tar --dereference` on Linux CI tries to resolve them and fails silently (exit code 1)
- Added a cleanup step to remove these before artifact upload

Fixes CI after PRs #153 and #154.

## Test plan
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)