### PR TITLE
fix(printandplay): reduce PDF size — JPEG Q=85 + skip CMYK

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
@@ -147,12 +147,13 @@ namespace Argumentum.AssetConverter
             }
 
             // 1. Lire toutes les images en mémoire une seule fois
+            // Convert to JPEG Q=85 for Print&Play to reduce PDF size (PNG lossless = 223 MB → ~15-30 MB)
             var frontImagesData = images
-                .Select(img => !string.IsNullOrEmpty(img.Front) && File.Exists(img.Front) ? File.ReadAllBytes(img.Front) : null)
+                .Select(img => !string.IsNullOrEmpty(img.Front) && File.Exists(img.Front) ? ConvertToJpeg(File.ReadAllBytes(img.Front), 85) : null)
                 .ToList();
 
             var backImagesData = images
-                .Select(img => !string.IsNullOrEmpty(img.Back) && File.Exists(img.Back) ? File.ReadAllBytes(img.Back) : null)
+                .Select(img => !string.IsNullOrEmpty(img.Back) && File.Exists(img.Back) ? ConvertToJpeg(File.ReadAllBytes(img.Back), 85) : null)
                 .ToList();
 
             // La logique de livret sera gérée à l'intérieur de PrintAndPlayDocument
@@ -172,6 +173,22 @@ namespace Argumentum.AssetConverter
                 Logger.LogProblem($"FAILED to generate PDF document {fileName}: {ex.Message}");
                 Logger.LogException(ex);
                 throw; // Rethrow to maintain behavior
+            }
+        }
+
+        private static byte[] ConvertToJpeg(byte[] imageData, int quality)
+        {
+            if (imageData == null || imageData.Length == 0) return imageData;
+            try
+            {
+                using var image = new MagickImage(imageData);
+                image.Quality = (uint)quality;
+                image.Format = MagickFormat.Jpeg;
+                return image.ToByteArray();
+            }
+            catch
+            {
+                return imageData;
             }
         }
 

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
@@ -509,7 +509,7 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.RulesPrintAndPlay,
 							NbCopies = 1,
-							ConvertToCmyk = true,
+							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{
@@ -528,7 +528,7 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.FallaciesPrintAndPlay,
 							NbCopies = 1,
-							ConvertToCmyk = true,
+							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{
@@ -566,7 +566,7 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.MemoPrintAndPlay,
 							NbCopies = 5,
-							ConvertToCmyk = true,
+							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{
@@ -602,7 +602,7 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.ScenariiPrintAndPlay,
 							NbCopies = 1,
-							ConvertToCmyk = true,
+							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{


### PR DESCRIPTION
## Summary

- Convert card images to JPEG Q=85 before embedding in Print&Play PDFs (new `ConvertToJpeg` helper in `PdfManager.cs`)
- Set `ConvertToCmyk = false` on Print&Play CardSets only (Rules, Fallacies, Memo, Scenarii) — CMYK is for professional print, not home printing
- Other card types (Tarot, Poker, A0, Thumbnails) retain `ConvertToCmyk = true`

## Problem

Tarot Print&Play A4 PDFs were **223 MB**, exceeding Edge PDFium's ~256 MB memory limit. This made them unusable in browser-based PDF viewers.

## Expected Result

PDFs reduced from ~223 MB to **~15-30 MB** (JPEG compression + no CMYK colorspace expansion).

## Test plan

- [x] `dotnet build` — 0 errors, 19 warnings (pre-existing)
- [x] `dotnet test` — 120 pass / 0 fail / 5 skip (stable)
- [ ] Pipeline regeneration to produce new Print&Play PDFs
- [ ] Compare sizes: before ~223 MB → after ~15-30 MB
- [ ] Visual spot-check: card image quality still acceptable at JPEG Q=85

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)