### PR TITLE
fix(config): remove hardcoded Debug paths — thumbnails + Freeplane/FreeMind (#283)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -241,8 +241,8 @@ namespace Argumentum.AssetConverter
 		public FallacyMindMapCreatorConfig FallacyMindMapCreatorConfig { get; set; } = new FallacyMindMapCreatorConfig();
 		public VirtueMindMapCreatorConfig VirtueMindMapCreatorConfig { get; set; } = new VirtueMindMapCreatorConfig();
 
-		public string FreeplanePath { get; set; } = @"C:\Users\MYIA\AppData\Local\Programs\Freeplane\freeplane.exe";
-		public string FreeMindPath { get; set; } = @"C:\Program Files (x86)\FreeMind\FreeMind.exe";
+		public string FreeplanePath { get; set; } = "";
+		public string FreeMindPath { get; set; } = "";
 
 
 		public Dnn2sxcConfig Dnn2sxcConfig { get; set; } = new Dnn2sxcConfig();

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -183,8 +183,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 
-		//public string ImagePathExpression { get; set; } = @"../../bin/Debug/netcoreapp3.1/Target/Images/density-0/Fallacies-Web-Thumbnails/{fallacy.FileName}.png";
-		public string ThumbnailsPathExpression { get; set; } = @"../../bin/Debug/netcoreapp3.1/Target/Images/density-0/Fallacies-Web-Thumbnails/argumentum_{item.Path}_{item.Text.ToLower().Replace("" "",""_"")}.png";
+		public string ThumbnailsPathExpression { get; set; } = @"Target/Images/density-0/Fallacies-Web-Thumbnails/argumentum_{item.Path}_{item.Text.ToLower().Replace("" "",""_"")}.png";
 
 
 		public string GetThumbnailsPath(IMindMapItem item)

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/MindMapDocumentConfig.cs
@@ -168,8 +168,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 
-		//public string ImagePathExpression { get; set; } = @"../../bin/Debug/netcoreapp3.1/Target/Images/density-0/Fallacies-Web-Thumbnails/{fallacy.FileName}.png";
-		public string ThumbnailsPathExpression { get; set; } = @"../../bin/Debug/netcoreapp3.1/Target/Images/density-0/Fallacies-Web-Thumbnails/argumentum_{fallacy.Path}_{fallacy.TextFr.ToLower().Replace("" "",""_"")}.png";
+		public string ThumbnailsPathExpression { get; set; } = @"Target/Images/density-0/Fallacies-Web-Thumbnails/argumentum_{fallacy.Path}_{fallacy.TextFr.ToLower().Replace("" "",""_"")}.png";
 
 
 		public string GetThumbnailsPath(Fallacy fallacy)

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
@@ -173,7 +173,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 			}
 		}
 
-		public string ThumbnailsPathExpression { get; set; } = @"../../bin/Debug/netcoreapp3.1/Target/Images/density-0/Fallacies-Web-Thumbnails/argumentum_{item.Path}_{item.Text.ToLower().Replace("" "",""_"")}.png";
+		public string ThumbnailsPathExpression { get; set; } = @"Target/Images/density-0/Fallacies-Web-Thumbnails/argumentum_{item.Path}_{item.Text.ToLower().Replace("" "",""_"")}.png";
 
 
 		public string GetThumbnailsPath(IMindMapItem item)


### PR DESCRIPTION
## Summary

- **ThumbnailsPathExpression** (3 files): Replace hardcoded `../../bin/Debug/netcoreapp3.1/Target/...` with `Target/...` — the path now resolves correctly in both Debug and Release builds
- **FreeplanePath / FreeMindPath**: Change from machine-specific paths (`C:\Users\MYIA\...`) to empty string defaults — configurable via JSON, existing guard (`string.IsNullOrEmpty` + `!File.Exists`) ensures graceful skip

## Before

```csharp
// MindMapDocumentConfig.cs:172 (same in Fallacy + Virtue variants)
public string ThumbnailsPathExpression { get; set; } = @"../../bin/Debug/netcoreapp3.1/Target/Images/...";
// AssetConverterConfig.cs:244-245
public string FreeplanePath { get; set; } = @"C:\Users\MYIA\AppData\Local\Programs\Freeplane\freeplane.exe";
public string FreeMindPath { get; set; } = @"C:\Program Files (x86)\FreeMind\FreeMind.exe";
```

## After

```csharp
// Works from both bin/Debug/net9.0 and bin/Release/net9.0
public string ThumbnailsPathExpression { get; set; } = @"Target/Images/density-0/Fallacies-Web-Thumbnails/...";
// Empty defaults — user sets via JSON config or environment
public string FreeplanePath { get; set; } = "";
public string FreeMindPath { get; set; } = "";
```

## Test plan
- [x] `dotnet build` — 0 error
- [x] `dotnet test` — 120 pass / 0 fail / 5 skip
- [ ] Mind map generation with thumbnails still resolves paths correctly (functional test post-merge)

Fixes HIGH items #1-5 from issue #283. Parent: Epic #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)