### PR TITLE
fix(config): correct ReleaseCardpenUrl — GitHub Pages root

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
@@ -49,7 +49,7 @@ namespace Argumentum.AssetConverter
 
 
 
-		public string ReleaseCardpenUrl { get; set; } = @"https://argumentumgames.github.io/Argumentum/Generation/CardPen/index.html";
+		public string ReleaseCardpenUrl { get; set; } = @"https://argumentumgames.github.io/Argumentum/index.html";
 		public string LocalCardpenUrl { get; set; } = @"https://argumentum.myia.io/index.html";
 
 


### PR DESCRIPTION
## Summary

- Fix `ReleaseCardpenUrl` from 404 to working GitHub Pages URL
- The Pages workflow deploys CardPen to repo root, not `/Generation/CardPen/`

## Proof

```
$ curl -sI https://argumentumgames.github.io/Argumentum/index.html
HTTP/1.1 200 OK
Content-Length: 11510

$ curl -sI https://argumentumgames.github.io/Argumentum/Generation/CardPen/index.html
HTTP/1.1 404 Not Found
```

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `curl -I` confirms new URL returns 200 OK
- [ ] Verify `UseLocalCardpen = false` + `dotnet run` resolves CardPen correctly (requires network access)

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)