### PR TITLE
feat(dataset-updater): Scenarii FR→EN/RU/PT translation configs (#219)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -657,49 +657,251 @@ public class DatasetUpdaterRootConfig
 			WriteOneTargetFileByField = true,
 			MaxChildren = 8
 		},
-			new DatasetUpdaterConfig()
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Rules to Portuguese by chunk 0-shot",
+			SourceDataset = KnownDataSets.Rules,
+			FieldsToInclude = new List<string>()
 			{
-				Enabled = false,
-				Name = "Translate Rules to Portuguese by chunk 0-shot",
-				SourceDataset = KnownDataSets.Rules,
-				FieldsToInclude = new List<string>()
+				"pk",
+				"Text",
+				"Text_pt"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"Text_pt"
+			},
+			PrimaryField = "pk",
+			TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
 				{
-					"pk",
-					"Text",
-					"Text_pt"
-				},
-				FieldsToUpdate = new List<string>()
+					UserPromptPath = PromptsRootPath + "PromptRulesTranslatePtUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslatePtAssistant.txt"
+				}
+			},
+			Model = "gpt-5.4-mini", // Fallback: gpt-4.1-mini
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 3,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = false,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 3,
+			CompareMode = false,
+			AutoCompare = false,
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = false,
+			MaxChildren = 8
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Scenarii to English by chunk empty-only 0-shot",
+			SourceDataset = KnownDataSets.Scenarii,
+			FieldsToInclude = new List<string>()
+			{
+				"path",
+				"catégorie",
+				"sous-catégorie",
+				"titre",
+				"baratineur",
+				"piocheur",
+				"contexte",
+				"enjeu",
+				"suggestion",
+				"category",
+				"subcategory",
+				"title",
+				"smoothTalker",
+				"drawer",
+				"context",
+				"issue",
+				"suggestion_en"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"category",
+				"subcategory",
+				"title",
+				"smoothTalker",
+				"drawer",
+				"context",
+				"issue",
+				"suggestion_en"
+			},
+			PrimaryField = "path",
+			TargetPath = @".\Target\Datasets\Argumentum Scenarii - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
 				{
-					"Text_pt"
-				},
-				PrimaryField = "pk",
-				TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
-				SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
-				DialogPrompts = new List<PromptExample>()
-				{
-					new PromptExample()
-					{
-						UserPromptPath = PromptsRootPath + "PromptRulesTranslatePtUser.txt",
-						AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslatePtAssistant.txt"
-					}
-				},
-				Model = "gpt-5.4-mini", // Fallback: gpt-4.1-mini
-				MaxTokensPerMinute = 70000,
-				DivisionMode = DivisionMode.SequentialChunks,
-				ChunkSize = 3,
-				UseFunctionCalling = true,
-				NbMessageCalls = 1,
-				SkipChunkNb = 0,
-				TakeChunkNb = -1,
-				SelectEmptyTargets = false,
-				RandomizeChunks = false,
-				MaxDegreeOfParallelismWebService = 3,
-				CompareMode = false,
-				AutoCompare = false,
-				MaxGroupItemNb = 12,
-				WriteOneTargetFileByField = false,
-				MaxChildren = 8
-			}
+					UserPromptPath = PromptsRootPath + "PromptScenariiTranslateEnUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptScenariiTranslateEnAssistant.txt"
+				}
+			},
+			// FR → EN translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 8,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = true,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 4,
+			CompareMode = false,
+			AutoCompare = true,
+			AutoCompareField = "titre",
+			CompareField = "title",
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = true,
+			MaxChildren = 8
+		},
 
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Scenarii to Russian by chunk empty-only 0-shot",
+			SourceDataset = KnownDataSets.Scenarii,
+			FieldsToInclude = new List<string>()
+			{
+				"path",
+				"catégorie",
+				"sous-catégorie",
+				"titre",
+				"baratineur",
+				"piocheur",
+				"contexte",
+				"enjeu",
+				"suggestion",
+				"category_ru",
+				"subcategory_ru",
+				"title_ru",
+				"smoothTalker_ru",
+				"drawer_ru",
+				"context_ru",
+				"issue_ru",
+				"suggestion_ru"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"category_ru",
+				"subcategory_ru",
+				"title_ru",
+				"smoothTalker_ru",
+				"drawer_ru",
+				"context_ru",
+				"issue_ru",
+				"suggestion_ru"
+			},
+			PrimaryField = "path",
+			TargetPath = @".\Target\Datasets\Argumentum Scenarii - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptScenariiTranslateRuUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptScenariiTranslateRuAssistant.txt"
+				}
+			},
+			// FR → RU translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 8,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = true,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 4,
+			CompareMode = false,
+			AutoCompare = true,
+			AutoCompareField = "titre",
+			CompareField = "title_ru",
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = true,
+			MaxChildren = 8
+		},
+
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Scenarii to Portuguese by chunk empty-only 0-shot",
+			SourceDataset = KnownDataSets.Scenarii,
+			FieldsToInclude = new List<string>()
+			{
+				"path",
+				"catégorie",
+				"sous-catégorie",
+				"titre",
+				"baratineur",
+				"piocheur",
+				"contexte",
+				"enjeu",
+				"suggestion",
+				"category_pt",
+				"subcategory_pt",
+				"title_pt",
+				"smoothTalker_pt",
+				"drawer_pt",
+				"context_pt",
+				"issue_pt",
+				"suggestion_pt"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"category_pt",
+				"subcategory_pt",
+				"title_pt",
+				"smoothTalker_pt",
+				"drawer_pt",
+				"context_pt",
+				"issue_pt",
+				"suggestion_pt"
+			},
+			PrimaryField = "path",
+			TargetPath = @".\Target\Datasets\Argumentum Scenarii - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptScenariiTranslatePtUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptScenariiTranslatePtAssistant.txt"
+				}
+			},
+			// FR → PT translation empty-only — eco tier. Fallback: gpt-4.1-mini
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 8,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = true,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 4,
+			CompareMode = false,
+			AutoCompare = true,
+			AutoCompareField = "titre",
+			CompareField = "title_pt",
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = true,
+			MaxChildren = 8
+		}
 	};
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateEnAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateEnAssistant.txt
@@ -1,0 +1,6 @@
+Instructions bien reçues. Je vais traduire les scénarios du jeu Argumentum vers l'anglais en respectant :
+- Le mapping spécifique des champs (catégorie→category, baratineur→smoothTalker, piocheur→drawer, enjeu→issue, suggestion→suggestion_en)
+- La cohérence lexicale des catégories et sous-catégories entre scénarios
+- Le ton narratif vivant et ludique (rythme, humour, brièveté)
+- L'adaptation mesurée des noms propres et références culturelles
+Je n'utiliserai que des appels à la fonction `UpdateRecord` pour chaque entrée à compléter, sans texte libre. Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateEnUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateEnUser.txt
@@ -1,0 +1,36 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de scénarios du jeu Argumentum. Chaque entrée décrit une situation de dialogue piégeuse où un personnage « baratineur » tente de convaincre un « piocheur » avec des arguments fallacieux. Chaque entrée comporte plusieurs champs :
+- `path` : identifiant hiérarchique (ex. "1.2.3")
+- `catégorie`, `sous-catégorie` : classification thématique française
+- `titre` : titre court du scénario
+- `baratineur` : nom/rôle du personnage qui tente de convaincre
+- `piocheur` : nom/rôle du personnage cible
+- `contexte` : mise en situation (lieu, circonstances)
+- `enjeu` : ce qui est en jeu dans la discussion
+- `suggestion` : piste de réplique ou conseil ludique
+- Les champs cibles anglais (sans suffixe `_en`, sauf pour suggestion) : `category`, `subcategory`, `title`, `smoothTalker`, `drawer`, `context`, `issue`, `suggestion_en`
+
+Ta tâche consiste à traduire en **anglais** les champs source français vers les champs cible anglais, uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Mapping des champs (ATTENTION) :**
+   - `catégorie` → `category`
+   - `sous-catégorie` → `subcategory`
+   - `titre` → `title`
+   - `baratineur` → `smoothTalker`
+   - `piocheur` → `drawer`
+   - `contexte` → `context`
+   - `enjeu` → `issue`
+   - `suggestion` → `suggestion_en` (seul champ avec suffixe)
+
+3. **Cohérence lexicale :** Les catégories et sous-catégories doivent rester cohérentes entre scénarios — si "Vie quotidienne" est traduit "Daily life" dans un scénario, réutilise cette traduction pour tous les scénarios de la même catégorie.
+
+4. **Ton narratif :** Les scénarios sont ludiques et vivants. Préserve le rythme, l'humour, la brièveté. Évite les formulations lourdes ou scolaires.
+
+5. **Noms propres et culture :** Les noms de personnages clairement français (ex. "Jean-Michel") peuvent être conservés ou anglicisés selon ce qui est plus naturel. Les références culturelles universelles restent telles quelles ; les références trop franco-françaises peuvent être adaptées si elles rendent le scénario incompréhensible.
+
+6. **Argumentum :** "Argumentum" reste "Argumentum".
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslatePtAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslatePtAssistant.txt
@@ -1,0 +1,7 @@
+Instructions bien reçues. Je vais traduire les scénarios du jeu Argumentum vers le portugais européen (pt-PT) en respectant :
+- La variante pt-PT (pas brésilienne)
+- La cohérence lexicale des catégories et sous-catégories entre scénarios
+- Le ton narratif vivant et ludique (rythme, humour, brièveté) avec des tournures idiomatiques portugaises
+- La traduction cohérente des rôles "baratineur" et "piocheur"
+- L'adaptation mesurée des noms propres et références culturelles
+Je n'utiliserai que des appels à la fonction `UpdateRecord` pour chaque entrée à compléter, sans texte libre. Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslatePtUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslatePtUser.txt
@@ -1,0 +1,30 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de scénarios du jeu Argumentum. Chaque entrée décrit une situation de dialogue piégeuse où un personnage « baratineur » tente de convaincre un « piocheur » avec des arguments fallacieux. Chaque entrée comporte plusieurs champs :
+- `path` : identifiant hiérarchique (ex. "1.2.3")
+- `catégorie`, `sous-catégorie` : classification thématique française
+- `titre` : titre court du scénario
+- `baratineur` : nom/rôle du personnage qui tente de convaincre
+- `piocheur` : nom/rôle du personnage cible
+- `contexte` : mise en situation (lieu, circonstances)
+- `enjeu` : ce qui est en jeu dans la discussion
+- `suggestion` : piste de réplique ou conseil ludique
+- Les champs cibles portugais (suffixe `_pt`) : `category_pt`, `subcategory_pt`, `title_pt`, `smoothTalker_pt`, `drawer_pt`, `context_pt`, `issue_pt`, `suggestion_pt`
+
+Ta tâche consiste à traduire en **portugais européen (pt-PT)** les champs source français vers les champs cible, uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Langue cible :** Portugais européen (pt-PT), **pas** brésilien. Utilise le vocabulaire et les tournures idiomatiques du Portugal (ex. "telemóvel" pas "celular", "casa de banho" pas "banheiro").
+
+3. **Cohérence lexicale :** Les catégories et sous-catégories doivent rester cohérentes entre scénarios — si "Vie quotidienne" est traduit "Vida quotidiana" dans un scénario, réutilise cette traduction pour tous les scénarios de la même catégorie.
+
+4. **Ton narratif :** Les scénarios sont ludiques et vivants. Préserve le rythme, l'humour, la brièveté. En pt-PT, privilégie les tournures idiomatiques naturelles du Portugal plutôt que des calques du français.
+
+5. **Rôles des personnages :** "baratineur" et "piocheur" désignent des rôles de jeu. Traduis par des équivalents portugais naturels évoquant le sens. Reste cohérent entre scénarios.
+
+6. **Noms propres et culture :** Les noms de personnages clairement français peuvent être conservés ou adaptés à des prénoms portugais courants selon ce qui est plus naturel. Les références culturelles trop franco-françaises peuvent être adaptées si elles rendent le scénario incompréhensible pour un lecteur portugais.
+
+7. **Argumentum :** "Argumentum" reste "Argumentum".
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateRuAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateRuAssistant.txt
@@ -1,0 +1,7 @@
+Instructions bien reçues. Je vais traduire les scénarios du jeu Argumentum vers le russe en respectant :
+- La cohérence lexicale des catégories et sous-catégories entre scénarios
+- Un vocabulaire russe contemporain et naturel, adapté à des situations de jeu quotidiennes
+- Le ton narratif vivant et ludique (rythme, humour, brièveté) avec des tournures idiomatiques russes
+- La traduction cohérente des rôles "baratineur" et "piocheur"
+- L'adaptation mesurée des noms propres et références culturelles
+Je n'utiliserai que des appels à la fonction `UpdateRecord` pour chaque entrée à compléter, sans texte libre. Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateRuUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslateRuUser.txt
@@ -1,0 +1,28 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de scénarios du jeu Argumentum. Chaque entrée décrit une situation de dialogue piégeuse où un personnage « baratineur » tente de convaincre un « piocheur » avec des arguments fallacieux. Chaque entrée comporte plusieurs champs :
+- `path` : identifiant hiérarchique (ex. "1.2.3")
+- `catégorie`, `sous-catégorie` : classification thématique française
+- `titre` : titre court du scénario
+- `baratineur` : nom/rôle du personnage qui tente de convaincre
+- `piocheur` : nom/rôle du personnage cible
+- `contexte` : mise en situation (lieu, circonstances)
+- `enjeu` : ce qui est en jeu dans la discussion
+- `suggestion` : piste de réplique ou conseil ludique
+- Les champs cibles russes (suffixe `_ru`) : `category_ru`, `subcategory_ru`, `title_ru`, `smoothTalker_ru`, `drawer_ru`, `context_ru`, `issue_ru`, `suggestion_ru`
+
+Ta tâche consiste à traduire en **russe** les champs source français vers les champs cible, uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Cohérence lexicale :** Les catégories et sous-catégories doivent rester cohérentes entre scénarios. Utilise un vocabulaire russe naturel et contemporain (pas soutenu/archaïque, ce sont des situations de jeu quotidiennes).
+
+3. **Ton narratif :** Les scénarios sont ludiques et vivants. Préserve le rythme, l'humour, la brièveté. En russe, privilégie les tournures idiomatiques naturelles plutôt que des calques du français.
+
+4. **Rôles des personnages :** "baratineur" et "piocheur" désignent des rôles de jeu. Traduis par des équivalents russes naturels évoquant le sens (ex. un personnage qui cherche à embobiner vs le personnage cible). Reste cohérent entre scénarios.
+
+5. **Noms propres et culture :** Les noms de personnages français peuvent être conservés en translittération cyrillique ou russifiés selon ce qui est plus naturel. Les références culturelles trop franco-françaises peuvent être adaptées si elles rendent le scénario incompréhensible pour un lecteur russe.
+
+6. **Argumentum :** "Argumentum" reste "Argumentum" (ou "Аргументум" en translittération cyrillique si le contexte l'exige).
+
+Es-tu prêt à recevoir les données ?


### PR DESCRIPTION
## Summary

Adds DatasetUpdater infrastructure to translate the 76 untranslated scenarios per target language, closing the translation gap for Scenarii (167 total, 76-85 missing per lang).

Same pattern as PR #231 (Virtues translation configs), but adapted for the game-scenario context.

## Changes

### 3 new DatasetUpdaterConfig entries (all `Enabled = false`)
- **Scenarii FR → EN** — 85 scenarios with ≥1 missing EN field
- **Scenarii FR → RU** — 76 scenarios missing `_ru` fields
- **Scenarii FR → PT** — 76 scenarios missing `_pt` fields

Pattern: `SequentialChunks`, `ChunkSize=8`, `SelectEmptyTargets=true`, `MaxGroupItemNb=12`, `UseFunctionCalling=true`, `MaxChildren=8`, `MaxDegreeOfParallelismWebService=4`, model `gpt-5.4-mini`.

### 6 new Scenarii-specific prompt files
- `PromptScenariiTranslate{En,Ru,Pt}{User,Assistant}.txt`

Why dedicated prompts? Scenarii are narrative game situations (not abstract taxonomy), so the prompts specifically enforce:
- **Field mapping discipline** — EN target fields do NOT use `_en` suffix (historical design): `catégorie→category`, `baratineur→smoothTalker`, `piocheur→drawer`, `enjeu→issue`, `suggestion→suggestion_en` (sole suffixed field)
- **Narrative tone** — rhythm, humor, brevity; avoid heavy/scholarly phrasing
- **Lexical consistency** across the category taxonomy
- **pt-PT vs pt-BR** — explicitly requests European Portuguese vocabulary (e.g. "telemóvel" not "celular")
- **Russian register** — contemporary/natural for daily-life scenarios, not archaic/philosophical
- **Measured cultural adaptation** — French personal names / cultural refs preserved or adapted depending on naturalness

## Audit (empirical measurement)

Run on `Cards/Scenarii/Argumentum Scenarii - Cards.csv`:

| Lang | FR-complete rows with ≥1 missing target field |
|------|-----------------------------------------------|
| EN   | 85 / 167                                      |
| RU   | 76 / 167                                      |
| PT   | 76 / 167                                      |

All 167 rows have all 8 FR source fields populated. `path` is unique (167/167) and non-empty — valid `PrimaryField`.

## Prerequisites

- ✅ #183 (SDK migration to official OpenAI .NET SDK v2.10.0) — merged via PR #210
- ✅ #222 (GPT-5.x model migration) — merged
- ✅ `Scenario.cs` entity has complete i18n scaffolding — no entity changes needed
  - EN fields without `_en` suffix are a historical design choice (English was considered the "base" locale), not a bug
  - RU/PT fields use `_ru`/`_pt` suffix as expected

## Validation

- ✅ Build: 0 errors, 17 warnings (all pre-existing)
- ✅ Tests: 88 pass, 1 skip (Freeplane GUI — interactive-only), 0 fail

## Test plan

- [ ] Merge & regenerate `AssetConverterConfig.json` from C# source
- [ ] Set `Enabled = true` on one Scenarii config (e.g. EN) with `TakeChunkNb = 1` for a dry-run on 8 scenarios
- [ ] Verify `UpdateRecord` function calls fire, CSV is updated with translations
- [ ] Validate translation quality on a sample (tone, field mapping, lexical consistency)
- [ ] Run full translation campaign (EN then RU then PT) once sample validated

## Closes

Closes #219 (pending successful end-to-end run with OpenAI key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)