### PR TITLE
refactor(pdf): respect UseDebugParams for CMYK + JPEG quality

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
@@ -136,7 +136,7 @@ namespace Argumentum.AssetConverter
 					}
                 }
 
-                if (documentCardSet.ConvertToCmyk)
+                if (documentCardSet.GetConvertToCmyk(config))
                 {
                     imageFromEmbeddedUrl.ConvertToCmyk();
                 }

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/DocumentCardSet.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/DocumentCardSet.cs
@@ -17,6 +17,15 @@ namespace Argumentum.AssetConverter
 
         public bool ConvertToCmyk { get; set; } = true;
 
+        /// <summary>CMYK conversion for Debug builds (preview-friendly, smaller files).</summary>
+        public bool ConvertToCmykDebug { get; set; } = false;
+
+        /// <summary>CMYK conversion for Release builds (printer quality).</summary>
+        public bool ConvertToCmykRelease { get; set; } = true;
+
+        public bool GetConvertToCmyk(AssetConverterConfig config)
+            => config.UseDebugParams ? ConvertToCmykDebug : ConvertToCmykRelease;
+
         public DocumentCard FrontCards { get; set; } = new DocumentCard();
 
         public DocumentCard BackCards { get; set; } = new DocumentCard();

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
@@ -130,7 +130,7 @@ namespace Argumentum.AssetConverter
             GeneratePdfsFromImages(targetFiles, overwriteExistingDocs);
         }
 
-        public void GeneratePrintAndPlay(string fileName, CardSetDocumentConfig docConfig, List<CardImages> images, bool configOverwriteExistingDocs)
+        public void GeneratePrintAndPlay(string fileName, CardSetDocumentConfig docConfig, List<CardImages> images, bool configOverwriteExistingDocs, bool useReleaseMode = false)
         {
             if (File.Exists(fileName) && !configOverwriteExistingDocs)
             {
@@ -146,15 +146,13 @@ namespace Argumentum.AssetConverter
                 return;
             }
 
-            // 1. Lire toutes les images en mémoire une seule fois
-            // Convert to JPEG Q=85 for Print&Play to reduce PDF size (PNG lossless = 223 MB → ~15-30 MB)
-            var frontImagesData = images
-                .Select(img => !string.IsNullOrEmpty(img.Front) && File.Exists(img.Front) ? ConvertToJpeg(File.ReadAllBytes(img.Front), 85) : null)
-                .ToList();
+            // 1. Read images — JPEG Q=85 for Debug (Edge preview), PNG lossless for Release (printer)
+            byte[] ProcessImage(string path) => !string.IsNullOrEmpty(path) && File.Exists(path)
+                ? (useReleaseMode ? File.ReadAllBytes(path) : ConvertToJpeg(File.ReadAllBytes(path), 85))
+                : null;
 
-            var backImagesData = images
-                .Select(img => !string.IsNullOrEmpty(img.Back) && File.Exists(img.Back) ? ConvertToJpeg(File.ReadAllBytes(img.Back), 85) : null)
-                .ToList();
+            var frontImagesData = images.Select(img => ProcessImage(img.Front)).ToList();
+            var backImagesData = images.Select(img => ProcessImage(img.Back)).ToList();
 
             // La logique de livret sera gérée à l'intérieur de PrintAndPlayDocument
             // if (isBooklet) { ... }

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGenerator.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGenerator.cs
@@ -121,7 +121,8 @@ namespace Argumentum.AssetConverter
 								break;
 							case CardDocumentFormat.PrintAndPlay:
 								objPdfManager.GeneratePrintAndPlay(baseName, docImageList.Key.document,
-									docImageList.Value, AssetConverterConfig.OverwriteExistingDocs);
+									docImageList.Value, AssetConverterConfig.OverwriteExistingDocs,
+									AssetConverterConfig.UseReleaseParams);
 								break;
 							default:
 								throw new InvalidOperationException(

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
@@ -509,7 +509,6 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.RulesPrintAndPlay,
 							NbCopies = 1,
-							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{
@@ -528,7 +527,6 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.FallaciesPrintAndPlay,
 							NbCopies = 1,
-							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{
@@ -566,7 +564,6 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.MemoPrintAndPlay,
 							NbCopies = 5,
-							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{
@@ -602,7 +599,6 @@ namespace Argumentum.AssetConverter
 						{
 							CardSetName = KnownCardSets.ScenariiPrintAndPlay,
 							NbCopies = 1,
-							ConvertToCmyk = false,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
 							{


### PR DESCRIPTION
## Summary

- Add `ConvertToCmykDebug`/`ConvertToCmykRelease` + `GetConvertToCmyk(config)` to `DocumentCardSet`, following the existing `JsonFilePathDebug`/`Release` pattern
- `ImageHelper` uses `GetConvertToCmyk(config)` instead of hardcoded `ConvertToCmyk`
- `PdfManager.GeneratePrintAndPlay` receives `useReleaseMode` parameter: Debug=JPEG Q=85, Release=PNG lossless
- Remove hardcoded `ConvertToCmyk = false` from 4 Print&Play CardSets (defaults now handle it)

## Behavior

| Build | Print&Play output | Tarot FR size | Use case |
|-------|-------------------|---------------|----------|
| `dotnet run` (Debug) | RGB JPEG Q=85 | ~71 MB | Edge preview, Playwright |
| `dotnet run -c Release` | CMYK PNG lossless | ~222 MB | Printer quality |
| `ForceReleaseParams=true` | CMYK PNG lossless | ~222 MB | Release from Debug build |

## Test plan

- [x] `dotnet build` — 0 errors, 19 warnings (pre-existing)
- [x] `dotnet test` — 120 pass / 0 fail / 5 skip
- [ ] Verify Debug build produces JPEG (~71 MB Tarot P&P)
- [ ] Verify Release build produces PNG lossless (~222 MB Tarot P&P)

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)