### PR TITLE
feat(dataset-updater): multi-provider API + gpt-5.5 for EN translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ _ref_preview/
 
 # Claude Code session artifacts in subdirectories (not root .claude/)
 Generation/**/.claude/
+.keys/

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
@@ -31,6 +31,10 @@ public class DatasetUpdaterConfig
 
 	public string Model { get; set; } = "gpt-5.4-mini";
 
+	public string? BaseUrl { get; set; }
+
+	public int? MaxOutputTokens { get; set; }
+
 	public int MaxTokensPerMinute { get; set; } = 70000;
 
 	public DivisionMode DivisionMode { get; set; }
@@ -469,6 +473,8 @@ public class DatasetUpdaterConfig
 				var dataPrompt = new Prompt()
 				{
 					ApiKey = openAIKey,
+					BaseUrl = BaseUrl,
+					MaxOutputTokens = MaxOutputTokens,
 					Model = Model,
 					SystemPrompt = systemPrompt,
 					DialogPrompts = DialogPrompts,

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -509,11 +509,13 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptVirtuesTranslateEnAssistant.txt"
 				}
 			},
-			// FR → EN translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			// FR → EN via OpenAI gpt-5.5 (best quality per benchmark)
+			Model = "gpt-5.5",
+			OpenAIKeyPath = @".keys\openai-key.txt",
+			MaxOutputTokens = 4096,
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
-			ChunkSize = 8,
+			ChunkSize = 4,
 			UseFunctionCalling = true,
 			NbMessageCalls = 1,
 			SkipChunkNb = 0,
@@ -794,11 +796,13 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptScenariiTranslateEnAssistant.txt"
 				}
 			},
-			// FR → EN translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			// FR → EN via OpenAI gpt-5.5 (best quality per benchmark)
+			Model = "gpt-5.5",
+			OpenAIKeyPath = @".keys\openai-key.txt",
+			MaxOutputTokens = 4096,
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
-			ChunkSize = 8,
+			ChunkSize = 4,
 			UseFunctionCalling = true,
 			NbMessageCalls = 1,
 			SkipChunkNb = 0,

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Prompt.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Prompt.cs
@@ -18,6 +18,10 @@ public class Prompt
 
     public string ApiKey { get; set; } = "";
 
+    public string? BaseUrl { get; set; }
+
+    public int? MaxOutputTokens { get; set; }
+
     public string SystemPrompt { get; set; } = "";
 
     public List<PromptExample> DialogPrompts { get; set; } = new();
@@ -32,7 +36,15 @@ public class Prompt
         {
             if (_chatClient == null)
             {
-                _openAIClient = new OpenAI.OpenAIClient(ApiKey);
+                if (!string.IsNullOrEmpty(BaseUrl))
+                {
+                    var options = new OpenAI.OpenAIClientOptions { Endpoint = new Uri(BaseUrl) };
+                    _openAIClient = new OpenAI.OpenAIClient(new System.ClientModel.ApiKeyCredential(ApiKey), options);
+                }
+                else
+                {
+                    _openAIClient = new OpenAI.OpenAIClient(ApiKey);
+                }
                 _chatClient = _openAIClient.GetChatClient(Model);
             }
             return _chatClient;
@@ -76,6 +88,11 @@ public class Prompt
         messages.Add(new UserChatMessage(UserPrompt));
 
         var options = new ChatCompletionOptions();
+
+        if (MaxOutputTokens.HasValue)
+        {
+            options.MaxOutputTokenCount = MaxOutputTokens.Value;
+        }
 
         if (Functions != null && Functions.Count > 0)
         {


### PR DESCRIPTION
## Summary

- Add `BaseUrl` and `MaxOutputTokens` support to `Prompt.cs` and `DatasetUpdaterConfig.cs`, enabling any OpenAI-compatible API endpoint (OpenRouter, local models, etc.)
- Switch **Virtues EN** and **Scenarii EN** translation configs from `gpt-5.4-mini` to `gpt-5.5` via direct OpenAI API for best translation quality
- Add `.keys/` to `.gitignore` for API key file storage

## Benchmark Results (6 models tested)

| Model | Time | Quality | Cost/1M tokens |
|-------|------|---------|----------------|
| gpt-5.4-mini | 2.5s | Standard | $0.30/$1.60 |
| **gpt-5.5** | **6s** | **Excellent** | **$5/$30** |
| claude-sonnet-4.6 | 4s | Very good | $3/$15 |
| claude-opus-4.7 | 12s | Excellent | $15/$75 |

## Changes

- `Prompt.cs`: Added `BaseUrl` (custom endpoint) and `MaxOutputTokens` properties; client construction branches on BaseUrl presence using `ApiKeyCredential`
- `DatasetUpdaterConfig.cs`: Added `BaseUrl` and `MaxOutputTokens` properties, threaded into Prompt construction
- `DatasetUpdaterRootConfig.cs`: Virtues EN + Scenarii EN configs updated to `Model = "gpt-5.5"`, `OpenAIKeyPath = ".keys\openai-key.txt"`, `MaxOutputTokens = 4096`, `ChunkSize = 4`
- `.gitignore`: Added `.keys/` directory

## Test plan

- [x] `dotnet build` passes with 0 errors
- [x] 120 tests pass, 0 fail, 5 skip (GSheet OAuth + Freeplane — expected)
- [ ] Manual: enable Scenarii EN config and run pilot (3-5 records) to verify gpt-5.5 endpoint
- [ ] Manual: verify Virtues EN translation with gpt-5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)