### PR TITLE
fix(mindmap): route HTML wrapper generation through MindMapHtmlWrapper + Playwright tests (#196)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MindMapHtmlWrapperTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MindMapHtmlWrapperTests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using Argumentum.AssetConverter.Mindmapper;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.MindmapGeneration
+{
+    /// <summary>
+    /// Pure unit tests for <see cref="MindMapHtmlWrapper.FormatWrapper"/> — exercises the two
+    /// placeholder substitutions on both real templates (<c>included.html</c>, <c>external.html</c>)
+    /// without spinning up Playwright. Issue #196 phase 1 — ensures the regression that shipped
+    /// literal "[SVGCONTENT]" strings in the DOM cannot reappear silently.
+    /// </summary>
+    public class MindMapHtmlWrapperTests
+    {
+        private static readonly string RepoRoot =
+            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
+
+        private static readonly string IncludedTemplatePath =
+            Path.Combine(RepoRoot, "Cards", "Fallacies", "Mindmaps", "included.html");
+
+        private static readonly string ExternalTemplatePath =
+            Path.Combine(RepoRoot, "Cards", "Fallacies", "Mindmaps", "external.html");
+
+        [Fact]
+        public void FormatWrapper_Included_ReplacesSvgContentPlaceholder()
+        {
+            var template = File.ReadAllText(IncludedTemplatePath);
+            template.Should().Contain("[SVGCONTENT]",
+                "pre-condition: the committed template must contain the placeholder this fix targets");
+
+            var result = MindMapHtmlWrapper.FormatWrapper(
+                template,
+                "Fallacies_fr.content.svg",
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"embedded-test\"><g class=\"node\" id=\"n1\"/></svg>");
+
+            result.Should().NotContain("[SVGCONTENT]",
+                "the regression introduced in #129 shipped wrappers with the literal placeholder in the DOM");
+            result.Should().Contain("id=\"embedded-test\"", "the SVG markup must be inlined inside the wrapper");
+            result.Should().Contain("class=\"node\"", "clickable nodes must be preserved in the inline SVG");
+        }
+
+        [Fact]
+        public void FormatWrapper_External_ReplacesSvgPathPlaceholder()
+        {
+            var template = File.ReadAllText(ExternalTemplatePath);
+            template.Should().Contain("[SVGPATH]");
+
+            var result = MindMapHtmlWrapper.FormatWrapper(
+                template,
+                "Fallacies_fr.content.svg",
+                "<svg/>"); // external template ignores SVGCONTENT — safe no-op
+
+            result.Should().NotContain("[SVGPATH]");
+            result.Should().Contain("data=\"Fallacies_fr.content.svg\"",
+                "the <object> tag should reference the SVG file via the replaced [SVGPATH]");
+        }
+
+        [Fact]
+        public void FormatWrapper_External_TemplateHasNoSvgContentPlaceholder()
+        {
+            // Documents the design: only included.html carries [SVGCONTENT]. This prevents future
+            // edits from accidentally embedding an SVG twice in the external variant.
+            var template = File.ReadAllText(ExternalTemplatePath);
+            template.Should().NotContain("[SVGCONTENT]");
+        }
+
+        [Fact]
+        public void FormatWrapper_HandlesNullSvgContentGracefully()
+        {
+            var template = "<html>[SVGPATH] / [SVGCONTENT]</html>";
+
+            var result = MindMapHtmlWrapper.FormatWrapper(template, "a.svg", svgContent: null!);
+
+            result.Should().Be("<html>a.svg / </html>");
+        }
+
+        [Fact]
+        public void FormatWrapper_HandlesNullSvgPathGracefully()
+        {
+            var template = "<html>[SVGPATH] / [SVGCONTENT]</html>";
+
+            var result = MindMapHtmlWrapper.FormatWrapper(template, svgRelativePath: null!, "<svg/>");
+
+            result.Should().Be("<html> / <svg/></html>");
+        }
+
+        [Fact]
+        public void FormatWrapper_NullTemplate_Throws()
+        {
+            Action act = () => MindMapHtmlWrapper.FormatWrapper(null!, "a.svg", "<svg/>");
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void FormatWrapper_Idempotent_SecondCallIsNoOp()
+        {
+            var template = "<html>[SVGPATH] [SVGCONTENT]</html>";
+            var once = MindMapHtmlWrapper.FormatWrapper(template, "a.svg", "<svg/>");
+            var twice = MindMapHtmlWrapper.FormatWrapper(once, "b.svg", "<svg id=\"other\"/>");
+
+            // Guardrail: once the placeholders are gone, re-running the helper must not mutate
+            // the content. Documents the expectation and catches regressions where someone adds
+            // a third placeholder without updating the contract.
+            twice.Should().Be(once);
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/MindmapWrapperTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/MindmapWrapperTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Argumentum.AssetConverter.Mindmapper;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Argumentum.AssetConverter.VisualTests
+{
+    /// <summary>
+    /// Playwright integration tests for mind map HTML wrapper rendering.
+    /// Issue #196: proves that the wrappers generated from the committed templates +
+    /// committed Batik SVGs actually render in a real browser, nodes are clickable,
+    /// and the overlay card reacts to clicks. Every assertion corresponds to something
+    /// the user would spot visually when opening the file.
+    ///
+    /// These tests DO NOT require a full pipeline run — they compose the wrapper in a
+    /// temp directory using the same <see cref="MindMapHtmlWrapper.FormatWrapper"/> path
+    /// the pipeline uses, so a regression in the helper will surface here.
+    /// </summary>
+    public class MindmapWrapperTests : IAsyncLifetime
+    {
+        private readonly ITestOutputHelper _output;
+        private IPlaywright _playwright = null!;
+        private IBrowser _browser = null!;
+        private string _tempDir = null!;
+
+        private static readonly string RepoRoot =
+            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".."));
+
+        private static readonly string IncludedTemplatePath =
+            Path.Combine(RepoRoot, "Cards", "Fallacies", "Mindmaps", "included.html");
+
+        private static readonly string ExternalTemplatePath =
+            Path.Combine(RepoRoot, "Cards", "Fallacies", "Mindmaps", "external.html");
+
+        public MindmapWrapperTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public async Task InitializeAsync()
+        {
+            _playwright = await Playwright.CreateAsync();
+            _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+            _tempDir = Path.Combine(Path.GetTempPath(), "argumentum-wrapper-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_browser != null) await _browser.CloseAsync();
+            _playwright?.Dispose();
+            try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); }
+            catch { /* best-effort temp cleanup */ }
+        }
+
+        private static string GetSvgPath(string lang, string fileName)
+            => Path.Combine(RepoRoot, "Cards", "Fallacies", "Mindmaps", lang, fileName);
+
+        /// <summary>
+        /// Inline-SVG variant driven by the real committed Batik SVGs. Verifies the embedded
+        /// <c>&lt;svg&gt;</c> is present in the DOM and carries non-empty geometric content
+        /// (groups, paths, text). Does NOT assert on <c>.node</c> markers — the current Batik
+        /// SVGs are visual-only and intentionally carry no semantic node class (a tracked gap,
+        /// not a regression). The interactive overlay path is covered in a separate test below
+        /// with a synthetic SVG that mimics the expected marker convention.
+        /// </summary>
+        [Theory]
+        [InlineData("fr", "Fallacies_fr.content.svg")]
+        [InlineData("en", "Fallacies_en.content.svg")]
+        [InlineData("ru", "Fallacies_ru.content.svg")]
+        [InlineData("pt", "Fallacies_pt.content.svg")]
+        public async Task Included_Wrapper_Renders_Inline_Svg_With_Content(string lang, string svgFileName)
+        {
+            var svgPath = GetSvgPath(lang, svgFileName);
+            Assert.True(File.Exists(IncludedTemplatePath), $"Missing template: {IncludedTemplatePath}");
+            Assert.True(File.Exists(svgPath), $"Missing SVG fixture: {svgPath}");
+
+            var template = await File.ReadAllTextAsync(IncludedTemplatePath);
+            var svg = await File.ReadAllTextAsync(svgPath);
+
+            var wrapperHtml = MindMapHtmlWrapper.FormatWrapper(
+                template,
+                svgRelativePath: svgFileName,
+                svgContent: svg);
+
+            var wrapperPath = Path.Combine(_tempDir, $"included_{lang}.html");
+            await File.WriteAllTextAsync(wrapperPath, wrapperHtml);
+
+            // Hard guarantee the regression cannot ship silently.
+            Assert.DoesNotContain("[SVGCONTENT]", wrapperHtml);
+            Assert.DoesNotContain("[SVGPATH]", wrapperHtml);
+
+            var page = await _browser.NewPageAsync();
+            await page.GotoAsync("file:///" + wrapperPath.Replace('\\', '/'));
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            var svgCount = await page.Locator("#mindmap svg").CountAsync();
+            Assert.True(svgCount >= 1, $"Expected an inline <svg> under #mindmap for {lang}, got {svgCount}");
+
+            // Any geometric child demonstrates the SVG was actually parsed and embedded.
+            var pathCount = await page.Locator("#mindmap svg path").CountAsync();
+            _output.WriteLine($"[{lang}] inline SVG path elements: {pathCount}");
+            Assert.True(pathCount > 0, $"Expected <path> elements inside the inline SVG for {lang}");
+
+            await page.CloseAsync();
+        }
+
+        /// <summary>
+        /// Interactive overlay path, driven with a synthetic SVG fixture that carries the
+        /// <c>class="node"</c> markers the overlay JS expects. This is the regression harness
+        /// for the interactive layer — if <c>included.html</c>'s JS ever breaks, this test fails
+        /// even before we commit to a particular SVG generator.
+        /// </summary>
+        [Fact]
+        public async Task Included_Wrapper_Click_Node_Shows_Overlay_Card()
+        {
+            Assert.True(File.Exists(IncludedTemplatePath), $"Missing template: {IncludedTemplatePath}");
+
+            var template = await File.ReadAllTextAsync(IncludedTemplatePath);
+
+            // Synthetic SVG with the attributes the overlay JS reads on click:
+            // family / subfamily / subsubfamily / description / example / link / depth / familyclass.
+            const string syntheticSvg = @"<svg xmlns=""http://www.w3.org/2000/svg"" width=""400"" height=""200"">
+  <g class=""node"" family=""Insuffisance"" subfamily=""Argument bâclé"" subsubfamily=""Justification triviale""
+     description=""Test description"" example=""Test example"" link=""https://example.org/test""
+     depth=""3"" familyclass=""insuffisance"">
+    <rect x=""10"" y=""10"" width=""380"" height=""180"" fill=""#f0f0f0""/>
+    <text x=""200"" y=""100"" text-anchor=""middle"">Synthetic node</text>
+  </g>
+</svg>";
+
+            var wrapperHtml = MindMapHtmlWrapper.FormatWrapper(template, "synthetic.svg", syntheticSvg);
+            var wrapperPath = Path.Combine(_tempDir, "included_synthetic_click.html");
+            await File.WriteAllTextAsync(wrapperPath, wrapperHtml);
+
+            var page = await _browser.NewPageAsync();
+            await page.GotoAsync("file:///" + wrapperPath.Replace('\\', '/'));
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            // The overlay JS only wires up click handlers on page load. We confirm the node is
+            // present, click it, and verify the overlay reacts.
+            var nodeLocator = page.Locator("#mindmap svg .node");
+            Assert.Equal(1, await nodeLocator.CountAsync());
+
+            await nodeLocator.ClickAsync();
+
+            // After the click, the JS copies the node's 'family' attribute into .famille,
+            // which is the most observable user-facing change. We read textContent (not
+            // innerText) because the template applies `text-transform: uppercase` to
+            // `.famille`, and innerText would return the visually-uppercased string.
+            var familleText = await page.Locator("card .famille").EvaluateAsync<string>("el => el.textContent");
+            _output.WriteLine($"Overlay famille textContent after click: '{familleText}'");
+            Assert.Equal("Insuffisance", familleText?.Trim());
+
+            // And the card loses its 'hidden' class (it starts hidden after the JS adds it).
+            var cardHasHidden = await page.Locator("card").EvaluateAsync<bool>("el => el.classList.contains('hidden')");
+            Assert.False(cardHasHidden, "The overlay card should become visible after clicking a .node");
+
+            await page.CloseAsync();
+        }
+
+        /// <summary>
+        /// External variant: the wrapper references the SVG via <c>&lt;object data&gt;</c>. Verifies
+        /// the object tag carries the correct relative path (no literal placeholder) and that
+        /// the referenced file exists alongside the wrapper in the expected layout.
+        /// </summary>
+        [Theory]
+        [InlineData("fr", "Fallacies_fr.content.svg")]
+        [InlineData("en", "Fallacies_en.content.svg")]
+        [InlineData("ru", "Fallacies_ru.content.svg")]
+        [InlineData("pt", "Fallacies_pt.content.svg")]
+        public async Task External_Wrapper_References_Svg_Via_Object_Tag(string lang, string svgFileName)
+        {
+            var svgPath = GetSvgPath(lang, svgFileName);
+            Assert.True(File.Exists(ExternalTemplatePath), $"Missing template: {ExternalTemplatePath}");
+            Assert.True(File.Exists(svgPath), $"Missing SVG fixture: {svgPath}");
+
+            var template = await File.ReadAllTextAsync(ExternalTemplatePath);
+            var wrapperHtml = MindMapHtmlWrapper.FormatWrapper(
+                template,
+                svgRelativePath: svgFileName,
+                svgContent: string.Empty); // external variant ignores SVGCONTENT
+
+            // Stage both the wrapper AND the SVG side-by-side in the temp dir, mirroring
+            // what the pipeline does when writing Cards/Fallacies/Mindmaps/{lang}/.
+            var stagedWrapper = Path.Combine(_tempDir, $"external_{lang}.html");
+            var stagedSvg = Path.Combine(_tempDir, svgFileName);
+            await File.WriteAllTextAsync(stagedWrapper, wrapperHtml);
+            File.Copy(svgPath, stagedSvg, overwrite: true);
+
+            Assert.DoesNotContain("[SVGPATH]", wrapperHtml);
+
+            var page = await _browser.NewPageAsync();
+            await page.GotoAsync("file:///" + stagedWrapper.Replace('\\', '/'));
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            var dataAttr = await page.Locator("#svgObject").GetAttributeAsync("data");
+            Assert.Equal(svgFileName, dataAttr);
+
+            await page.CloseAsync();
+        }
+
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -1320,8 +1320,8 @@ if (mapFile != null) {
 				{
 					var svgRelativePath = svgSavedFilePath.GetRelativePathFrom(Path.GetDirectoryName(htmlFileName));
 
-					htmlTemplate = htmlTemplate.Replace("[SVGPATH]", svgRelativePath);
-					htmlTemplate = htmlTemplate.Replace("<!-- Insert here the SVG -->", await svgContent());
+					// Issue #196: single helper, tested separately (see MindMapHtmlWrapperTests).
+					htmlTemplate = MindMapHtmlWrapper.FormatWrapper(htmlTemplate, svgRelativePath, await svgContent());
 
 					File.WriteAllText(htmlFileName, htmlTemplate, Encoding.UTF8);
 					Logger.LogSuccess($"Html SVG MindMap wrapper {htmlFileName} successfully saved");

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
@@ -781,8 +781,8 @@ namespace Argumentum.AssetConverter.Mindmapper
 				{
 					var svgRelativePath = svgSavedFilePath.GetRelativePathFrom(Path.GetDirectoryName(htmlFileName));
 
-					htmlTemplate = htmlTemplate.Replace("[SVGPATH]", svgRelativePath);
-					htmlTemplate = htmlTemplate.Replace("[SVGCONTENT]", await svgContent());
+					// Issue #196: single helper, tested separately (see MindMapHtmlWrapperTests).
+					htmlTemplate = MindMapHtmlWrapper.FormatWrapper(htmlTemplate, svgRelativePath, await svgContent());
 
 					File.WriteAllText(htmlFileName, htmlTemplate, Encoding.UTF8);
 					Logger.LogSuccess($"Html SVG MindMap wrapper {htmlFileName} successfully saved");

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapHtmlWrapper.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapHtmlWrapper.cs
@@ -8,14 +8,16 @@ namespace Argumentum.AssetConverter.Mindmapper;
 ///
 /// The templates used by the pipeline are <c>Cards/Fallacies/Mindmaps/included.html</c>
 /// (inline SVG variant) and <c>external.html</c> (external <c>&lt;object&gt;</c> variant).
-/// They share two placeholder tokens:
+/// They each carry exactly one placeholder token — the helper runs both substitutions
+/// unconditionally, which is a no-op on whichever token is absent:
 /// <list type="bullet">
-///   <item><c>[SVGPATH]</c> — relative path from the wrapper directory to the SVG file. Used by the
-///       external variant inside <c>&lt;object data="..."&gt;</c>. Also present in included.html
-///       for fallback, harmless there.</item>
-///   <item><c>[SVGCONTENT]</c> — the full inline SVG markup. Used only by the included variant.
-///       External.html does not contain this token.</item>
+///   <item><c>[SVGPATH]</c> — external.html only. Relative path from the wrapper directory to
+///       the SVG file, injected inside <c>&lt;object data="..."&gt;</c>.</item>
+///   <item><c>[SVGCONTENT]</c> — included.html only. Full inline SVG markup, dropped directly
+///       into the <c>#mindmap</c> container.</item>
 /// </list>
+/// <c>FormatWrapper_External_TemplateHasNoSvgContentPlaceholder</c> and the
+/// <c>grep</c>-backed precondition in the unit tests pin this contract.
 /// </summary>
 public static class MindMapHtmlWrapper
 {

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapHtmlWrapper.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapHtmlWrapper.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Argumentum.AssetConverter.Mindmapper;
+
+/// <summary>
+/// Pure helper for mind map HTML wrapper templating. Extracted in issue #196 to make
+/// wrapper generation testable without Playwright / filesystem / pipeline runs.
+///
+/// The templates used by the pipeline are <c>Cards/Fallacies/Mindmaps/included.html</c>
+/// (inline SVG variant) and <c>external.html</c> (external <c>&lt;object&gt;</c> variant).
+/// They share two placeholder tokens:
+/// <list type="bullet">
+///   <item><c>[SVGPATH]</c> — relative path from the wrapper directory to the SVG file. Used by the
+///       external variant inside <c>&lt;object data="..."&gt;</c>. Also present in included.html
+///       for fallback, harmless there.</item>
+///   <item><c>[SVGCONTENT]</c> — the full inline SVG markup. Used only by the included variant.
+///       External.html does not contain this token.</item>
+/// </list>
+/// </summary>
+public static class MindMapHtmlWrapper
+{
+    /// <summary>
+    /// Applies the two placeholder substitutions in a single pass. Safe to call on both
+    /// <c>included.html</c> and <c>external.html</c> templates: missing placeholders are no-ops.
+    /// </summary>
+    public static string FormatWrapper(string template, string svgRelativePath, string svgContent)
+    {
+        if (template == null) throw new ArgumentNullException(nameof(template));
+        return template
+            .Replace("[SVGPATH]", svgRelativePath ?? string.Empty)
+            .Replace("[SVGCONTENT]", svgContent ?? string.Empty);
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapCreatorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapCreatorConfig.cs
@@ -53,16 +53,19 @@ namespace Argumentum.AssetConverter.Mindmapper
                         RemoveImages = true,
                         HtmlWrappers = new List<DocumentConfig>(new[]
                         {
+                            // Issue #196: use [LANGUAGE] placeholder so each language produces its
+                            // own file name, mirroring the Fallacies convention. Previous hardcoded
+                            // "_fr" caused every language to ship a misnamed file.
                             new DocumentConfig()
                             {
-                                DocumentName    = "Argumentation_Virtues_fr.html",
+                                DocumentName    = "Argumentation_Virtues_[LANGUAGE].html",
                                 TemplatePathRelease =
                                     "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Fallacies/Mindmaps/included.html",
                                 TemplatePathDebug = @"..\..\..\..\..\..\Cards\Fallacies\Mindmaps\included.html"
                             },
                             new DocumentConfig()
                             {
-                                DocumentName    = "Argumentation_Virtues_fr_ext.html",
+                                DocumentName    = "Argumentation_Virtues_[LANGUAGE]_ext.html",
                                 TemplatePathRelease =
                                     "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Fallacies/Mindmaps/external.html",
                                 TemplatePathDebug = @"..\..\..\..\..\..\Cards\Fallacies\Mindmaps\external.html"

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
@@ -890,8 +890,8 @@ namespace Argumentum.AssetConverter.Mindmapper
 				{
 					var svgRelativePath = svgSavedFilePath.GetRelativePathFrom(Path.GetDirectoryName(htmlFileName));
 
-					htmlTemplate = htmlTemplate.Replace("[SVGPATH]", svgRelativePath);
-					htmlTemplate = htmlTemplate.Replace("<!-- Insert here the SVG -->", await svgContent());
+					// Issue #196: single helper, tested separately (see MindMapHtmlWrapperTests).
+					htmlTemplate = MindMapHtmlWrapper.FormatWrapper(htmlTemplate, svgRelativePath, await svgContent());
 
 					File.WriteAllText(htmlFileName, htmlTemplate, Encoding.UTF8);
 					Logger.LogSuccess($"Html SVG MindMap wrapper {htmlFileName} successfully saved");


### PR DESCRIPTION
Closes #196

## Summary
- Extracts `MindMapHtmlWrapper.FormatWrapper` as a pure, tested helper and routes the three `*MindMapDocumentConfig` subclasses through it. Fixes a shipped regression where `Fallacy`/`Virtue` subclasses searched for a `<!-- Insert here the SVG -->` comment that no longer exists in `included.html`, leaving `[SVGCONTENT]` as a literal placeholder in the generated DOM.
- Fixes `VirtueMindMapCreatorConfig` hardcoded `Argumentation_Virtues_fr.html` filename — now uses the standard `[LANGUAGE]` token so each of the four languages ships under its own name.
- Adds two complementary test layers so the regression cannot ship silently again.

## Test layers
### Unit tests — `Argumentum.AssetConverter.Tests/MindmapGeneration/MindMapHtmlWrapperTests.cs`
7 tests exercising `FormatWrapper` against the real committed `included.html` / `external.html`:
- both placeholders are replaced
- the external template contract (no `[SVGCONTENT]`) is documented and enforced
- idempotency (second call is a no-op)
- null handling for both parameters
- `null` template throws

### Playwright integration tests — `Argumentum.AssetConverter.VisualTests/MindmapWrapperTests.cs`
9 tests that stage wrappers in a temp dir, load them via `file://` in headless Chromium, and verify the DOM:
- 4 parametrized tests (fr/en/ru/pt): embed the real committed Batik SVG via `included.html` wrapper, assert an inline `<svg>` is present under `#mindmap` with non-empty path geometry, and that no raw `[SVGCONTENT]` / `[SVGPATH]` ever reaches the DOM.
- 4 parametrized tests (fr/en/ru/pt): external variant references the SVG via `<object data="...">`, with both wrapper and SVG staged side-by-side mirroring the pipeline layout.
- 1 synthetic-SVG test for the **interactive overlay**: inlines an SVG with `class=\"node\"` markers and the `family`/`description`/`example`/`link` attributes the overlay JS expects, clicks the node, and asserts `card .famille` becomes visible and carries the injected family string (via `textContent`, not `innerText`, to bypass the CSS `text-transform: uppercase`).

The synthetic SVG is the regression harness for the interactive layer. The current committed Batik SVGs are visual-only (no `.node` markers — a tracked gap, not a regression), so a test based on them alone could never prove the click path actually works. The synthetic fixture keeps the overlay test decoupled from the SVG generator's evolution.

## Test plan
- [x] `dotnet test ... --filter MindMapHtmlWrapperTests` → 7/7 pass
- [x] `dotnet test ... --filter MindmapWrapperTests` → 9/9 pass
- [ ] Pipeline run with `Mode = Mindmapper` to regenerate the 16 wrappers under `Cards/Fallacies/Mindmaps/{lang}/` (phase 3, deferred to a follow-up PR so this one stays focused on the code + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)