### PR TITLE
chore(dataset-updater): migrate to GPT-5.x models

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
@@ -29,7 +29,7 @@ public class DatasetUpdaterConfig
 
 	public string OpenAIKeyPath { get; set; } = @"G:\Mon Drive\MyIA\Argumentum\Fallacies\Gestion\OpenAI-Key.txt";
 
-	public string Model { get; set; } = "gpt-4.1";
+	public string Model { get; set; } = "gpt-5.4-mini";
 
 	public int MaxTokensPerMinute { get; set; } = 70000;
 

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -57,7 +57,8 @@ public class DatasetUpdaterRootConfig
                     AssistantAnswerPath = PromptsRootPath + "VirtuesJsonPromptSampleAssistant.json"
                 }
             },
-            Model = "gpt-4.1-mini",
+            // Taxonomy creation/refinement — quality tier. Fallback: gpt-4.1-mini
+            Model = "gpt-5.4",
             MaxTokensPerMinute = 70000,
             DivisionMode = DivisionMode.SequentialChunks,
             ChunkSize = 3,
@@ -112,7 +113,8 @@ public class DatasetUpdaterRootConfig
                     AssistantAnswerPath = PromptsRootPath + "PromptInstructionsAssistantDescription.txt"
                 }
             },
-            Model = "gpt-4.1",
+            // desc_fr refinement — quality tier for nuanced taxonomic descriptions. Fallback: gpt-4.1
+            Model = "gpt-5.4",
             MaxTokensPerMinute = 70000,
             DivisionMode = DivisionMode.PKHierarchicalChar,
             PKHierarchyLevel = 3,
@@ -176,7 +178,8 @@ public class DatasetUpdaterRootConfig
                     AssistantAnswerPath = PromptsRootPath + "PromptInstructionsLightAssistantExamples.txt"
                 }
             },
-            Model = "gpt-4.1",
+            // example_fr creative generation — quality tier. Fallback: gpt-4.1
+            Model = "gpt-5.4",
             MaxTokensPerMinute = 70000,
             DivisionMode = DivisionMode.PKHierarchicalChar,
             PKHierarchyLevel = 3,
@@ -239,7 +242,8 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptTranslateFrEnInstructionsAssistant.txt"
 				}
 			},
-			Model = "gpt-4.1",
+			// FR → EN translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.PKHierarchicalChar,
 			PKHierarchyLevel = 3,
@@ -301,7 +305,8 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptTranslateRuInstructionsAssistant.txt"
 				}
 			},
-			Model = "gpt-4.1",
+			// FR → RU translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			PKHierarchyLevel = 3,
@@ -364,7 +369,8 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptTranslatePtInstructionsAssistant.txt"
 				}
 			},
-			Model = "gpt-4.1",
+			// FR → PT translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			PKHierarchyLevel = 3,
@@ -436,7 +442,8 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptTranslateCleanupInstructionsAssistant.txt"
 				}
 			},
-			Model = "gpt-4.1",
+			// Multi-lang cleanup review — quality tier for nuanced comparisons. Fallback: gpt-4.1
+			Model = "gpt-5.4",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			PKHierarchyLevel = 3,


### PR DESCRIPTION
## Summary
- Migrate 7 DatasetUpdater task configs + default model from `gpt-4.1`/`gpt-4.1-mini` → GPT-5.x family
- Tiered by task nature: empty-only translation uses `gpt-5.4-mini`, taxonomy/description refinement + multi-lang cleanup uses `gpt-5.4`
- Inline fallback comments preserve path to `gpt-4.1` series for quick rollback

## Context
po-2023 updated `OpenAI-Key.txt` (hors-repo) with a new project key that grants access to GPT-5.x models (`gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.3`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, `o3`, `o3-pro`, `o4-mini`). This PR unblocks downstream translation work that was waiting on SOTA models.

## Tier mapping
| Task type | Model | Rationale |
|-----------|-------|-----------|
| FR→EN / FR→RU / FR→PT empty-only translation | `gpt-5.4-mini` | Eco, fast, sufficient quality for faithful translation of short content |
| Virtues taxonomy refinement | `gpt-5.4` | Taxonomy creation needs quality — long-term schema |
| Fallacies `desc_fr` simplification | `gpt-5.4` | Nuanced taxonomic descriptions |
| Fallacies `example_fr` creative generation | `gpt-5.4` | Creative writing + hierarchy fidelity |
| Multi-lang cleanup review | `gpt-5.4` | Nuanced cross-lang comparisons |
| Default (`DatasetUpdaterConfig.Model`) | `gpt-5.4-mini` | Safe default for ad-hoc configs |

## Safety
- `DatasetUpdater` is **not** in default `AssetConverterConfig.Mode` — opt-in only
- All 7 task entries remain `Enabled=false` except the Cleanup entry (pre-existing state, untouched)
- Fallback models are documented as comments above each `Model =` line

## Unblocks
- #211 — PT Rules retranslation
- #218 — Virtues i18n population
- #219 — Scenarii EN/RU/PT completion
- #183 follow-up — SOTA models now in use

## Test plan
- [x] Build passes (0 errors, 17 preexisting warnings)
- [ ] Runtime validation: po-2023 will test with PT Rules (#211) on small volume first
- [ ] If `gpt-5.4-mini` unavailable (rate-limit/access), revert to `gpt-4.1-mini` per inline comments

Related: #183, #205, #210 (SDK upgrade), #211, #218, #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)