### PR TITLE
fix(visual-tests): restore FallacyCardTests fixture + net9.0-windows path (#220)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,8 @@ test_output.txt
 AssetConverterConfig.json
 AssetConverterConfig.*.json
 !AssetConverterConfig.cs
+# Exception: VisualTests fixture must be committed (referenced by FallacyCardTests)
+!Generation/Converters/Argumentum.AssetConverter.VisualTests/TestData/**/AssetConverterConfig.test.json
 
 # Logs d'erreur temporaires
 *.log.err

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfContentTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfContentTests.cs
@@ -22,7 +22,7 @@ namespace Argumentum.AssetConverter.VisualTests
         private readonly ITestOutputHelper _output;
         private static readonly string TargetRoot = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..",
-            "Generation", "Converters", "Argumentum.AssetConverter", "bin", "Debug", "net9.0", "Target"));
+            "Generation", "Converters", "Argumentum.AssetConverter", "bin", "Debug", "net9.0-windows", "Target"));
 
         private static readonly string[] Languages = { "fr", "en", "ru", "pt" };
 

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfDimensionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfDimensionTests.cs
@@ -18,11 +18,9 @@ namespace Argumentum.AssetConverter.VisualTests
         private readonly ITestOutputHelper _output;
         private static readonly string TargetRoot = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..",
-            "Generation", "Converters", "Argumentum.AssetConverter", "bin", "Debug", "net9.0", "Target"));
+            "Generation", "Converters", "Argumentum.AssetConverter", "bin", "Debug", "net9.0-windows", "Target"));
 
         private static readonly string[] Languages = { "fr", "en", "ru", "pt" };
-
-        private static readonly HashSet<string> _skipIfMissing = new();
 
         public PdfDimensionTests(ITestOutputHelper output)
         {

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/TestData/FallacyCard/Render_Nominal/AssetConverterConfig.test.json
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/TestData/FallacyCard/Render_Nominal/AssetConverterConfig.test.json
@@ -1,0 +1,75 @@
+{
+  "Mode": "WebBasedImageGeneration",
+  "BaseTargetDirectoryName": "TestData/FallacyCard/Render_Nominal/Output/",
+  "LocalizationConfig": {
+    "Enabled": false,
+    "DefaultLanguage": "fr"
+  },
+  "WebBasedGeneratorConfig": {
+    "EnableParallelism": false,
+    "EnableSVGPrompt": false,
+    "ShowInfoLogs": true,
+    "HeadLessBrowser": true,
+    "OverwriteExistingDocs": true,
+    "OverwriteExistingHtmlMaps": true,
+    "MaxDegreeOfParallelismCardpen": 1,
+    "MaxDegreeOfParallelismCardpenTranslations": 1,
+    "MaxDegreeOfParallelismImages": 1,
+    "MaxDegreeOfParallelismImageTranslations": 1,
+    "MaxDegreeOfParallelismDocuments": 1,
+    "MaxDegreeOfParallelismMindMaps": 1,
+    "BaseTargetDirectoryName": "TestData/FallacyCard/Render_Nominal/Output/",
+    "HarvestDirectoryName": "TestData/FallacyCard/Render_Nominal/Output/Harvest/",
+    "ImagesDirectoryName": "TestData/FallacyCard/Render_Nominal/Output/Images/",
+    "DocumentsDirectoryName": "TestData/FallacyCard/Render_Nominal/Output/Documents/",
+    "UseLocalCardpen": false,
+    "ReleaseCardpenUrl": "https://argumentumgames.github.io/Argumentum/Generation/CardPen/index.html",
+    "LocalCardpenUrl": "https://argumentum.myia.io/index.html",
+    "DebugCardpenUrl": "https://argumentumgames.github.io/Argumentum/Generation/CardPen/index.html",
+    "CardpenUrl": "https://argumentumgames.github.io/Argumentum/Generation/CardPen/index.html",
+    "CardSets": [
+      {
+        "Name": "FallacyTestSet",
+        "FaceCardSetInfo": {
+          "DataSet": "FallacyTestData",
+          "JsonFilePathRelease": "TestData/FallacyCard/Render_Nominal/template.json",
+          "JsonFilePathDebug": "TestData/FallacyCard/Render_Nominal/template.json",
+          "Dpi": 300,
+          "CardSize": "poker",
+          "RowsetNb": 1,
+          "SkipDataUpdate": false
+        },
+        "BackCardSetInfo": {
+          "SkipDataUpdate": true
+        }
+      }
+    ],
+    "CardSetDocuments": [
+      {
+        "DocumentName": "FallacyTestDoc",
+        "Enabled": true,
+        "DocumentFormat": "FacesOnly",
+        "PageSize": "A4",
+        "Padding": 10,
+        "Header": "",
+        "Footer": "",
+        "CardSets": [
+          {
+            "CardSetName": "FallacyTestSet",
+            "NbCopies": 1
+          }
+        ],
+        "Translations": [],
+        "DataSet": "FallacyTestData"
+      }
+    ],
+    "DataSets": [
+      {
+        "Name": "FallacyTestData",
+        "CsvType": "Argumentum.AssetConverter.Entities.TestFallacyCard",
+        "CsvPath": "TestData/FallacyCard/Render_Nominal/test-data.csv",
+        "UseDebugParams": false
+      }
+    ]
+  }
+}

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/TestData/FallacyCard/Render_Nominal/test-data.csv
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/TestData/FallacyCard/Render_Nominal/test-data.csv
@@ -1,2 +1,2 @@
 Id,Title,Type,IllustrationPath,Description
-test01,"Ad Hominem","Fallacy","path/to/image.png","Attacking the person instead of the argument."
+test01,"Chewbacca Defense","Fallacy","path/to/image.png","An irrelevant argument used to confuse the opponent or audience."


### PR DESCRIPTION
## Summary

Closes #220. Fixes three distinct bugs that accumulated in `Argumentum.AssetConverter.VisualTests`:

1. **`FallacyCardTests.Render_NominalCard`** has been broken since Dec 2025 — commit `bc02db50` ("cleanup test and backup configuration files") deleted `AssetConverterConfig.test.json`, and the file was matched by `.gitignore`'s broad `AssetConverterConfig.*.json` pattern so nobody could add it back without a negate rule.
2. **Every test in `PdfContentTests.cs` + `PdfDimensionTests.cs`** was silently passing regardless of state — they pointed at `bin/Debug/net9.0/Target/` which never exists (the project targets `net9.0-windows`). Same bug I fixed in PR #221 for the vision validator; this is the sibling occurrence.
3. **Dead code** `static readonly HashSet<string> _skipIfMissing` in `PdfDimensionTests.cs:22` — flagged during PR #215 review, never removed.

## Changes

| File | Change |
|------|--------|
| `.gitignore` | Add negate rule `!Generation/Converters/Argumentum.AssetConverter.VisualTests/TestData/**/AssetConverterConfig.test.json` to exempt the test fixture from the broad auto-generated-config pattern |
| `TestData/FallacyCard/Render_Nominal/AssetConverterConfig.test.json` | Restored from `78eaa902`. Updated `CardpenUrl` / `ReleaseCardpenUrl` to the public GitHub Pages URL (`https://argumentumgames.github.io/Argumentum/Generation/CardPen/index.html`) so the test doesn't depend on machine-specific IIS setup |
| `TestData/FallacyCard/Render_Nominal/test-data.csv` | Card title `"Ad Hominem"` → `"Chewbacca Defense"` to match the expected image filename `chewbacca-defense_face.png` hardcoded in the test (the original mismatch existed at test creation in `29f7189c` and prevented the test from ever passing) |
| `PdfContentTests.cs` | `net9.0` → `net9.0-windows` in `TargetRoot` path |
| `PdfDimensionTests.cs` | Same path fix + remove dead `_skipIfMissing` field |

## Environmental dependencies (not addressed here)

`FallacyCardTests` drives a real browser against a real CardPen instance — it needs Playwright browsers installed locally and internet access to GitHub Pages. These are pre-existing requirements; this PR only unblocks the test from even starting. Machines without Playwright (po-2023 per dashboard) still can't run it — that's orthogonal infrastructure.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test AssetConverter.Tests.csproj` — 88 pass / 0 fail / 1 skip (unaffected regression suite)
- [ ] `dotnet test AssetConverter.VisualTests.csproj --filter FallacyCardTests` — running at PR open time, will post result as comment
- [ ] After next full-pipeline regeneration: `dotnet test AssetConverter.VisualTests.csproj` should now actually exercise `Target/` PDFs instead of silently skipping

Refs #220, #212, #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)