### PR TITLE
feat(dataset-updater): Virtues FR→EN/RU/PT translation configs (#218 phase 2)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -464,6 +464,198 @@ public class DatasetUpdaterRootConfig
 			WriteOneTargetFileByField = true,
 			MaxChildren = 8,
 			NbGlobalPasses = 2
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Virtues to English by chunk empty-only 0-shot",
+			SourceDataset = KnownDataSets.VirtuesTaxonomy,
+			FieldsToInclude = new List<string>()
+			{
+				"path",
+				"family_fr",
+				"subfamily_fr",
+				"subsubfamily_fr",
+				"title_fr",
+				"description_fr",
+				"remark_fr",
+				"link_fr",
+				"family_en",
+				"subfamily_en",
+				"subsubfamily_en",
+				"title_en",
+				"description_en",
+				"remark_en",
+				"link_en"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"family_en",
+				"subfamily_en",
+				"subsubfamily_en",
+				"title_en",
+				"description_en",
+				"remark_en",
+				"link_en"
+			},
+			PrimaryField = "path",
+			TargetPath = @".\Target\Datasets\Argumentum Virtues - Taxonomy.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptVirtuesTranslateEnUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptVirtuesTranslateEnAssistant.txt"
+				}
+			},
+			// FR → EN translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 8,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = true,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 4,
+			CompareMode = false,
+			AutoCompare = true,
+			AutoCompareField = "title_fr",
+			CompareField = "title_en",
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = true,
+			MaxChildren = 8
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Virtues to Russian by chunk empty-only 0-shot",
+			SourceDataset = KnownDataSets.VirtuesTaxonomy,
+			FieldsToInclude = new List<string>()
+			{
+				"path",
+				"family_fr",
+				"subfamily_fr",
+				"subsubfamily_fr",
+				"title_fr",
+				"description_fr",
+				"remark_fr",
+				"link_fr",
+				"family_ru",
+				"subfamily_ru",
+				"subsubfamily_ru",
+				"title_ru",
+				"description_ru",
+				"remark_ru",
+				"link_ru"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"family_ru",
+				"subfamily_ru",
+				"subsubfamily_ru",
+				"title_ru",
+				"description_ru",
+				"remark_ru",
+				"link_ru"
+			},
+			PrimaryField = "path",
+			TargetPath = @".\Target\Datasets\Argumentum Virtues - Taxonomy.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptVirtuesTranslateRuUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptVirtuesTranslateRuAssistant.txt"
+				}
+			},
+			// FR → RU translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 8,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = true,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 4,
+			CompareMode = false,
+			AutoCompare = true,
+			AutoCompareField = "title_fr",
+			CompareField = "title_ru",
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = true,
+			MaxChildren = 8
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Virtues to Portuguese by chunk empty-only 0-shot",
+			SourceDataset = KnownDataSets.VirtuesTaxonomy,
+			FieldsToInclude = new List<string>()
+			{
+				"path",
+				"family_fr",
+				"subfamily_fr",
+				"subsubfamily_fr",
+				"title_fr",
+				"description_fr",
+				"remark_fr",
+				"link_fr",
+				"family_pt",
+				"subfamily_pt",
+				"subsubfamily_pt",
+				"title_pt",
+				"description_pt",
+				"remark_pt",
+				"link_pt"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"family_pt",
+				"subfamily_pt",
+				"subsubfamily_pt",
+				"title_pt",
+				"description_pt",
+				"remark_pt",
+				"link_pt"
+			},
+			PrimaryField = "path",
+			TargetPath = @".\Target\Datasets\Argumentum Virtues - Taxonomy.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptVirtuesTranslatePtUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptVirtuesTranslatePtAssistant.txt"
+				}
+			},
+			// FR → PT translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 8,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = true,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 4,
+			CompareMode = false,
+			AutoCompare = true,
+			AutoCompareField = "title_fr",
+			CompareField = "title_pt",
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = true,
+			MaxChildren = 8
 		}
 
 	};

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateEnAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateEnAssistant.txt
@@ -1,0 +1,6 @@
+Instructions bien reçues. Je vais traduire la taxonomie des vertus argumentatives vers l'anglais en respectant :
+- La cohérence des noms de familles entre entrées
+- Le passage du style "vous" (FR) au style impératif/infinitif (EN)
+- Les traductions canoniques des concepts logiques
+- Les équivalents Wikipedia anglophones pour les liens
+Je n'utiliserai que des appels à la fonction `UpdateRecord` pour chaque entrée à compléter, sans texte libre. Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateEnUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateEnUser.txt
@@ -1,0 +1,22 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble d'entrées de la taxonomie des vertus argumentatives du jeu Argumentum. Chaque entrée comporte plusieurs champs :
+- `path` : identifiant hiérarchique (ex. "1.2.3")
+- `family_fr`, `subfamily_fr`, `subsubfamily_fr` : position taxonomique en français
+- `title_fr`, `description_fr`, `remark_fr` : contenu éditorial en français
+- `link_fr` : lien de référence (souvent Wikipedia FR)
+- Les champs cibles : `family_en`, `subfamily_en`, `subsubfamily_en`, `title_en`, `description_en`, `remark_en`, `link_en`
+
+Ta tâche consiste à traduire en **anglais** les champs source (suffixe `_fr`) vers les champs cible (suffixe `_en`), uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Cohérence taxonomique :** Les noms de familles doivent rester cohérents entre entrées — si "argumentPertinent" a été traduit "relevantArgument" dans une entrée, réutilise cette traduction pour toutes les entrées de cette famille.
+
+3. **Format des descriptions :** En français, les descriptions de vertus sont formulées à la deuxième personne du pluriel ("Vous..."). En anglais, utilise la forme impérative ou à l'infinitif ("To..." ou verbe d'action).
+
+4. **Noms propres du jeu :** "Argumentum" reste "Argumentum". Les concepts logiques classiques ont des traductions canoniques (ex. "raisonnement valide" → "valid reasoning", "honnêteté intellectuelle" → "intellectual honesty").
+
+5. **Liens :** Si le `link_fr` pointe vers une page Wikipedia française, cherche l'équivalent anglais si possible (en.wikipedia.org/...). Sinon, laisse `link_en` vide.
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslatePtAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslatePtAssistant.txt
@@ -1,0 +1,7 @@
+Instructions bien reçues. Je vais traduire la taxonomie des vertus argumentatives vers le portugais européen (pt-PT) en respectant :
+- La variante pt-PT (pas brésilienne)
+- La cohérence des noms de familles entre entrées
+- Le passage du "vous" (FR) à la deuxième personne de politesse ou impératif pt-PT
+- Les traductions canoniques des concepts logiques
+- Les équivalents Wikipedia portugais pour les liens
+Je n'utiliserai que des appels à la fonction `UpdateRecord` pour chaque entrée à compléter, sans texte libre. Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslatePtUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslatePtUser.txt
@@ -1,0 +1,24 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble d'entrées de la taxonomie des vertus argumentatives du jeu Argumentum. Chaque entrée comporte plusieurs champs :
+- `path` : identifiant hiérarchique (ex. "1.2.3")
+- `family_fr`, `subfamily_fr`, `subsubfamily_fr` : position taxonomique en français
+- `title_fr`, `description_fr`, `remark_fr` : contenu éditorial en français
+- `link_fr` : lien de référence (souvent Wikipedia FR)
+- Les champs cibles : `family_pt`, `subfamily_pt`, `subsubfamily_pt`, `title_pt`, `description_pt`, `remark_pt`, `link_pt`
+
+Ta tâche consiste à traduire en **portugais européen (pt-PT)** les champs source (suffixe `_fr`) vers les champs cible (suffixe `_pt`), uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Cohérence taxonomique :** Les noms de familles doivent rester cohérents entre entrées — si "argumentPertinent" a été traduit "argumentoPertinente" dans une entrée, réutilise cette traduction pour toutes les entrées de cette famille.
+
+3. **Format des descriptions :** En français, les descriptions de vertus sont formulées à la deuxième personne du pluriel ("Vous..."). En portugais européen, utilise la deuxième personne de politesse ("Deve..." ou impératif), PAS la forme brésilienne ("Você deve...").
+
+4. **Langue cible :** Portugais européen (pt-PT), **pas** brésilien. Utilise le vocabulaire et les tournures idiomatiques du Portugal.
+
+5. **Noms propres du jeu :** "Argumentum" reste "Argumentum". Les concepts logiques classiques ont des traductions canoniques en portugais.
+
+6. **Liens :** Si le `link_fr` pointe vers une page Wikipedia française, cherche l'équivalent portugais si possible (pt.wikipedia.org/...). Sinon, laisse `link_pt` vide.
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateRuAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateRuAssistant.txt
@@ -1,0 +1,6 @@
+Instructions bien reçues. Je vais traduire la taxonomie des vertus argumentatives vers le russe en respectant :
+- La cohérence des noms de familles entre entrées
+- Le vocabulaire soutenu et philosophique (style non familier)
+- Le passage du style "vous" (FR) à l'impératif ou infinitif russe selon le contexte
+- Les équivalents Wikipedia russophones pour les liens
+Je n'utiliserai que des appels à la fonction `UpdateRecord` pour chaque entrée à compléter, sans texte libre. Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateRuUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesTranslateRuUser.txt
@@ -1,0 +1,22 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble d'entrées de la taxonomie des vertus argumentatives du jeu Argumentum. Chaque entrée comporte plusieurs champs :
+- `path` : identifiant hiérarchique (ex. "1.2.3")
+- `family_fr`, `subfamily_fr`, `subsubfamily_fr` : position taxonomique en français
+- `title_fr`, `description_fr`, `remark_fr` : contenu éditorial en français
+- `link_fr` : lien de référence (souvent Wikipedia FR)
+- Les champs cibles : `family_ru`, `subfamily_ru`, `subsubfamily_ru`, `title_ru`, `description_ru`, `remark_ru`, `link_ru`
+
+Ta tâche consiste à traduire en **russe** les champs source (suffixe `_fr`) vers les champs cible (suffixe `_ru`), uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Cohérence taxonomique :** Les noms de familles doivent rester cohérents entre entrées. Utilise un vocabulaire russe soutenu et philosophique (pas familier).
+
+3. **Format des descriptions :** En français, les descriptions de vertus sont formulées à la deuxième personne du pluriel ("Vous..."). En russe, utilise la forme impérative (повелительное наклонение) ou infinitif selon le contexte.
+
+4. **Noms propres du jeu :** "Argumentum" reste "Argumentum" (ou en translitération cyrillique si le contexte l'exige : "Аргументум").
+
+5. **Liens :** Si le `link_fr` pointe vers une page Wikipedia française, cherche l'équivalent russe si possible (ru.wikipedia.org/...). Sinon, laisse `link_ru` vide.
+
+Es-tu prêt à recevoir les données ?


### PR DESCRIPTION
## Summary

Completes phase 2 of #218. With the CSV i18n columns (PR #223) and Virtue entity scaffold (PR #229) now on master, this PR wires the DatasetUpdater to populate Virtues translations via OpenAI.

## What's added

### 3 new configs in \`DatasetUpdaterRootConfig.cs\` (Enabled=false each)

| Name | Target fields | Model |
|------|---------------|-------|
| Translate Virtues to English by chunk empty-only 0-shot | \`family_en\`, \`subfamily_en\`, \`subsubfamily_en\`, \`title_en\`, \`description_en\`, \`remark_en\`, \`link_en\` | gpt-5.4-mini |
| Translate Virtues to Russian by chunk empty-only 0-shot | \`*_ru\` | gpt-5.4-mini |
| Translate Virtues to Portuguese by chunk empty-only 0-shot | \`*_pt\` (pt-PT) | gpt-5.4-mini |

### 6 new prompt files in \`DatasetUpdater/Resources/\`

\`PromptVirtuesTranslate{En,Ru,Pt}{User,Assistant}.txt\` — each enforces:
- Taxonomy coherence across entries (same family name translated consistently)
- FR "vous" register → target-language equivalent (infinitive EN, impératif/infinitif RU, 2nd person formal pt-PT)
- Canonical logic terminology
- Wikipedia link localization when an equivalent page exists

## Design rationale

- \`SelectEmptyTargets=true\` — re-runs only fill gaps, so iterative passes are cheap
- \`ChunkSize=8\`, \`MaxGroupItemNb=12\` — small batches because translation quality degrades on niche logic terms with large batches
- Eco tier (\`gpt-5.4-mini\`) matching Fallacies translation configs that are already production-proven
- pt-PT explicit (not pt-BR), consistent with Rules PT retranslation (#211)

## Test plan

- [x] \`dotnet build\` succeeds (0 errors)
- [x] 88 tests pass
- [ ] End-to-end: set \`Enabled=true\` on Virtues EN config, run pipeline with OpenAI key on a 3-5 row subset, verify output quality and column population (same acceptance gate as the #183 DatasetUpdater SDK upgrade)

## Follow-ups not in this PR

- CSV data population: requires someone to run the configs with \`Enabled=true\` and an OpenAI key (local-only, costs money — intentionally gated)
- pt-PT quality post-run: could reuse the #202 micro-fix workflow for rare idiomatic corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)