### PR TITLE
data(rules): fix PT cover subtitle (EN contamination row 1)

### DIFF
--- a/Cards/Rules/Argumentum Rules - Cards.csv
+++ b/Cards/Rules/Argumentum Rules - Cards.csv
@@ -3,7 +3,7 @@ Rules_01,"# Argumentum
 ## L'école des menteurs","# Argumentum
 ## The school of liars","# Argumentum
 ## Школа лжецов","# Argumentum
-## Liars 'School"
+## A Escola dos Mentirosos"
 Rules_02,"*Règles du jeu : de 4 à 8 joueurs*
 
 ## Matériel


### PR DESCRIPTION
## Context

Rules CSV row 1 `Text_pt` contained the EN string `# Argumentum\n## Liars 'School` (with typo space) instead of the PT translation. This affected the cover subtitle of TarotCards_pt PDF.

## Diff

| Field | Before | After |
|-------|--------|-------|
| `Text_pt` row 1 | `# Argumentum\n## Liars 'School` | `# Argumentum\n## A Escola dos Mentirosos` |

## Translation rationale

- Source FR : `L'école des menteurs`
- Validated PT : `A Escola dos Mentirosos` (Title Case, branding-consistent)
- Native PT validation by po-2023 cycle 55 (2026-05-18): "Escola" féminin singulier (article `A`), "dos Mentirosos" génitif pluriel masculin, cohérent pt-PT et pt-BR
- Aligned with cycle 25 glossary style guide (Title Case for game branding)

## Audit

Audited all 24 rows of Rules CSV for similar EN contamination → **only row 1 Text_pt affected**. No other multilingual cells require correction in Rules CSV.

## Cycle 44 Phase 2 impact

This fix resolves what was originally tracked as **2 separate blockers** in cycle 44 Phase 2 plan:
- ~~Blocker #3 (PT cover tagline LIARS 'SCHOOL)~~ → fixed by this PR
- ~~Blocker #4 (Footer L'ÉCOLE DES MENTEURS partout)~~ → cycle 47 grep confirms this was a misinterpretation; no footer hardcoded in Fallacies/Scenarii/Memo/Virtues templates

→ Phase 2 v1.0.0 blocker count reduced from 5 to 3.

## Test plan

- [ ] CSV parses correctly (`dotnet run` harvest Rules)
- [ ] Regenerate TarotCards_pt PDF → confirms row 1 cover shows `A Escola dos Mentirosos`
- [ ] Visual diff TarotCards_fr/_en/_ru unchanged
- [ ] CI Debug + Release SUCCESS

## Linked issue

Rattaché à Epic #202 (text & translation finalization). No dedicated issue required (trivial data fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)