### PR TITLE
fix(gsheet-sync): align Rules PrimaryKeyColumn with restored pk column

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncRootConfig.cs
@@ -37,7 +37,7 @@ namespace Argumentum.AssetConverter.GSheetSync
 				SpreadsheetId = "1jnhlod6PLgvVI-Qgrz3sTYytMgnrMyZrHcc8htPn_DQ",
 				Gid = 0,
 				LocalCsvPath = @"..\..\..\..\..\..\Cards\Rules\Argumentum Rules - Cards.csv",
-				PrimaryKeyColumn = "Text",
+				PrimaryKeyColumn = "pk",
 			},
 		});
 


### PR DESCRIPTION
## Summary
- Follow-up to #233 (which restored the `pk` column to Rules CSV).
- Updates [GSheetSyncRootConfig.cs:40](Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncRootConfig.cs#L40) so the Rules sync config uses `pk` as primary key, matching the column actually present in `Cards/Rules/Argumentum Rules - Cards.csv`.

## Why
Without this alignment, when GSheetSync runs on Rules:
- diff engine matches rows on `Text` (the rule statement, FR) vs the GDrive sheet
- any edit to FR rule text would orphan the row in diff (matched as add+delete instead of modify)
- inconsistent with the other 3 configs (Fallacies, Scenarii, Virtues) which all use stable `pk`/`path` columns

This prepares Phase 1 of the GDrive-authoritative translation workflow on the dashboard.

## Test plan
- [x] `dotnet build` clean (0 errors, 17 warnings — preexisting)
- [ ] After OAuth bootstrap on po-2023, run GSheetSync `Direction=Download DryRun=true Enabled=true` for Rules — diff should match all 18 rows on `pk` column
- [ ] Verify diff is stable across re-runs (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)