### PR TITLE
fix(mindmap): localize mind map content for EN/RU/PT

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MmGeneratorTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MmGeneratorTests.cs
@@ -85,7 +85,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
                 xmlDoc.Should().NotBeNull();
                 xmlDoc.Root.Name.LocalName.Should().Be("map");
 
-                // Validate root node (TitleFunc uses DefaultTitleExpression = "{item.Text}")
+                // Validate root node (TitleFunc uses TitleExpression = "{item.TextFr}")
                 xmlDoc.Root.Element("node")?.Attribute("TEXT")?.Value.Should().Be("Sophismes");
 
                 foreach (var fallacy in fallacies)
@@ -241,6 +241,57 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
                 records.Add(record);
             }
             return records;
+        }
+
+        [Theory]
+        [InlineData("en", "TextEn", "DescEn", "ExampleEn", "LinkEnFallback", "Subfamily", "Subsubfamily", "Family")]
+        [InlineData("ru", "TextRu", "DescRu", "Exampleru", "LinkRuFallback", "SubfamilyRu", "SubsubfamilyRu", "FamilyRu")]
+        [InlineData("pt", "TextPt", "DescPt", "ExamplePt", "LinkPtFallback", "SubfamilyPt", "SubsubfamilyPt", "FamilyPt")]
+        public void MindMapLocalization_ShouldTranslateAllFallacyExpressions(
+            string lang, string expectedText, string expectedDesc, string expectedExample,
+            string expectedLink, string expectedSubFamily, string expectedSubSubFamily, string expectedFamily)
+        {
+            // Arrange
+            var config = new FallacyMindMapDocumentConfig();
+
+            // Act - apply all localizations like the pipeline does
+            foreach (var localization in _config.LocalizationConfig.MindMapLocalization)
+            {
+                localization.DoReflectionTranslate(config, lang);
+            }
+
+            // Assert - text fields
+            config.TitleExpression.Should().Contain(expectedText,
+                $"TitleExpression should reference {expectedText} for language '{lang}'");
+            config.DescriptionExpression.Should().Contain(expectedDesc,
+                $"DescriptionExpression should reference {expectedDesc} for language '{lang}'");
+            config.ExampleExpression.Should().Contain(expectedExample,
+                $"ExampleExpression should reference {expectedExample} for language '{lang}'");
+            config.LinkExpression.Should().Contain(expectedLink,
+                $"LinkExpression should reference {expectedLink} for language '{lang}'");
+
+            // Assert - family hierarchy
+            config.FamilleExpression.Should().Contain(expectedFamily,
+                $"FamilleExpression should reference {expectedFamily} for language '{lang}'");
+            config.SousFamilleExpression.Should().Contain(expectedSubFamily,
+                $"SousFamilleExpression should reference {expectedSubFamily} for language '{lang}'");
+            config.SoussousFamilleExpression.Should().Contain(expectedSubSubFamily,
+                $"SoussousFamilleExpression should reference {expectedSubSubFamily} for language '{lang}'");
+        }
+
+        [Fact]
+        public void MindMapLocalization_FrenchDefaults_ShouldUseFrProperties()
+        {
+            // Verify the default (FR) expressions use concrete FR property names
+            var config = new FallacyMindMapDocumentConfig();
+
+            config.TitleExpression.Should().Contain("TextFr");
+            config.DescriptionExpression.Should().Contain("DescFr");
+            config.ExampleExpression.Should().Contain("ExampleFr");
+            config.LinkExpression.Should().Contain("LinkFrFallback");
+            config.FamilleExpression.Should().Contain("Famille");
+            config.SousFamilleExpression.Should().Contain("SousFamille");
+            config.SoussousFamilleExpression.Should().Contain("Soussousfamille");
         }
 
         public void Dispose()

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -146,26 +146,39 @@ namespace Argumentum.AssetConverter
 			}),
 			MindMapLocalization = new List<DocumentLocalization>(new[]
 			{
+				// Fallacy text fields: FR property names → localized property names
 				new DocumentLocalization(){
 					TargetProperties = new List<string>(new []
 					{
 						nameof(FallacyMindMapDocumentConfig.TitleExpression),
-						nameof (FallacyMindMapDocumentConfig.CardExpression)
+						nameof(FallacyMindMapDocumentConfig.CardExpression),
+						nameof(FallacyMindMapDocumentConfig.DescriptionExpression),
+						nameof(FallacyMindMapDocumentConfig.ExampleExpression),
+						nameof(FallacyMindMapDocumentConfig.LinkExpression),
 					}),
 					StaticConversions = new List<(string sourceText, List<(string Language, string destText)> textConversions)>(new[]{
-						(nameof(Fallacy.SousFamille), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.Subfamily)), ("ru", nameof(Fallacy.SubfamilyRu)), ("pt", nameof(Fallacy.SubfamilyPt)) }) )
+						(nameof(Fallacy.TextFr), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.TextEn)), ("ru", nameof(Fallacy.TextRu)), ("pt", nameof(Fallacy.TextPt)) }) ),
+						(nameof(Fallacy.DescFr), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.DescEn)), ("ru", nameof(Fallacy.DescRu)), ("pt", nameof(Fallacy.DescPt)) }) ),
+						(nameof(Fallacy.ExampleFr), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.ExampleEn)), ("ru", nameof(Fallacy.Exampleru)), ("pt", nameof(Fallacy.ExamplePt)) }) ),
+						("LinkFrFallback", new List<(string Language, string destText)>(new []{("en", "LinkEnFallback"), ("ru", "LinkRuFallback"), ("pt", "LinkPtFallback") }) ),
 					}),
 				},
+				// Fallacy family hierarchy: FR names → localized names
+				// Order: most specific first (Soussousfamille > SousFamille > Famille) to avoid partial matches
 				new DocumentLocalization(){
 					TargetProperties = new List<string>(new []
 					{
-						nameof(FallacyMindMapDocumentConfig.TitleExpression),
-						nameof (FallacyMindMapDocumentConfig.CardExpression)
+						nameof(FallacyMindMapDocumentConfig.FamilleExpression),
+						nameof(FallacyMindMapDocumentConfig.SousFamilleExpression),
+						nameof(FallacyMindMapDocumentConfig.SoussousFamilleExpression),
 					}),
 					StaticConversions = new List<(string sourceText, List<(string Language, string destText)> textConversions)>(new[]{
-						(nameof(Fallacy.Soussousfamille), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.Subsubfamily)), ("ru", nameof(Fallacy.SubsubfamilyRu)), ("pt", nameof(Fallacy.SubsubfamilyPt)) }) )
+						(nameof(Fallacy.Soussousfamille), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.Subsubfamily)), ("ru", nameof(Fallacy.SubsubfamilyRu)), ("pt", nameof(Fallacy.SubsubfamilyPt)) }) ),
+						(nameof(Fallacy.SousFamille), new List<(string Language, string destText)>(new []{("en", nameof(Fallacy.Subfamily)), ("ru", nameof(Fallacy.SubfamilyRu)), ("pt", nameof(Fallacy.SubfamilyPt)) }) ),
+						(nameof(Fallacy.Famille), new List<(string Language, string destText)>(new []{("en", "Family"), ("ru", nameof(Fallacy.FamilyRu)), ("pt", nameof(Fallacy.FamilyPt)) }) ),
 					}),
 				},
+				// Virtue root title translation (data is FR-only, only tree root name changes)
 				new DocumentLocalization(){
 					TargetProperties = new List<string>(new []
 					{
@@ -175,6 +188,7 @@ namespace Argumentum.AssetConverter
 						("Vertus", new List<(string Language, string destText)>(new []{("en", "Virtues"), ("ru", "Dobrodeteli"), ("pt", "Virtudes") }) )
 					}),
 				},
+				// Document name: _fr. → _en./_ru./_pt.
 				new DocumentLocalization(){
 					TargetProperties = new List<string>(new []
 					{

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -39,7 +39,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 
-		const string DefaultTitleExpression = @"{item.Text}";
+		const string DefaultTitleExpression = @"{item.TextFr}";
 
 		public string TitleExpression { get; set; } = DefaultTitleExpression;
 
@@ -51,8 +51,8 @@ namespace Argumentum.AssetConverter.Mindmapper
 			{
 				return item =>
 				{
-					
-					var expression = DefaultTitleExpression;
+
+					var expression = TitleExpression;
 					var title = expression.Interpolate(new Dictionary<string, object>() { { "item", item } });
 					if (AddNodePath)
 					{
@@ -66,7 +66,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 		public bool AddNodePath { get; set; } = false;
 
 
-		const string DefaultFamilleExpression = @"{item.Family}";
+		const string DefaultFamilleExpression = @"{item.Famille}";
 		public string FamilleExpression { get; set; } = DefaultFamilleExpression;
 
 		[IgnoreDataMember]
@@ -80,7 +80,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 		}
 
 
-		const string DefaultSousFamilleExpression = @"{item.SubFamily}";
+		const string DefaultSousFamilleExpression = @"{item.SousFamille}";
 		public string SousFamilleExpression { get; set; } = DefaultSousFamilleExpression;
 
 		[IgnoreDataMember]
@@ -94,7 +94,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 		}
 
 
-		const string DefaultSoussousFamilleExpression = @"{item.SubSubFamily}";
+		const string DefaultSoussousFamilleExpression = @"{item.Soussousfamille}";
 		public string SoussousFamilleExpression { get; set; } = DefaultSoussousFamilleExpression;
 
 		[IgnoreDataMember]
@@ -110,7 +110,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 		public string DescriptionExpression { get; set; } =
 @"
 <p>
-    {HttpUtility.HtmlEncode(item.Description)}
+    {HttpUtility.HtmlEncode(item.DescFr)}
 </p>
 ";
 
@@ -148,7 +148,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 		public string ExampleExpression { get; set; } =
 @"
 <p>
-    <i>{HttpUtility.HtmlEncode(item.Example)}</i>
+    <i>{HttpUtility.HtmlEncode(item.ExampleFr)}</i>
 </p>
 ";
 
@@ -165,7 +165,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 
-		public string LinkExpression { get; set; } = @"{item.Link}";
+		public string LinkExpression { get; set; } = @"{item.LinkFrFallback}";
 
 
 		[IgnoreDataMember]

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
@@ -47,7 +47,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 				return item =>
 				{
 					
-					var expression = DefaultTitleExpression;
+					var expression = TitleExpression;
 					var title = expression.Interpolate(new Dictionary<string, object>() { { "item", item } });
 					if (AddNodePath)
 					{

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Localization/DocumentLocalization.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Localization/DocumentLocalization.cs
@@ -15,6 +15,7 @@ public class DocumentLocalization
 
 	public string DoStaticConversions(string template, string destLang)
 	{
+		if (template == null) return template;
 		foreach (var staticConversion in StaticConversions)
 		{
 			var translations =


### PR DESCRIPTION
## Summary
- **Bug**: All mind maps (.mm files) contained French text regardless of target language
- **Root cause**: Three compounding bugs in the localization pipeline:
  1. `TitleFunc` read from a compile-time constant instead of the localizable `TitleExpression` property
  2. Default expressions used `IMindMapItem` interface properties (`Text`, `Description`, etc.) which are hardcoded to French
  3. No `StaticConversions` existed for text fields (TextFr→TextEn) or family hierarchy (Famille→Family)
- **Fix**: Use concrete FR property names in expressions + comprehensive `StaticConversions` for all 4 languages
- **Also**: Null guard in `DoStaticConversions` to prevent NRE on uninitialized properties

## Files changed
- `FallacyMindMapDocumentConfig.cs` — Fix TitleFunc, change expressions to FR property names
- `VirtueMindMapDocumentConfig.cs` — Fix TitleFunc (Virtue data is FR-only)
- `AssetConverterConfig.cs` — Add StaticConversions for text fields + family hierarchy
- `DocumentLocalization.cs` — Null guard
- `MmGeneratorTests.cs` — 4 new localization tests (EN/RU/PT + FR defaults)

## Test plan
- [x] Build: 0 errors
- [x] Tests: 31/31 pass (4 new localization tests)
- [ ] Pipeline re-run with Mindmapper mode to verify EN/RU/PT .mm files

🤖 Generated with [Claude Code](https://claude.com/claude-code)