### PR TITLE
chore(docs): update i18n status in CLAUDE.md and AssetConverterConfig comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,8 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 
 **Bug #216 découvert 2026-04-22 + corrigé 2026-04-23** : `LocalizationConfig.FrontFieldConversions` pour Fallacies référençait des noms de champs (`Titre`, `Definition`, `Exemple`, `Contre-Exemple`) qui n'existaient PAS dans les templates Mustache (qui utilisent `{{text_fr}}`, `{{desc_fr}}`, `{{example_fr}}`, `{{Famille}}`, `{{Sous-Famille}}`, `{{Soussousfamille}}`). Résultat : `template.Replace()` ne trouvait rien à remplacer → tous les PDFs EN/RU/PT contenaient du contenu français. Corrigé en restaurant le mapping Golden Master (avril 2024) + ajout de Rules (absent) + tests de régression `FallaciesLocalizationTests`. **Regénération pipeline complète requise** pour produire les PDFs réellement multilingues.
 
+**Mise à jour cycle 56+59 (mai 2026)** : Bug #216 corrigé avril 2026, pipeline régen post-merges #301/#302 auditée cycle 56 (Stratégie D recommandée : spot-check 5 cartes pixel diff ~15 min avant décision régen complète A ou aucune C). Tableau ci-dessus reste snapshot 17 mars 2026 (pré-fix).
+
 ### État actuel par CardSet (FR - COMPLET)
 
 | CardSet | Images | PDFs | Status |
@@ -424,11 +426,12 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 ### Translation Pipeline (DatasetUpdater)
 
 - **SDK**: Official OpenAI .NET SDK v2.10.0 (PR #210 merged)
-- **Models**: `gpt-4.1`, `gpt-4.1-mini` (all deprecated model constants replaced)
+- **Models**: `gpt-5.5` (EN translations primary, PR #302), `gpt-4.1`/`gpt-4.1-mini` (fallback + RU/PT)
+- **Multi-provider**: API support added via PR #302 (OpenAI + alternative providers configurable)
 - **Config**: `DatasetUpdater/DatasetUpdaterRootConfig.cs` — 7 task configs (all `Enabled = false`)
 - **Prompts**: 29 files in `DatasetUpdater/Resources/`
 - **Function calling**: Manual `FunctionToolDef` + JSON schema + `BinaryData.FromString()`
-- **Virtues CSV has NO multilingual columns** — only `_fr` fields, translation entirely absent
+- **Virtues CSV**: 100% translated (title/description/remark × fr/en/ru/pt), via PRs #218, #236, #246, #290, #295
 - **Issue #183** DONE — merged via PR #210
 
 ### GSheet ↔ CSV Sync (PR #200 merged)
@@ -457,12 +460,12 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 6. ~~#183 — Upgrade SDK traduction~~ FAIT (PR #210 merged, avril 2026)
 7. ~~#193 — GSheet ↔ CSV sync~~ FAIT (PR #200 merged, avril 2026)
 8. ~~#202 Phase 1 — CSV text micro-fixes~~ FAIT (PR #203 + #213 merged)
-9. Valider DatasetUpdater round-trip avec OpenAI API (3-5 records, Enabled=true)
-10. #211 — Retraduction complète PT Rules via pipeline (débloqué par #183)
+9. Valider DatasetUpdater round-trip avec OpenAI API (3-5 records, Enabled=true) — smoke test gpt-5.5 en cours (po-2023, cycle 61bis)
+10. ~~#211 — Retraduction PT Rules~~ ✅ DONE (closed 2026-05-17), Rules PT 100% sauf row 1 cover (fix PR #306 cycle 47)
 11. #212 — Playwright visual regression tests pour PDFs générés
-12. Virtues i18n — ajouter colonnes _en/_ru/_pt au CSV + traduire
-13. Scenarii — 77 scénarios manquants EN/RU/PT à traduire
-14. #134 — GitHub Release
+12. ~~Virtues i18n — ajouter colonnes _en/_ru/_pt~~ ✅ DONE (April-May 2026, PRs #218/#236/#246/#290/#295) — 100% coverage title/description/remark
+13. Scenarii EN/RU/PT — 76/167 records missing (~46%), Phase 1 EN run via gpt-5.5 (post smoke test cycle 61bis)
+14. #134 — GitHub Release v0.9.0 (en attente validation docs)
 15. #133 — Publication OWL
 16. #131/#132 — DNN site + déploiement
 
@@ -481,14 +484,14 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 | `e24cbd17` | fix(prompt): enable #nullable context and guard null param.Name |
 | `092d4639` | Merge PR #200 — bidirectional GSheet ↔ CSV sync (#193) |
 
-### Data Quality Issues (April 2026)
+### Data Quality Issues (April-May 2026)
 
 | Issue | Description | Status |
 | ------- | ----------- | ------ |
 | Fallacies duplicate PKs 520, 1000 | Warning surfaces during GSheet sync | Needs upstream fix |
-| Scenarii 53% translated | 77/167 scenarios missing EN/RU/PT | Blocked by #211 → then pipeline run |
-| Virtues 0% translated | No _en/_ru/_pt columns | Unblocked by #183, needs CSV columns added |
-| PT Rules MT errors (#211) | Catastrophic MT translations | Needs full retranslation via pipeline |
+| Scenarii 54% translated | 76/167 records missing EN/RU/PT (title/context/issue) | Pipeline run via gpt-5.5 (smoke test cycle 61bis in progress) |
+| ~~Virtues 0% translated~~ | ✅ Resolved via PRs #218, #236, #246, #290, #295 (April-May 2026) — 100% coverage title/description/remark × 4 languages | DONE |
+| PT Rules row 1 EN contamination | Rules cover showed "Liars 'School" instead of "A Escola dos Mentirosos" | ✅ Fix PR #306 cycle 47 (1 cell CSV, native PT validated po-2023) |
 
 ## Related Documentation
 

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -129,9 +129,9 @@ namespace Argumentum.AssetConverter
 				},
 				new CardSetLocalization()
 				{
-					// Virtues: CSV currently only has _fr columns (issue #183/#205 upgrade unblocks translation but dataset not yet regenerated).
-					// Mapping is a no-op until the CSV exposes title_en/description_en/... etc.
+					// Virtues: CSV has fr/en/ru/pt at 100% coverage on title/description/remark (PRs #218, #236, #246, #290, #295 — April-May 2026).
 					// Template placeholders use {{title_fr}}, {{description_fr}}, {{family_fr}}, {{subfamily_fr}}, {{subsubfamily_fr}}, {{remark_fr}}.
+					// FrontFieldConversions below swap _fr → _en/_ru/_pt at runtime via LocalizationConfig.CardSetLocalizations.
 					CardSetNames = new List<string>(new []
 					{
 						KnownCardSets.Virtues,


### PR DESCRIPTION
## Context

Consolidates obsolete documentation findings from cycles 57, 59, 60:
- Audit cycle 57 confirmed Virtues CSV is fully translated (100% × 4 languages, 223 rows × 38 cols) since April-May 2026 via PRs #218, #236, #246, #290, #295
- Audit cycle 59 identified 5 obsolete CLAUDE.md sections beyond Virtues
- Cycle 60 spec proposed code comment fix in AssetConverterConfig.cs:132

Single PR per jsboige direction ("consolide les docs cycle 57+59+60").

## Changes

### CLAUDE.md (5 sections updated)

| Section | Change |
|---------|--------|
| Translation Pipeline | `gpt-4.1` primary → `gpt-5.5` primary (PR #302), `gpt-4.1`/`gpt-4.1-mini` fallback; Virtues 100% translated (PRs listed) |
| Prochaines etapes | Item 10 (#211 closed), item 12 (Virtues done), item 13 (76/167 missing, not 77) — strike-through completed |
| Data Quality Issues | Scenarii 53%→54%, Virtues resolved (strike-through), PT Rules fix linked to PR #306 |
| Validation Multilingue | Note Bug #216 fixed April 2026 + cycle 56 audit reference (Strategy D recommended) |
| Coherent sections | CardPen, GSheet, Mind Maps, Tests, Stable Deps — **unchanged** (cycle 57+59 audit confirmed coherent) |

### AssetConverterConfig.cs:132-134

```diff
-					// Virtues: CSV currently only has _fr columns (issue #183/#205 upgrade unblocks translation but dataset not yet regenerated).
-					// Mapping is a no-op until the CSV exposes title_en/description_en/... etc.
-					// Template placeholders use {{title_fr}}, {{description_fr}}, {{family_fr}}, {{subfamily_fr}}, {{subsubfamily_fr}}, {{remark_fr}}.
+					// Virtues: CSV has fr/en/ru/pt at 100% coverage on title/description/remark (PRs #218, #236, #246, #290, #295 — April-May 2026).
+					// Template placeholders use {{title_fr}}, {{description_fr}}, {{family_fr}}, {{subfamily_fr}}, {{subsubfamily_fr}}, {{remark_fr}}.
+					// FrontFieldConversions below swap _fr → _en/_ru/_pt at runtime via LocalizationConfig.CardSetLocalizations.
```

3 lines comment replaced by 3 lines accurate comment.

## Verification

- Virtues CSV factual audit: 223 rows × 38 cols, Python `csv.DictReader` parsing, 100% coverage on title/description/remark fields × 4 languages
- Git log confirms 6 PRs traduction Virtues (#218 scaffold, #236 refine, #246 PT Wikipedia, #290 gaps, #295 normalize)
- Cycle 56+57+59 spec/findings cross-reference

## Test plan

- [ ] CI build (Debug + Release) — should pass (comment-only change in C#, doc-only in CLAUDE.md)
- [ ] CI tests — should pass (77 tests, no logic touched)
- [ ] No CSV touched, no template touched, no config logic touched

## Linked

- Consolidates documentation findings from `cycle57-virtues-i18n-audit/findings.md`, `cycle59-claude-md-audit/findings.md`, `cycle60-config-comment-fix/spec.md`
- Related: PR #306 (cycle 47 Rules PT fix, separate PR for data layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)