### PR TITLE
chore(validation): make SK_AGENT_CONFIG path portable via env var

### DIFF
--- a/Validation/pdf_vision_validator.py
+++ b/Validation/pdf_vision_validator.py
@@ -48,9 +48,13 @@ DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 DEFAULT_MODEL = "glm-4.6v"
 DEFAULT_API_KEY_ENV = "ZAI_API_KEY"
 
-# Fallback: read from sk-agent config if env var not set
+# Fallback: read from sk-agent config if env var not set.
+# Set SK_AGENT_CONFIG_PATH env var to override (required on machines
+# where roo-extensions is not a sibling of Argumentum).
 SK_AGENT_CONFIG = (
-    Path(__file__).resolve().parent.parent.parent.parent
+    Path(os.environ["SK_AGENT_CONFIG_PATH"])
+    if os.environ.get("SK_AGENT_CONFIG_PATH")
+    else Path(__file__).resolve().parent.parent.parent.parent
     / "roo-extensions/mcps/internal/servers/sk-agent/sk_agent_config.json"
 )
 


### PR DESCRIPTION
## Summary

Ports the SK_AGENT_CONFIG portability fix from po-2023's branch `feat/issue-212-vision-validator` (commit b25eefc0) onto master. The original PR #221 merged before this follow-up landed.

## Change

`Validation/pdf_vision_validator.py` — `SK_AGENT_CONFIG` now honors the `SK_AGENT_CONFIG_PATH` env var, falling back to the previous hardcoded `roo-extensions`-as-sibling path if the var is unset.

## Why

The previous hardcoded path (`parent.parent.parent.parent / "roo-extensions/mcps/..."`) assumes roo-extensions is a sibling of the Argumentum repo. True on po-2023's layout; not portable elsewhere. On ai-01 that tree does not exist in that position, and there was no way to point the validator at a different location without editing source.

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` — syntax clean
- [ ] Runtime validation: invoke `pdf_vision_validator.py` with `SK_AGENT_CONFIG_PATH` unset (fallback path) and with it set to a custom location — either should resolve

## Related

- PR #221 — base vision validator (merged as 8927abc6)
- po-2023's review feedback on #221 prompted this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)