### PR TITLE
fix(mindmap): prevent async/WinForms deadlock after SendKeys

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -304,7 +304,10 @@ namespace Argumentum.AssetConverter.Mindmapper
 				SerializeMindMapAsync(freemindMap, fileName);
 
 				var svgPath = Path.ChangeExtension(fileName, "svg");
-				TryAutomateSvgConversion(fileName, svgPath, config, config.EnableSVGPrompt);
+				// Run on thread pool to isolate WinForms SyncContext installed by SendKeys
+				Task.Run(() => TryAutomateSvgConversion(fileName, svgPath, config, config.EnableSVGPrompt)).GetAwaiter().GetResult();
+				// Clean up any WinForms SyncContext that may have been installed
+				System.Threading.SynchronizationContext.SetSynchronizationContext(null);
 			}
 		}
 
@@ -957,7 +960,7 @@ if (mapFile != null) {
 					XNamespace xlinkNamespace = "http://www.w3.org/1999/xlink";
 
 					UpdateSvgWithItems(svgFreemindMap, mindMapItems, svgDoc, svgNamespace, xlinkNamespace);
-					await File.WriteAllTextAsync(svgSavedFilePath, GetSvgContent(svgDoc), Encoding.UTF8);
+					File.WriteAllText(svgSavedFilePath, GetSvgContent(svgDoc), Encoding.UTF8);
 					Logger.LogSuccess($"SVG file with detailed content {svgSavedFilePath} successfully saved");
 					processedDocs.Add(svgSavedFilePath, svgDoc);
 				}
@@ -1320,7 +1323,7 @@ if (mapFile != null) {
 					htmlTemplate = htmlTemplate.Replace("[SVGPATH]", svgRelativePath);
 					htmlTemplate = htmlTemplate.Replace("<!-- Insert here the SVG -->", await svgContent());
 
-					await File.WriteAllTextAsync(htmlFileName, htmlTemplate, Encoding.UTF8);
+					File.WriteAllText(htmlFileName, htmlTemplate, Encoding.UTF8);
 					Logger.LogSuccess($"Html SVG MindMap wrapper {htmlFileName} successfully saved");
 				}
 

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -488,7 +488,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 					svgLoader = () => Task.FromResult(GetSvgContent(svgDoc));
 
 
-					await File.WriteAllTextAsync(svgSavedFilePath, await svgLoader(), Encoding.UTF8);
+					File.WriteAllText(svgSavedFilePath, svgLoader().GetAwaiter().GetResult(), Encoding.UTF8);
 					Logger.LogSuccess($"SVG file with detailed content {svgSavedFilePath} successfully saved");
 
 				}
@@ -784,7 +784,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 					htmlTemplate = htmlTemplate.Replace("[SVGPATH]", svgRelativePath);
 					htmlTemplate = htmlTemplate.Replace("[SVGCONTENT]", await svgContent());
 
-					await File.WriteAllTextAsync(htmlFileName, htmlTemplate, Encoding.UTF8);
+					File.WriteAllText(htmlFileName, htmlTemplate, Encoding.UTF8);
 					Logger.LogSuccess($"Html SVG MindMap wrapper {htmlFileName} successfully saved");
 				}
 

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
@@ -585,7 +585,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 					svgLoader = () => Task.FromResult(GetSvgContent(svgDoc));
 
 
-					await File.WriteAllTextAsync(svgSavedFilePath, await svgLoader(), Encoding.UTF8);
+					File.WriteAllText(svgSavedFilePath, svgLoader().GetAwaiter().GetResult(), Encoding.UTF8);
 					Logger.LogSuccess($"SVG file with detailed content {svgSavedFilePath} successfully saved");
 
 				}
@@ -893,7 +893,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 					htmlTemplate = htmlTemplate.Replace("[SVGPATH]", svgRelativePath);
 					htmlTemplate = htmlTemplate.Replace("<!-- Insert here the SVG -->", await svgContent());
 
-					await File.WriteAllTextAsync(htmlFileName, htmlTemplate, Encoding.UTF8);
+					File.WriteAllText(htmlFileName, htmlTemplate, Encoding.UTF8);
 					Logger.LogSuccess($"Html SVG MindMap wrapper {htmlFileName} successfully saved");
 				}
 			}


### PR DESCRIPTION
## Summary
- Isolate `SendKeys.SendWait()` in `Task.Run` to prevent WinForms SyncContext from polluting the thread pool
- Clear `SynchronizationContext` after FreeMind automation
- Replace `await File.WriteAllTextAsync` with sync `File.WriteAllText` in all Mindmapper code paths that may execute after SendKeys

## Root cause
`SendKeys.SendWait()` from `System.Windows.Forms` installs a `WindowsFormsSynchronizationContext` on the current thread. In a console app with no message pump, subsequent `await` calls deadlock because the WinForms context posts callbacks that never get processed.

## Test plan
- [ ] Run pipeline with `Mode = Mindmapper` — verify it completes all 4 languages (FR/EN/RU/PT) without hanging
- [ ] Verify .mm, .svg, and HTML wrapper files are generated for each language
- [ ] Run `dotnet test` — verify all tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)