### PR TITLE
fix(mindmap): add XSLT fallback chain in TryAutomateSvgConversion

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -318,7 +318,20 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 		private bool TryAutomateSvgConversion(string sourceMmPath, string destinationSvgPath, AssetConverterConfig config, bool isInteractive = true)
 		{
-			return TryFreeMindSvgExport(sourceMmPath, destinationSvgPath, config);
+			// 1. Try FreeMind GUI (high-fidelity Batik SVG, requires interactive desktop)
+			if (TryFreeMindSvgExport(sourceMmPath, destinationSvgPath, config))
+				return true;
+
+			// 2. Fallback to XSLT (lower fidelity but works headless)
+			Logger.Log($"FreeMind GUI unavailable, falling back to XSLT for {Path.GetFileName(sourceMmPath)}");
+			if (TryXsltSvgConversion(sourceMmPath, destinationSvgPath))
+				return true;
+
+			// 3. Prompt user if interactive
+			if (isInteractive && Program.IsInteractive)
+				Logger.LogWarning($"SVG not generated. Please convert manually: {sourceMmPath}");
+
+			return false;
 		}
 
 		/// <summary>

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
@@ -298,7 +298,17 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 		private bool TryAutomateSvgConversion(string sourceMmPath, string destinationSvgPath, AssetConverterConfig config, bool isInteractive = true)
 		{
-			return FallacyMindMapDocumentConfig.TryFreeMindSvgExport(sourceMmPath, destinationSvgPath, config);
+			if (FallacyMindMapDocumentConfig.TryFreeMindSvgExport(sourceMmPath, destinationSvgPath, config))
+				return true;
+
+			Logger.Log($"FreeMind GUI unavailable, falling back to XSLT for {Path.GetFileName(sourceMmPath)}");
+			if (FallacyMindMapDocumentConfig.TryXsltSvgConversion(sourceMmPath, destinationSvgPath))
+				return true;
+
+			if (isInteractive && Program.IsInteractive)
+				Logger.LogWarning($"SVG not generated. Please convert manually: {sourceMmPath}");
+
+			return false;
 		}
 
 


### PR DESCRIPTION
## Summary
- `TryAutomateSvgConversion` only called `TryFreeMindSvgExport` (GUI-based) without falling back to `TryXsltSvgConversion` on failure
- Headless machines (no FreeMind GUI) produced 0 SVG files despite XSLT being available
- Now implements proper fallback chain: FreeMind GUI → XSLT → manual prompt
- Fixed in both `FallacyMindMapDocumentConfig` and `VirtueMindMapDocumentConfig`

Bug found by po-2023 during T3 (multilingual SVG export).

## Test plan
- [x] Build: 0 errors
- [ ] Tests: running
- [ ] po-2023 re-test: SVG should be generated via XSLT on headless machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)