### PR TITLE
fix(virtues): extend i18n scaffold to Virtue entity (follow-up to #223)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Virtue.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Virtue.cs
@@ -34,6 +34,30 @@ namespace Argumentum.AssetConverter.Entities
         public string Card { get; set; }
         public string Update { get; set; }
         public string Locked { get; set; }
+
+        public string FamilyEn { get; set; }
+        public string SubfamilyEn { get; set; }
+        public string SubsubfamilyEn { get; set; }
+        public string TitleEn { get; set; }
+        public string DescriptionEn { get; set; }
+        public string RemarkEn { get; set; }
+        public string LinkEn { get; set; }
+
+        public string FamilyRu { get; set; }
+        public string SubfamilyRu { get; set; }
+        public string SubsubfamilyRu { get; set; }
+        public string TitleRu { get; set; }
+        public string DescriptionRu { get; set; }
+        public string RemarkRu { get; set; }
+        public string LinkRu { get; set; }
+
+        public string FamilyPt { get; set; }
+        public string SubfamilyPt { get; set; }
+        public string SubsubfamilyPt { get; set; }
+        public string TitlePt { get; set; }
+        public string DescriptionPt { get; set; }
+        public string RemarkPt { get; set; }
+        public string LinkPt { get; set; }
     }
 
     public sealed class VirtueClassMap : ClassMap<Virtue>
@@ -58,6 +82,30 @@ namespace Argumentum.AssetConverter.Entities
             Map(m => m.Card).Name("card");
             Map(m => m.Update).Name("update");
             Map(m => m.Locked).Name("locked");
+
+            Map(m => m.FamilyEn).Name("family_en").Optional();
+            Map(m => m.SubfamilyEn).Name("subfamily_en").Optional();
+            Map(m => m.SubsubfamilyEn).Name("subsubfamily_en").Optional();
+            Map(m => m.TitleEn).Name("title_en").Optional();
+            Map(m => m.DescriptionEn).Name("description_en").Optional();
+            Map(m => m.RemarkEn).Name("remark_en").Optional();
+            Map(m => m.LinkEn).Name("link_en").Optional();
+
+            Map(m => m.FamilyRu).Name("family_ru").Optional();
+            Map(m => m.SubfamilyRu).Name("subfamily_ru").Optional();
+            Map(m => m.SubsubfamilyRu).Name("subsubfamily_ru").Optional();
+            Map(m => m.TitleRu).Name("title_ru").Optional();
+            Map(m => m.DescriptionRu).Name("description_ru").Optional();
+            Map(m => m.RemarkRu).Name("remark_ru").Optional();
+            Map(m => m.LinkRu).Name("link_ru").Optional();
+
+            Map(m => m.FamilyPt).Name("family_pt").Optional();
+            Map(m => m.SubfamilyPt).Name("subfamily_pt").Optional();
+            Map(m => m.SubsubfamilyPt).Name("subsubfamily_pt").Optional();
+            Map(m => m.TitlePt).Name("title_pt").Optional();
+            Map(m => m.DescriptionPt).Name("description_pt").Optional();
+            Map(m => m.RemarkPt).Name("remark_pt").Optional();
+            Map(m => m.LinkPt).Name("link_pt").Optional();
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fix for PR #223 (#218). The merged PR added `_en`/`_ru`/`_pt` columns to the Virtues CSV and scaffolded the `ArgumentVirtue` entity — but **`ArgumentVirtue` is dead code**. The pipeline actually loads Virtues via `CsvType = typeof(Virtue)` in [AssetConverterConfig.cs:79](Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs#L79), mapped by `VirtueClassMap`.

Without this fix, the 21 new CSV columns are silently ignored at runtime.

## What changed

- Added 21 string properties (`FamilyEn`, `SubfamilyEn`, …, `LinkPt`) to `Virtue.cs`
- Added matching 21 `.Optional()` ClassMap entries in `VirtueClassMap`

Symmetric with the scaffold already in `ArgumentVirtue.cs` (kept for reverse-mapping via `MappingProfile.cs`, cheap to maintain).

## Why this got missed in PR #223

Two `Virtue` entity classes exist:
- `ArgumentVirtue` — referenced only by `MappingProfile.CreateMap<ArgumentVirtue, Fallacy>()`, which is **never invoked** (`.Map()` call absent)
- `Virtue` — the one actually used by the pipeline

A post-merge blind-spot audit traced `CsvType` references and caught this.

## Test plan

- [x] `dotnet build` passes (0 errors, 17 pre-existing warnings)
- [ ] Pipeline run with Virtues CardSet enabled loads non-null values for `TitleEn`/`TitleRu`/`TitlePt` when CSV columns are populated
- [ ] Future i18n migration (issue #218 follow-up) can now populate Virtue translations without additional entity work

🤖 Generated with [Claude Code](https://claude.com/claude-code)