### PR TITLE
fix(tests): adapt Compare API for Magick.NET 14

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Tests/CardGenerationValidationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Tests/CardGenerationValidationTests.cs
@@ -538,12 +538,9 @@ namespace Argumentum.AssetConverter.Tests
                 }
                 
                 // Comparer les images
-                using (var diff = new MagickImage())
-                {
-                    // Calculer la différence
-                    var error = image1.Compare(image2, ErrorMetric.RootMeanSquared, diff);
-                    return error;
-                }
+                // Calculer la différence
+                using var diff = image1.Compare(image2, ErrorMetric.RootMeanSquared, Channels.Composite, out double error);
+                return error;
             }
         }
     }


### PR DESCRIPTION
## Summary
Follow-up to PR #147 (Magick.NET 13.5.0 → 14.11.1). The `MagickImage.Compare` API changed:
- Old: `Compare(image, metric, diffImage)` returns `double`
- New: `Compare(image, metric, channels, out error)` returns `IMagickImage`

## Test plan
- [x] Build: 0 errors
- [x] Tests: 27/27 pass, 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)