### PR TITLE
fix(rules): replace PT garble Baratinener with Embromador

### DIFF
--- a/Cards/Rules/Argumentum Rules - Cards.csv
+++ b/Cards/Rules/Argumentum Rules - Cards.csv
@@ -194,7 +194,7 @@ Otherwise, the winner of the round is the one whose card has obtained the most v
 
 Победителем этого круга является тот, чья карта получила наибольшее количество голосов, это может быть болтун или кто-то из игроков (🥇👇👇… ➜).
 Победивший оставляет карту себе и кладет ее перед собой лицом вверх. Он получил 1 очко. 
-","O embromador exibe seus argumentos e o puxador lhe dá a réplica sem tentar dominar a cena. O Baratinener pode optar por reduzir o Saynet quando desejar.
+","O embromador exibe seus argumentos e o puxador lhe dá a réplica sem tentar dominar a cena. O Embromador pode optar por reduzir o Saynet quando desejar.
 
 ### 4. O júri
 
@@ -279,8 +279,8 @@ Depois que o vencedor for designado, os jogadores desenham uma série de cartas 
 * Durante o Saynet, qualquer membro do júri pode usar uma carta de seu jogo para intervir no papel de pickaxe. Se sua intervenção ilustrar bem o cartão, ele reipoca um e será nomeado a próxima picareta, se não, ele perde o cartão e o jogo assume sua quadra.
 * Picher tem o direito de designar diretamente o embromador do canal.
 * Se o puxador vencer, ele também vence o cartão Embromador.
-* O embromador pode definir vários cartões. Muitos vencedores de votação são declarados, o Baratinener que pode ganhar todas ou parte de suas cartas.
-* O vencedor do jogo deve incorporar o baratinener de um cenário final, onde ele deve colocar em jogo todas as cartas que ganhou durante o jogo."
+* O embromador pode definir vários cartões. Muitos vencedores de votação são declarados, o Embromador que pode ganhar todas ou parte de suas cartas.
+* O vencedor do jogo deve incorporar o embromador de um cenário final, onde ele deve colocar em jogo todas as cartas que ganhou durante o jogo."
 Rules_07,"# Argumentum
 ## Le Bingo mixologie argumentative","# Argumentum
 ## The school of liars","# Argumentum


### PR DESCRIPTION
## Summary
- Replace 3 occurrences of "Baratinener"/"baratinener" (garbled PT) with correct glossaire term "Embromador"/"embromador" in Rules CSV
- Lines 197, 282, 283 affected

## Scope
- **1 file**: `Cards/Rules/Argumentum Rules - Cards.csv`
- **3 replacements**, no other changes
- Separate PR from Scenarii residuals (different file per ai-01's instructions)

## Part of
- Issue #335, P1 residuals item 3

## Test plan
- [x] Programmatic verification: 0 remaining "baratinener" occurrences
- [ ] ai-01 gate review

🤖 Generated with [Claude Code](https://claude.com/claude-code)