### PR TITLE
fix(pipeline): make Rule pk optional and remove Mindmapper from default mode

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -34,7 +34,7 @@ namespace Argumentum.AssetConverter
 	    public bool SkipConfigFile { get; set; } = true;
 
 	       [JsonConverter(typeof(JsonStringEnumConverter))]
-	       public ConverterMode Mode { get; set; } = ConverterMode.WebBasedImageGeneration | ConverterMode.QuestPdfGeneration | ConverterMode.Mindmapper;
+	       public ConverterMode Mode { get; set; } = ConverterMode.WebBasedImageGeneration | ConverterMode.QuestPdfGeneration;
 
 		public bool ForceDebugParams { get; set; }
 

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Rule.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Rule.cs
@@ -25,7 +25,7 @@ namespace Argumentum.AssetConverter.Entities
     {
         public RuleClassMap()
         {
-            Map(m => m.Pk).Name("pk");
+            Map(m => m.Pk).Name("pk").Optional();
             Map(m => m.Text).Name("Text");
             Map(m => m.Text_en).Name("Text_en");
             Map(m => m.Text_ru).Name("Text_ru");


### PR DESCRIPTION
## Summary
- Mark Rule CSV `pk` column mapping as `Optional()` in CsvHelper `RuleClassMap` to prevent parsing errors when the column is absent
- Remove `ConverterMode.Mindmapper` from default Mode to prevent FreeMind GUI prompts from blocking non-interactive pipeline runs

## Context
During PDF regeneration and visual verification of all 32 multilingual PDFs (FR/EN/PT/RU), two pipeline blockers were found and fixed:

1. **Rule.cs**: CsvHelper threw errors parsing Rules CSV when the `pk` column was missing. Making it Optional allows graceful handling.
2. **AssetConverterConfig.cs**: The Mindmapper mode triggered a FreeMind GUI prompt during `--non-interactive` runs, blocking the entire pipeline.

## Visual Verification Results (32 PDFs)

| PDF Type | FR | EN | PT | RU |
|----------|----|----|----|----|
| TarotCards | ✅ | ✅ | ✅ | ✅ |
| TarotCards Virtues | ✅ | ✅ | ✅ | ✅ |
| PokerCards | ✅ | ✅ | ✅ | ✅ |
| Fallacies Web (A0/A4/Thumbnails) | ✅ | ✅ | ✅ | ✅ |
| Print & Play (Tarot + Poker) | ✅ | ✅ | ✅ | ✅ |

### Known gaps (not regressions — pre-existing)
- **Memo cards** (TarotCards pages 18-31): No `CardSetLocalization` entry → always shows French content for non-FR languages
- **Card backs** (branding): Game subtitle "L'ART DE NE JAMAIS AVOIR TORT" not localized in back templates

## Test plan
- [x] Pipeline runs without blocking on FreeMind prompt
- [x] Rules CSV parses correctly with and without `pk` column
- [x] All 32 multilingual PDFs visually verified (content matches expected language)
- [ ] `dotnet test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)