### PR TITLE
fix(mindmap): register Fallacy/Virtue MindMapDocumentConfig in CustomTypeProvider

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/CustomTypeProvider.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/CustomTypeProvider.cs
@@ -18,6 +18,8 @@ namespace Argumentum.AssetConverter
             HashSet<Type> types = DefaultProvider.GetCustomTypes();
             types.Add(typeof(HttpUtility));
             types.Add(typeof(MindMapDocumentConfig));
+            types.Add(typeof(FallacyMindMapDocumentConfig));
+            types.Add(typeof(VirtueMindMapDocumentConfig));
             return types;
         }
 


### PR DESCRIPTION
## Summary
- `DynamicExpressionParser` is used to resolve `CardFunc` expressions like `{mindMap.GetThumbnailsPath(item)}` where `mindMap` is a concrete `FallacyMindMapDocumentConfig` or `VirtueMindMapDocumentConfig` instance.
- `GetThumbnailsPath` is defined **separately** on each subclass (no polymorphic override on the base), so `System.Linq.Dynamic.Core` cannot resolve the method when only the base type is registered in `CustomTypeProvider`.
- Result: `ParseException: Methods on type 'FallacyMindMapDocumentConfig' are not accessible` at runtime when the Mindmapper mode runs.

## Fix
Register both subclasses alongside the base `MindMapDocumentConfig` in `CustomTypeProvider.GetCustomTypes()`.

## Context
- Bug identified by po-2023 during pipeline run #1 on 2026-04-08 (dashboard report, tags `STATUS/PIPELINE/FIX`).
- Not committed by po-2023 — picked up by ai-01 for review + PR.

## Test plan
- [x] Build succeeds (0 errors)
- [x] Tests pass (31/31, 1 skipped Freeplane)
- [ ] Mindmapper pipeline run no longer throws `ParseException` (to be verified on next pipeline run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)