### PR TITLE
fix(localization): restore multilingual Fallacies mapping + add Rules + regression tests (#216)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,18 +371,20 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 
 ## Pipeline Recovery Status (Mars 2026)
 
-### Validation Multilingue - 17 Mars 2026 ✅ COMPLETE
+### Validation Multilingue - 17 Mars 2026 (dimensions OK, contenu CASSÉ)
 
-**P1 - Pipeline multilingue validé** : 79 PDFs générés, 4209 images, dimensions correctes
+**P1 - Pipeline multilingue validé en DIMENSIONS uniquement** : 79 PDFs générés, 4209 images, dimensions correctes.
 
 | Langue | PDFs | Images | Status |
 |--------|------|--------|--------|
 | FR (Français) | 18 | 620 | ✅ Golden Master |
-| EN (English) | 22 | 1781 | ✅ Cards + FallaciesWeb |
-| RU (Русский) | 17 | 1270 | ✅ Cards + FallaciesWeb |
-| PT (Português) | 22 | 538 | ✅ Cards + FallaciesWeb |
+| EN (English) | 22 | 1781 | ⚠ Structure OK, contenu FR (voir #216) |
+| RU (Русский) | 17 | 1270 | ⚠ Structure OK, contenu FR (voir #216) |
+| PT (Português) | 22 | 538 | ⚠ Structure OK, contenu FR (voir #216) |
 
 **Issue #119 validée** : Rules cards apparaissent en premier dans tous les TarotCards multilingues.
+
+**Bug #216 découvert 2026-04-22 + corrigé 2026-04-23** : `LocalizationConfig.FrontFieldConversions` pour Fallacies référençait des noms de champs (`Titre`, `Definition`, `Exemple`, `Contre-Exemple`) qui n'existaient PAS dans les templates Mustache (qui utilisent `{{text_fr}}`, `{{desc_fr}}`, `{{example_fr}}`, `{{Famille}}`, `{{Sous-Famille}}`, `{{Soussousfamille}}`). Résultat : `template.Replace()` ne trouvait rien à remplacer → tous les PDFs EN/RU/PT contenaient du contenu français. Corrigé en restaurant le mapping Golden Master (avril 2024) + ajout de Rules (absent) + tests de régression `FallaciesLocalizationTests`. **Regénération pipeline complète requise** pour produire les PDFs réellement multilingues.
 
 ### État actuel par CardSet (FR - COMPLET)
 

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Localization/FallaciesLocalizationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Localization/FallaciesLocalizationTests.cs
@@ -1,0 +1,138 @@
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Localization
+{
+	/// <summary>
+	/// Regression tests for issue #216 — non-FR PDFs were shipping French content because
+	/// LocalizationConfig.FrontFieldConversions for Fallacies referenced field names
+	/// ("Titre", "Definition", "Exemple", "Contre-Exemple") that never existed in the
+	/// Handlebars templates. The templates use {{text_fr}}, {{desc_fr}}, {{example_fr}},
+	/// {{Famille}}, {{Sous-Famille}}, {{Soussousfamille}} — these must stay in lockstep
+	/// with the mapping source names.
+	///
+	/// The tests apply the substitution chain from CardSetLocalization.TranslateCardSetInfo
+	/// directly against real template files on disk (no mocking), for every target language.
+	/// </summary>
+	public class FallaciesLocalizationTests
+	{
+		private static readonly string RepoRoot = FindRepoRoot();
+
+		private static string FindRepoRoot()
+		{
+			var dir = new DirectoryInfo(AppContext.BaseDirectory);
+			while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Cards", "Fallacies")))
+			{
+				dir = dir.Parent;
+			}
+			return dir?.FullName ?? throw new DirectoryNotFoundException("Could not locate repository root (Cards/Fallacies not found).");
+		}
+
+		private static string ReadTemplate(string relPath)
+		{
+			var path = Path.Combine(RepoRoot, relPath);
+			return File.ReadAllText(path);
+		}
+
+		private static CardSetLocalization GetFallaciesLocalization()
+		{
+			var config = new AssetConverterConfig();
+			var loc = config.LocalizationConfig.CardSetLocalizations
+				.FirstOrDefault(l => l.CardSetNames.Contains(KnownCardSets.Fallacies));
+			loc.Should().NotBeNull("the default LocalizationConfig must carry a Fallacies mapping");
+			return loc!;
+		}
+
+		private static string ApplyFrontSubstitution(CardSetLocalization loc, string template, string destLang)
+		{
+			foreach (var fieldConversion in loc.FrontFieldConversions)
+			{
+				var sourcePattern = loc.FormatField(fieldConversion.sourceFieldName);
+				var conv = fieldConversion.fieldConversions.FirstOrDefault(c => c.Language == destLang);
+				if (string.IsNullOrEmpty(conv.destFieldName)) continue;
+				var destPattern = loc.FormatField(conv.destFieldName);
+				template = template.Replace(sourcePattern, destPattern);
+			}
+			return template;
+		}
+
+		[Theory]
+		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "en")]
+		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "ru")]
+		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "pt")]
+		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json", "en")]
+		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json", "en")]
+		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json", "pt")]
+		public void Fallacies_Templates_Translate_Away_All_French_Text_Placeholders(string templateRelPath, string destLang)
+		{
+			var original = ReadTemplate(templateRelPath);
+			var loc = GetFallaciesLocalization();
+
+			var translated = ApplyFrontSubstitution(loc, original, destLang);
+
+			var langSuffix = destLang == "en" ? "_en" : $"_{destLang}";
+
+			translated.Should().NotContain("{{text_fr}}",
+				$"text_fr placeholder must be replaced in {destLang} template (this was the #216 root cause)");
+			translated.Should().NotContain("{{desc_fr}}",
+				$"desc_fr placeholder must be replaced in {destLang} template");
+			translated.Should().Contain("text" + langSuffix,
+				$"translated template must reference text{langSuffix}");
+			translated.Should().Contain("desc" + langSuffix,
+				$"translated template must reference desc{langSuffix}");
+		}
+
+		[Theory]
+		[InlineData("en", "Family")]
+		[InlineData("ru", "Family_ru")]
+		[InlineData("pt", "Family_pt")]
+		public void Fallacies_Family_Hierarchy_Uses_CsvColumn_Casing(string destLang, string expectedFamilyColumn)
+		{
+			var original = ReadTemplate("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json");
+			var loc = GetFallaciesLocalization();
+
+			var translated = ApplyFrontSubstitution(loc, original, destLang);
+
+			translated.Should().Contain("{{" + expectedFamilyColumn + "}}",
+				$"{destLang} rendering must bind to the real CSV column '{expectedFamilyColumn}' (casing matters — CsvHelper is case-sensitive)");
+			translated.Should().NotContain("{{Famille}}",
+				$"{destLang} rendering must no longer reference the French {{{{Famille}}}} placeholder");
+		}
+
+		[Fact]
+		public void Fallacies_Front_Conversions_Are_Ordered_MostSpecificFirst_To_Avoid_Partial_Matches()
+		{
+			var loc = GetFallaciesLocalization();
+			var names = loc.FrontFieldConversions.Select(c => c.sourceFieldName).ToList();
+
+			var soussousIndex = names.IndexOf("Soussousfamille");
+			var sousIndex = names.IndexOf("Sous-Famille");
+			var familleIndex = names.IndexOf("Famille");
+
+			soussousIndex.Should().BeGreaterThanOrEqualTo(0, "Soussousfamille must be mapped");
+			sousIndex.Should().BeGreaterThanOrEqualTo(0, "Sous-Famille must be mapped");
+			familleIndex.Should().BeGreaterThanOrEqualTo(0, "Famille must be mapped");
+
+			soussousIndex.Should().BeLessThan(sousIndex,
+				"Soussousfamille must be substituted before Sous-Famille to prevent partial overlap");
+			sousIndex.Should().BeLessThan(familleIndex,
+				"Sous-Famille must be substituted before Famille to prevent partial overlap");
+		}
+
+		[Fact]
+		public void Rules_Localization_Is_Configured_For_All_Target_Languages()
+		{
+			var config = new AssetConverterConfig();
+			var loc = config.LocalizationConfig.CardSetLocalizations
+				.FirstOrDefault(l => l.CardSetNames.Contains(KnownCardSets.Rules));
+			loc.Should().NotBeNull("Rules must have a localization entry (regression from Golden Master April 2024)");
+
+			var textConv = loc!.FrontFieldConversions.FirstOrDefault(c => c.sourceFieldName == "Text");
+			textConv.fieldConversions.Should().Contain(c => c.Language == "en" && c.destFieldName == "Text_en");
+			textConv.fieldConversions.Should().Contain(c => c.Language == "ru" && c.destFieldName == "Text_ru");
+			textConv.fieldConversions.Should().Contain(c => c.Language == "pt" && c.destFieldName == "Text_pt");
+		}
+	}
+}

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -87,6 +87,10 @@ namespace Argumentum.AssetConverter
 		Enabled = true,  // Enabled for multilingual generation (FR, EN, RU, PT)
 			CardSetLocalizations = new List<CardSetLocalization>(new[]
 			{
+				// Fallacies: mappings aligned with real CSV columns and template placeholders.
+				// Templates use {{text_fr}}, {{desc_fr}}, {{example_fr}}, {{Famille}}, {{Sous-Famille}}, {{Soussousfamille}}.
+				// CSV exposes text_en/text_ru/text_pt, desc_en/desc_ru/desc_pt, example_en/example_ru/example_pt,
+				// and Family/Subfamily/Subsubfamily (+ _ru / _pt suffixes, preserving CSV casing).
 				new CardSetLocalization()
 				{
 					CardSetNames = new List<string>(new []
@@ -99,24 +103,46 @@ namespace Argumentum.AssetConverter
 						KnownCardSets.FallaciesWebThumbnails
 					}),
 					FrontFieldConversions = new List<(string sourceFieldName, List<(string Language, string destFieldName)> fieldConversions)>(new []{
-						("Titre", new List<(string Language, string destFieldName)>(new []{("en", "Title"), ("ru", "Title_ru"), ("pt", "title_pt") }) ),
-						("Famille", new List<(string Language, string destFieldName)>(new []{("en", "Family"), ("ru", "Family_ru"), ("pt", "family_pt") }) ),
-						("Sous-Famille", new List<(string Language, string destFieldName)>(new []{("en", "Subfamily"), ("ru", "Subfamily_ru"), ("pt", "subfamily_pt") }) ),
-						("soussousfamille", new List<(string Language, string destFieldName)>(new []{("en", "subsubfamily"), ("ru", "subsubfamily_ru"), ("pt", "subsubfamily_pt") }) ),
-						("Definition", new List<(string Language, string destFieldName)>(new []{("en", "Definition_en"), ("ru", "Definition_ru"), ("pt", "Definition_pt") }) ),
-						("Exemple", new List<(string Language, string destFieldName)>(new []{("en", "Example"), ("ru", "Example_ru"), ("pt", "Example_pt") }) ),
-						("Contre-Exemple", new List<(string Language, string destFieldName)>(new []{("en", "Counterexample"), ("ru", "Counterexample_ru"), ("pt", "Counterexample_pt") }) )
+						// Order: most specific first (Soussousfamille > Sous-Famille > Famille) to avoid partial-string collisions.
+						("Soussousfamille", new List<(string Language, string destFieldName)>(new []{("en", "Subsubfamily"), ("ru", "Subsubfamily_ru"), ("pt", "Subsubfamily_pt") }) ),
+						("Sous-Famille", new List<(string Language, string destFieldName)>(new []{("en", "Subfamily"), ("ru", "Subfamily_ru"), ("pt", "Subfamily_pt") }) ),
+						("Famille", new List<(string Language, string destFieldName)>(new []{("en", "Family"), ("ru", "Family_ru"), ("pt", "Family_pt") }) ),
+						("text_fr", new List<(string Language, string destFieldName)>(new []{("en", "text_en"), ("ru", "text_ru"), ("pt", "text_pt") }) ),
+						("desc_fr", new List<(string Language, string destFieldName)>(new []{("en", "desc_en"), ("ru", "desc_ru"), ("pt", "desc_pt") }) ),
+						("example_fr", new List<(string Language, string destFieldName)>(new []{("en", "example_en"), ("ru", "example_ru"), ("pt", "example_pt") }) ),
+					}),
+					BackFieldConversions = new List<(string sourceFieldName, List<(string Language, string destFieldName)> fieldConversions)>(new []{
+						("tagline_fr", new List<(string Language, string destFieldName)>(new []{("en", "tagline_en"), ("ru", "tagline_ru"), ("pt", "tagline_pt") }) ),
 					}),
 				},
 				new CardSetLocalization()
 				{
+					// Rules: template uses {{markdown Text}} and CSV exposes Text/Text_en/Text_ru/Text_pt.
+					CardSetNames = new List<string>(new []
+					{
+						KnownCardSets.Rules,
+						KnownCardSets.RulesPrintAndPlay,
+					}),
+					FrontFieldConversions = new List<(string sourceFieldName, List<(string Language, string destFieldName)> fieldConversions)>(new []{
+						("Text", new List<(string Language, string destFieldName)>(new []{("en", "Text_en"), ("ru", "Text_ru"), ("pt", "Text_pt") }) ),
+					}),
+				},
+				new CardSetLocalization()
+				{
+					// Virtues: CSV currently only has _fr columns (issue #183/#205 upgrade unblocks translation but dataset not yet regenerated).
+					// Mapping is a no-op until the CSV exposes title_en/description_en/... etc.
+					// Template placeholders use {{title_fr}}, {{description_fr}}, {{family_fr}}, {{subfamily_fr}}, {{subsubfamily_fr}}, {{remark_fr}}.
 					CardSetNames = new List<string>(new []
 					{
 						KnownCardSets.Virtues,
 					}),
 					FrontFieldConversions = new List<(string sourceFieldName, List<(string Language, string destFieldName)> fieldConversions)>(new []{
-						("Nom", new List<(string Language, string destFieldName)>(new []{("en", "Name"), ("ru", "Name_ru"), ("pt", "Name_pt") }) ),
-						("Description", new List<(string Language, string destFieldName)>(new []{("en", "Description_en"), ("ru", "Description_ru"), ("pt", "Description_pt") }) ),
+						("title_fr", new List<(string Language, string destFieldName)>(new []{("en", "title_en"), ("ru", "title_ru"), ("pt", "title_pt") }) ),
+						("description_fr", new List<(string Language, string destFieldName)>(new []{("en", "description_en"), ("ru", "description_ru"), ("pt", "description_pt") }) ),
+						("remark_fr", new List<(string Language, string destFieldName)>(new []{("en", "remark_en"), ("ru", "remark_ru"), ("pt", "remark_pt") }) ),
+						("family_fr", new List<(string Language, string destFieldName)>(new []{("en", "family_en"), ("ru", "family_ru"), ("pt", "family_pt") }) ),
+						("subfamily_fr", new List<(string Language, string destFieldName)>(new []{("en", "subfamily_en"), ("ru", "subfamily_ru"), ("pt", "subfamily_pt") }) ),
+						("subsubfamily_fr", new List<(string Language, string destFieldName)>(new []{("en", "subsubfamily_en"), ("ru", "subsubfamily_ru"), ("pt", "subsubfamily_pt") }) ),
 					}),
 				},
 				new CardSetLocalization()


### PR DESCRIPTION
## Summary

Fixes #216 — all non-FR PDFs were shipping French content because the `LocalizationConfig.FrontFieldConversions` for Fallacies referenced field names (`Titre`, `Definition`, `Exemple`, `Contre-Exemple`) that **never existed** in the Handlebars templates.

**Root cause**: templates use `{{text_fr}}`, `{{desc_fr}}`, `{{example_fr}}`, `{{Famille}}`, `{{Sous-Famille}}`, `{{Soussousfamille}}` — so `CardSetLocalization.TranslateCardSetInfo` found no match to replace, left all French placeholders intact, and every EN/RU/PT rendering fell back to the FR source.

Git archaeology confirmed the mapping had been correct at the Golden Master (commit `0087f0ec`, April 2024) and was broken by an abandoned rename refactor.

## Changes

- **AssetConverterConfig.cs** — restored the Golden Master Fallacies mapping aligned with real CSV columns:
  - `text_fr` → `text_en` / `text_ru` / `text_pt`
  - `desc_fr` → `desc_en` / `desc_ru` / `desc_pt`
  - `example_fr` → `example_en` / `example_ru` / `example_pt`
  - `Famille` → `Family` / `Family_ru` / `Family_pt` (casing preserved)
  - `Sous-Famille` → `Subfamily` / `Subfamily_ru` / `Subfamily_pt`
  - `Soussousfamille` → `Subsubfamily` / `Subsubfamily_ru` / `Subsubfamily_pt`
  - Ordering: most specific first (Soussousfamille > Sous-Famille > Famille) to prevent partial-string collisions.
- **Rules localization added** — was entirely absent from the active config but present in the Golden Master. Maps `Text` → `Text_en` / `Text_ru` / `Text_pt`.
- **Virtues localization scaffolded** — target CSV columns don't exist yet (CSV only has `_fr` columns). Mapping is a conscious no-op until #183 dataset regeneration populates them.
- **FallaciesLocalizationTests.cs** — 11 regression tests (all pass) that apply the real substitution chain against on-disk Fallacies templates and assert French placeholders are gone after each per-language translation.
- **CLAUDE.md** — corrected the 17 March 2026 validation note: the 79 PDFs passed dimension checks only; content was French across all languages until this fix.

## Test coverage

- **Before**: 77 pass / 0 fail / 1 skip
- **After**: 88 pass / 0 fail / 1 skip (+11 regression tests)
- Build: 0 errors, 53 warnings (baseline unchanged)

The new tests lock in the substitution contract so the bug cannot silently return.

## Follow-up required

Pipeline regeneration (`dotnet run` on AssetConverter) is required before the non-FR PDFs in `Target/{en,ru,pt}/` reflect actual translations. This PR ships the config + regression fix only; the binary artefacts will be regenerated in a subsequent run.

## Test plan

- [x] Build clean (0 errors)
- [x] Full test suite 88/89 pass (1 pre-existing Freeplane skip)
- [x] New `FallaciesLocalizationTests` 11/11 pass (asserts no `{{text_fr}}` / `{{desc_fr}}` remain in translated templates)
- [x] Substitution ordering protects against partial-string collisions (Soussousfamille must be replaced before Sous-Famille, etc.)
- [ ] Pipeline regeneration + visual confirmation of EN/RU/PT content (separate run, user-triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)