### PR TITLE
fix(prompts): prevent baratineur contamination in PT DatasetUpdater

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslatePtUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslatePtUser.txt
@@ -8,11 +8,7 @@ Ta tâche consiste à traduire ou retraduire en portugais européen (pt-PT) le c
 
 2. **Format du texte :** Les règles contiennent du markdown (titres ##, listes à puces *, gras **, italique *, séparateurs ---). Préserve exactement ce formatage.
 
-3. **Termes du jeu :** Conserve les noms propres du jeu tels que :
-   - "Argumentum" (nom du jeu)
-   - "Baratineur" (rôle du jeu)
-   - "Mixologue" (rôle du jeu)
-   Les noms des familles de cartes (en français) sont des noms propres — conserve-les en français.
+3. **Termes du jeu :** "Argumentum" (nom du jeu) reste "Argumentum". Les noms des familles de cartes (en français) sont des noms propres — conserve-les en français. Les rôles comme "Baratineur" et "Mixologue" doivent être traduits en équivalents portugais naturels.
 
 4. **Langue cible :** Portugais européen (pt-PT), PAS brésilien. Traduis de manière naturelle et idiomatique, pas mot à mot.
 

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslatePtUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptScenariiTranslatePtUser.txt
@@ -15,16 +15,26 @@ Ta tâche consiste à traduire en **portugais européen (pt-PT)** les champs sou
 
 1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord`. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
 
-2. **Langue cible :** Portugais européen (pt-PT), **pas** brésilien. Utilise le vocabulaire et les tournures idiomatiques du Portugal (ex. "telemóvel" pas "celular", "casa de banho" pas "banheiro").
+2. **Mapping des champs (ATTENTION) :**
+   - `catégorie` → `category_pt`
+   - `sous-catégorie` → `subcategory_pt`
+   - `titre` → `title_pt`
+   - `baratineur` → `smoothTalker_pt`
+   - `piocheur` → `drawer_pt`
+   - `contexte` → `context_pt`
+   - `enjeu` → `issue_pt`
+   - `suggestion` → `suggestion_pt`
 
-3. **Cohérence lexicale :** Les catégories et sous-catégories doivent rester cohérentes entre scénarios — si "Vie quotidienne" est traduit "Vida quotidiana" dans un scénario, réutilise cette traduction pour tous les scénarios de la même catégorie.
+3. **Langue cible :** Portugais européen (pt-PT), **pas** brésilien. Utilise le vocabulaire et les tournures idiomatiques du Portugal (ex. "telemóvel" pas "celular", "casa de banho" pas "banheiro").
 
-4. **Ton narratif :** Les scénarios sont ludiques et vivants. Préserve le rythme, l'humour, la brièveté. En pt-PT, privilégie les tournures idiomatiques naturelles du Portugal plutôt que des calques du français.
+4. **Cohérence lexicale :** Les catégories et sous-catégories doivent rester cohérentes entre scénarios — si "Vie quotidienne" est traduit "Vida quotidiana" dans un scénario, réutilise cette traduction pour tous les scénarios de la même catégorie.
 
-5. **Rôles des personnages :** "baratineur" et "piocheur" désignent des rôles de jeu. Traduis par des équivalents portugais naturels évoquant le sens. Reste cohérent entre scénarios.
+5. **Ton narratif :** Les scénarios sont ludiques et vivants. Préserve le rythme, l'humour, la brièveté. En pt-PT, privilégie les tournures idiomatiques naturelles du Portugal plutôt que des calques du français.
 
-6. **Noms propres et culture :** Les noms de personnages clairement français peuvent être conservés ou adaptés à des prénoms portugais courants selon ce qui est plus naturel. Les références culturelles trop franco-françaises peuvent être adaptées si elles rendent le scénario incompréhensible pour un lecteur portugais.
+6. **Rôles des personnages — TRADUIRE OBLIGATOIREMENT :** "baratineur" et "piocheur" sont des rôles de jeu qui **doivent être traduits** en portugais. Ces mots sont français et ne doivent **jamais** apparaître tels quels dans les champs cibles. Utilise des équivalents portugais naturels (ex. "convencedor", "bobo" ou similaires). Reste cohérent entre scénarios.
 
-7. **Argumentum :** "Argumentum" reste "Argumentum".
+7. **Noms propres et culture :** Les noms de personnages clairement français peuvent être conservés ou adaptés à des prénoms portugais courants selon ce qui est plus naturel. Les références culturelles trop franco-françaises peuvent être adaptées si elles rendent le scénario incompréhensible pour un lecteur portugais.
+
+8. **Argumentum :** "Argumentum" reste "Argumentum".
 
 Es-tu prêt à recevoir les données ?


### PR DESCRIPTION
## Summary
Root cause fix for the 92% PT Scenarii and 42% PT Rules "baratineur" contamination identified during ai-01's i18n audit (cycles 32-33).

### Problem
- **Scenarii PT prompt** (`PromptScenariiTranslatePtUser.txt`): Lacked explicit source→target field mapping (unlike EN prompt which has a clear mapping table). The vague directive "traduis par des équivalents portugais naturels" was ignored by the model ~92% of the time.
- **Rules PT prompt** (`PromptRulesTranslatePtUser.txt`): Line 13 explicitly instructed the model to **conserve** "Baratineur" and "Mixologue" as proper nouns → the model was told NOT to translate them.

### Changes
**Scenarii PT**:
- Added explicit field mapping table (matching EN prompt structure): `baratineur → smoothTalker_pt`, `piocheur → drawer_pt`, etc.
- Strengthened directive: "baratineur" and "piocheur" **must be translated**, never left in French
- Renumbered items to maintain consistency

**Rules PT**:
- Removed "conserve Baratineur/Mixologue" directive
- Clarified: only "Argumentum" and card family names are proper nouns to preserve
- Roles must now be translated to Portuguese equivalents

### Test plan
- [x] Both prompt files reviewed against EN equivalents for consistency
- [ ] Validation: re-run DatasetUpdater PT on 3-5 test records to confirm "baratineur" is now translated
- [ ] Full PT re-translation run after validation (Scenarii 167 records + Rules 24 records)

### Context
- Finding #11 (PT Scenarii 92% contamination) from ai-01 cycle 33
- Finding #7 (Rules PT 42% broken, #211) 
- Root cause investigation confirmed ai-01's hypothesis #3: missing prompt directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)