### PR TITLE
fix(owl): add rdf:type skos:Concept/Scheme + implement validation tests (#313)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Ontology/OwlAdapter.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Ontology/OwlAdapter.cs
@@ -147,13 +147,16 @@ namespace Argumentum.AssetConverter.Ontology
         public void DeclareConceptScheme(RDFResource scheme)
         {
             DeclareClass(scheme);
-            SKOSHelper.DeclareConceptScheme(_ontology, scheme);
+            // SKOSHelper.DeclareConceptScheme is broken in OWLSharp 4.9.0 — emit rdf:type directly
+            AnnotateConceptWithResource(scheme, RDFVocabulary.RDF.TYPE, SKOSVocabulary.ConceptScheme);
         }
 
         public void DeclareConcept(RDFResource concept, RDFResource scheme)
         {
             DeclareClass(concept);
-            SKOSHelper.DeclareConcept(_ontology, concept, conceptScheme: scheme);
+            // SKOSHelper.DeclareConcept is broken in OWLSharp 4.9.0 — emit rdf:type + skos:inScheme directly
+            AnnotateConceptWithResource(concept, RDFVocabulary.RDF.TYPE, SKOSVocabulary.Concept);
+            AnnotateConceptWithResource(concept, SKOSVocabulary.InScheme, scheme);
         }
 
         public void DeclareTopConcept(RDFResource concept, RDFResource scheme)
@@ -373,6 +376,19 @@ namespace Argumentum.AssetConverter.Ontology
         public OWLOntology GetOntology()
         {
             return _ontology;
+        }
+
+        public List<RDFResource> GetResourcesByType(RDFResource typeResource)
+        {
+            return GetAnnotationSubjects(typeResource);
+        }
+
+        public bool HasAnnotation(RDFResource subject, RDFResource property, RDFResource value)
+        {
+            return _ontology.AnnotationAxioms.OfType<OWLAnnotationAssertion>()
+                .Any(a => a.AnnotationProperty.GetIRI().Equals(property.URI)
+                    && a.SubjectIRI.Equals(subject.URI)
+                    && a.ValueIRI != null && a.ValueIRI.Equals(value.URI));
         }
     }
 }

--- a/Generation/Converters/Argumentum.AssetConverter/Tests/OwlOntologyValidationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Tests/OwlOntologyValidationTests.cs
@@ -95,9 +95,63 @@ namespace Argumentum.AssetConverter.Tests
         /// <returns>Une tâche représentant l'opération asynchrone.</returns>
         public async Task<bool> ValidateOwlOntologyStructure()
         {
-            // Pour l'instant on ne fait rien, mais il faudra implémenter les tests
             await Task.CompletedTask;
-            return true;
+            var errors = new List<string>();
+
+            // Check ConceptScheme has rdf:type skos:ConceptScheme
+            var conceptSchemes = _ontology.GetResourcesByType(SKOSVocabulary.ConceptScheme);
+            if (conceptSchemes.Count == 0)
+            {
+                errors.Add("No skos:ConceptScheme found with rdf:type assertion");
+            }
+            Logger.Log($"ConceptSchemes with rdf:type: {conceptSchemes.Count}");
+
+            // Check concepts have rdf:type skos:Concept
+            var concepts = _ontology.GetResourcesByType(SKOSVocabulary.Concept);
+            if (concepts.Count == 0)
+            {
+                errors.Add("No skos:Concept found with rdf:type assertion");
+            }
+            Logger.Log($"Concepts with rdf:type: {concepts.Count}");
+
+            // Check top concepts exist
+            var topConcepts = _ontology.GetTopConcepts();
+            if (topConcepts.Count == 0)
+            {
+                errors.Add("No top concepts found (skos:hasTopConcept)");
+            }
+            Logger.Log($"Top concepts: {topConcepts.Count}");
+
+            // Check hierarchy via narrower/broader on top concepts
+            int totalNarrower = 0;
+            foreach (var topConcept in topConcepts.Take(5))
+            {
+                var labels = _ontology.GetConceptPreferredLabels(topConcept);
+                var label = labels.Count > 0 ? labels[0].Value : topConcept.URI.ToString();
+                // Check that top concept has narrower children
+                var childConcepts = _ontology.GetConcepts();
+                foreach (var child in childConcepts.Take(20))
+                {
+                    if (_ontology.CheckIsNarrowerConcept(child, topConcept))
+                    {
+                        totalNarrower++;
+                    }
+                }
+                Logger.Log($"  Top concept '{label}': checked narrower relations");
+            }
+            if (totalNarrower == 0)
+            {
+                errors.Add("No narrower concepts found in hierarchy");
+            }
+
+            foreach (var error in errors)
+            {
+                Logger.LogProblem(error);
+            }
+
+            bool valid = errors.Count == 0;
+            Logger.Log(valid ? "Structure validation: PASS" : $"Structure validation: FAIL ({errors.Count} errors)");
+            return valid;
         }
 
         /// <summary>
@@ -109,9 +163,46 @@ namespace Argumentum.AssetConverter.Tests
         /// <returns>Une tâche représentant l'opération asynchrone.</returns>
         public async Task<bool> ValidateMultilingualAnnotations()
         {
-            // Pour l'instant on ne fait rien, mais il faudra implémenter les tests
             await Task.CompletedTask;
-            return true;
+            var errors = new List<string>();
+
+            var concepts = _ontology.GetResourcesByType(SKOSVocabulary.Concept);
+            if (concepts.Count == 0)
+            {
+                Logger.Log("No concepts to validate annotations — skipping");
+                return true;
+            }
+
+            int missingLabels = 0, missingDefs = 0, checkedCount = 0;
+            foreach (var concept in concepts.Take(50))
+            {
+                checkedCount++;
+                var labels = _ontology.GetConceptPreferredLabels(concept);
+                if (labels.Count == 0) missingLabels++;
+
+                var defs = _ontology.GetConceptDocumentation(concept, SKOSDocumentationTypes.Definition);
+                if (defs.Count == 0) missingDefs++;
+            }
+
+            Logger.Log($"Checked {checkedCount} concepts: {missingLabels} missing prefLabel, {missingDefs} missing definition");
+
+            if (missingLabels > checkedCount / 2)
+            {
+                errors.Add($"{missingLabels}/{checkedCount} concepts missing skos:prefLabel");
+            }
+            if (missingDefs > checkedCount / 2)
+            {
+                errors.Add($"{missingDefs}/{checkedCount} concepts missing skos:definition");
+            }
+
+            foreach (var error in errors)
+            {
+                Logger.LogProblem(error);
+            }
+
+            bool valid = errors.Count == 0;
+            Logger.Log(valid ? "Annotation validation: PASS" : $"Annotation validation: FAIL ({errors.Count} errors)");
+            return valid;
         }
 
         /// <summary>
@@ -123,9 +214,42 @@ namespace Argumentum.AssetConverter.Tests
         /// <returns>Une tâche représentant l'opération asynchrone.</returns>
         public async Task<bool> ValidateAIFMappings()
         {
-            // Pour l'instant on ne fait rien, mais il faudra implémenter les tests
             await Task.CompletedTask;
-            return true;
+            var errors = new List<string>();
+
+            var concepts = _ontology.GetResourcesByType(SKOSVocabulary.Concept);
+            if (concepts.Count == 0)
+            {
+                Logger.Log("No concepts to validate AIF mappings — skipping");
+                return true;
+            }
+
+            int withExactMatch = 0, withAnyMatch = 0;
+            foreach (var concept in concepts)
+            {
+                var exact = _ontology.GetExactMatchConcepts(concept);
+                var close = _ontology.GetCloseMatchConcepts(concept);
+                var related = _ontology.GetRelatedMatchConcepts(concept);
+
+                if (exact.Count > 0) withExactMatch++;
+                if (exact.Count > 0 || close.Count > 0 || related.Count > 0) withAnyMatch++;
+            }
+
+            Logger.Log($"AIF mappings: {withExactMatch}/{concepts.Count} with exactMatch, {withAnyMatch}/{concepts.Count} with any match");
+
+            if (withAnyMatch == 0)
+            {
+                errors.Add("No concepts have any AIF match mappings (exactMatch, closeMatch, relatedMatch)");
+            }
+
+            foreach (var error in errors)
+            {
+                Logger.LogProblem(error);
+            }
+
+            bool valid = errors.Count == 0;
+            Logger.Log(valid ? "AIF mapping validation: PASS" : $"AIF mapping validation: FAIL ({errors.Count} errors)");
+            return valid;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Fix missing `rdf:type skos:Concept` and `rdf:type skos:ConceptScheme` assertions in generated OWL ontology
- Add `skos:inScheme` linking each concept to its scheme
- Replace broken `SKOSHelper` calls (OWLSharp 4.9.0 bug) with raw annotation assertions
- Implement real validation logic in `OwlOntologyValidationTests` (previously stubs returning `true`)

### Changes

**OwlAdapter.cs:**
- `DeclareConceptScheme()`: now emits `rdf:type skos:ConceptScheme` directly
- `DeclareConcept()`: now emits `rdf:type skos:Concept` + `skos:inScheme` directly
- Added `GetResourcesByType()` and `HasAnnotation()` public helpers

**OwlOntologyValidationTests.cs:**
- `ValidateOwlOntologyStructure()`: checks ConceptScheme/Concept type assertions, top concepts, hierarchy
- `ValidateMultilingualAnnotations()`: checks prefLabel and definition coverage
- `ValidateAIFMappings()`: checks exactMatch/closeMatch/relatedMatch presence

### Test plan
- [x] Build succeeds (0 errors)
- [ ] Run OWL generation pipeline to verify rdf:type assertions in output
- [ ] Run validation tests against generated ontology

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)