### PR TITLE
fix(tests): disable FreeMind/Freeplane GUI in unit tests

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MmGeneratorTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MmGeneratorTests.cs
@@ -22,7 +22,12 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
 
         public MmGeneratorTests()
         {
-            _config = new AssetConverterConfig { OverwriteExistingDocs = true };
+            _config = new AssetConverterConfig
+            {
+                OverwriteExistingDocs = true,
+                FreeMindPath = "",  // Disable FreeMind GUI in tests — use XSLT fallback only
+                FreeplanePath = "", // Disable Freeplane GUI in tests
+            };
             _config.LocalizationConfig.DefaultLanguage = "fr"; // Set default language for test consistency
             _tempTestDirectory = Path.Combine(Path.GetTempPath(), "MmGeneratorTests", Path.GetRandomFileName());
             Directory.CreateDirectory(_tempTestDirectory);

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgConversionIntegrationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgConversionIntegrationTests.cs
@@ -15,7 +15,12 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
 
         public SvgConversionIntegrationTests()
         {
-            _config = new AssetConverterConfig { OverwriteExistingDocs = true, FreeplanePath = "C:/Program Files/Freeplane/freeplane.bat" };
+            _config = new AssetConverterConfig
+            {
+                OverwriteExistingDocs = true,
+                FreeMindPath = "",  // Disable FreeMind GUI in tests
+                FreeplanePath = "", // Disable Freeplane GUI in tests
+            };
             _tempTestDirectory = Path.Combine(Path.GetTempPath(), "SvgConversionTests", Path.GetRandomFileName());
             Directory.CreateDirectory(_tempTestDirectory);
 


### PR DESCRIPTION
## Summary
- Tests called `GenerateMindMapFile` which triggered `TryFreeMindSvgExport`, launching FreeMind GUI 4 times
- Set `FreeMindPath=""` and `FreeplanePath=""` in test configs so the existing guard returns false immediately
- XSLT fallback handles SVG generation in tests instead
- Test duration: **2m30s → 2s**

## Test plan
- [x] Build: 0 errors
- [x] Tests: 27/27 pass, 1 skipped, **2 seconds**

🤖 Generated with [Claude Code](https://claude.com/claude-code)