### PR TITLE
fix(mindmap): wrapper sizing + neutral overlay + Virtues viewBox

### DIFF
--- a/Cards/Fallacies/Mindmaps/external.html
+++ b/Cards/Fallacies/Mindmaps/external.html
@@ -15,6 +15,14 @@
 
         #mindmap {
             position: relative;
+            width: 100vw;
+            height: 100vh;
+        }
+
+        #svgObject {
+            width: 100%;
+            height: 100%;
+            display: block;
         }
 
         .node:hover {
@@ -392,34 +400,34 @@
     <div id="mindmap" class="zoomable">
         <object id="svgObject" type="image/svg+xml" data="[SVGPATH]"></object>
     </div>
-    <card>
+    <card class="hidden">
         <bleed>
             <cut>
                 <safe>
-                    <div class="cardName">Argumentum_Fallacies_1.1.1..Justification triviale</div>
+                    <div class="cardName"></div>
 
                     <div class="body">
                         <div class="header">
                             <div class="supersetWrapper">
-                                <div class="famille">Insuffisance</div>
+                                <div class="famille"></div>
                                 <div class="sous_famille">
-                                    Argument bâclé | <span class="Soussousfamille"> Justification triviale</span>
+                                    <span class="Soussousfamille"></span>
                                 </div>
                             </div>
                         </div>
                         <div class="imageSection">
-                            <a id="externalLink" href="#" target="_blank">Lien externe</a>
+                            <a id="externalLink" href="#" target="_blank"></a>
                             <div class="title">
-                                <div>Justification triviale</div>
+                                <div></div>
                             </div>
                         </div>
                         <div class="texte">
-                            <div class="desc_fr">Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preuve.</div>
-                            <div class="exemple_fr">J'ai entendu dire que cette personne était sexiste ; il m'est donc impossible d'être en accord avec elle sur quoi que ce soit.</div>
+                            <div class="desc_fr"></div>
+                            <div class="exemple_fr"></div>
                         </div>
                     </div>
                     <div class="footer">
-                        <div class="niveau"> 3 </div>
+                        <div class="niveau"></div>
                     </div>
                 </safe>
             </cut>

--- a/Cards/Fallacies/Mindmaps/included.html
+++ b/Cards/Fallacies/Mindmaps/included.html
@@ -392,34 +392,34 @@
     <div id="mindmap" class="zoomable">
         [SVGCONTENT]
     </div>
-    <card>
+    <card class="hidden">
         <bleed>
             <cut>
                 <safe>
-                    <div class="cardName">Argumentum_Fallacies_1.1.1..Justification triviale</div>
+                    <div class="cardName"></div>
 
                     <div class="body">
                         <div class="header">
                             <div class="supersetWrapper">
-                                <div class="famille">Insuffisance</div>
+                                <div class="famille"></div>
                                 <div class="sous_famille">
-                                    Argument bâclé | <span class="Soussousfamille"> Justification triviale</span>
+                                    <span class="Soussousfamille"></span>
                                 </div>
                             </div>
                         </div>
                         <div class="imageSection">
-                            <a id="externalLink" href="#" target="_blank">Lien externe</a>
+                            <a id="externalLink" href="#" target="_blank"></a>
                             <div class="title">
-                                <div>Justification triviale</div>
+                                <div></div>
                             </div>
                         </div>
                         <div class="texte">
-                            <div class="desc_fr">Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preuve.</div>
-                            <div class="exemple_fr">J'ai entendu dire que cette personne était sexiste ; il m'est donc impossible d'être en accord avec elle sur quoi que ce soit.</div>
+                            <div class="desc_fr"></div>
+                            <div class="exemple_fr"></div>
                         </div>
                     </div>
                     <div class="footer">
-                        <div class="niveau"> 3 </div>
+                        <div class="niveau"></div>
                     </div>
                 </safe>
             </cut>

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapCreatorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapCreatorConfig.cs
@@ -48,6 +48,9 @@ namespace Argumentum.AssetConverter.Mindmapper
                     {
                         Enabled = true,
                         DocumentName = "content.svg",
+                        SvgViewBox = "0 0 6625 5807",
+                        SvgWidth = "96vw",
+                        SvgHeight = "93vh",
                         WrapNodeByLink = false,
                         SetSVGNodeAttributes = true,
                         RemoveImages = true,


### PR DESCRIPTION
## Summary

Fixes 4 mindmap issues identified during ai-01's HTML validation pass.

### Changes

| Issue | Fix | File |
|-------|-----|------|
| **#271** | Add `#mindmap` sizing (100vw/100vh) + `#svgObject` sizing (100%) — prevents 300×150 default `<object>` rendering | `external.html` |
| **#272** | Add `SvgViewBox`/`SvgWidth`/`SvgHeight` to Virtues content.svg config — blank Virtues HTML mind maps now render | `VirtueMindMapCreatorConfig.cs` |
| **#273** | Remove hardcoded French overlay card text from both templates — JS dynamically populates overlay, so static FR was dead code visible on load in EN/RU/PT files | `external.html` + `included.html` |
| **#274** | Same fix as #272 — Virtues SVG viewBox NaN caused by missing config properties | `VirtueMindMapCreatorConfig.cs` |

### Root Causes

- **#271**: `<object>` element with no CSS sizing defaults to 300×150px
- **#272/#274**: `VirtueMindMapCreatorConfig` never set `SvgViewBox`/`SvgWidth`/`SvgHeight` on the content.svg `SVGFreemindMap` entry, while `FallacyMindMapCreatorConfig` always did. Virtues SVGs came from Batik with `width="6625" height="5807"` and no `viewBox`, causing blank rendering in HTML and NaN in post-processing.
- **#273**: Both template files had a `<card>` block with hardcoded French fallacy "Justification triviale" as static preview content. The JS at lines 430-589 dynamically replaces all overlay content from SVG node attributes on click, so this was invisible in interactive use but visible as flash-of-wrong-content in EN/RU/PT.

### Visual Validation

Playwright before/after screenshot confirms:
- **BEFORE**: FR text "Insuffisance" + description visible in overlay
- **AFTER**: Overlay starts hidden (class="hidden"), no language-specific content

### Tests

120 pass / 0 fail / 5 skip (unchanged)

Closes #271, closes #272, closes #273, closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)