### PR TITLE
ci: add build matrix Debug + Release (#278 Task 5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'tmp/**'
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore "Argumentum Converters.sln"
+
+      - name: Build (${{ matrix.configuration }})
+        run: dotnet build "Argumentum Converters.sln" --no-restore -c ${{ matrix.configuration }}
+
+      - name: Test
+        run: dotnet test "Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj" --no-build -c ${{ matrix.configuration }} --verbosity normal


### PR DESCRIPTION
## Summary
- Add `.github/workflows/build.yml` — CI build matrix with Debug and Release configurations
- Runs on `windows-latest` (project targets Windows-specific features like FreeMind SendKeys)
- Triggers on push to master and PRs; skips on docs-only changes
- Steps: restore → build → test (xUnit)

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm both Debug and Release builds succeed
- [ ] Confirm tests pass in both configurations

Part of Epic #278 (Task 5/7). Completes the Epic when merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)