### PR TITLE
feat(mindmaps): add wheel zoom, pan drag, and pinch-to-zoom (#312)

### DIFF
--- a/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en.html
+++ b/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -3823,18 +3820,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -3842,6 +3845,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en_ext.html
+++ b/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/en/Fallacies_en.html
+++ b/Cards/Fallacies/Mindmaps/en/Fallacies_en.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -17011,18 +17008,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -17030,6 +17033,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/en/Fallacies_en_ext.html
+++ b/Cards/Fallacies/Mindmaps/en/Fallacies_en_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/external.html
+++ b/Cards/Fallacies/Mindmaps/external.html
@@ -383,16 +383,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -574,18 +571,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -593,6 +596,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr.html
+++ b/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -3823,18 +3820,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -3842,6 +3845,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr_ext.html
+++ b/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/fr/Fallacies_fr.html
+++ b/Cards/Fallacies/Mindmaps/fr/Fallacies_fr.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -17207,18 +17204,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -17226,6 +17229,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/fr/Fallacies_fr_ext.html
+++ b/Cards/Fallacies/Mindmaps/fr/Fallacies_fr_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/included.html
+++ b/Cards/Fallacies/Mindmaps/included.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -564,18 +561,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -583,6 +586,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt.html
+++ b/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -3823,18 +3820,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -3842,6 +3845,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt_ext.html
+++ b/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/pt/Fallacies_pt.html
+++ b/Cards/Fallacies/Mindmaps/pt/Fallacies_pt.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -17271,18 +17268,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -17290,6 +17293,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/pt/Fallacies_pt_ext.html
+++ b/Cards/Fallacies/Mindmaps/pt/Fallacies_pt_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru.html
+++ b/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -3823,18 +3820,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -3842,6 +3845,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru_ext.html
+++ b/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Cards/Fallacies/Mindmaps/ru/Fallacies_ru.html
+++ b/Cards/Fallacies/Mindmaps/ru/Fallacies_ru.html
@@ -373,16 +373,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
 
 
@@ -17754,18 +17751,24 @@
 
         const mindmapContainer = document.getElementById('mindmap');
         let zoomLevel = 1;
+        let panX = 0, panY = 0;
+        const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+        function applyTransform() {
+            mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+        }
 
         function zoomIn() {
-            zoomLevel += 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+            applyTransform();
         }
 
         function zoomOut() {
-            zoomLevel -= 0.1;
-            mindmapContainer.style.transform = `scale(${zoomLevel})`;
+            zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+            applyTransform();
         }
 
-        // Example usage
+        // Keyboard zoom
         document.addEventListener('keydown', (event) => {
             if (event.key === '+') {
                 zoomIn();
@@ -17773,6 +17776,59 @@
                 zoomOut();
             }
         });
+
+        // Mouse wheel zoom
+        mindmapContainer.addEventListener('wheel', (event) => {
+            event.preventDefault();
+            if (event.deltaY < 0) {
+                zoomIn();
+            } else {
+                zoomOut();
+            }
+        }, { passive: false });
+
+        // Pan with mouse drag
+        let isPanning = false, panStartX, panStartY;
+        mindmapContainer.addEventListener('mousedown', (event) => {
+            if (event.button !== 0) return;
+            isPanning = true;
+            panStartX = event.clientX - panX;
+            panStartY = event.clientY - panY;
+            mindmapContainer.classList.add('panning');
+        });
+        document.addEventListener('mousemove', (event) => {
+            if (!isPanning) return;
+            panX = event.clientX - panStartX;
+            panY = event.clientY - panStartY;
+            applyTransform();
+        });
+        document.addEventListener('mouseup', () => {
+            isPanning = false;
+            mindmapContainer.classList.remove('panning');
+        });
+
+        // Pinch-to-zoom (touch)
+        let initialPinchDistance = 0, pinchZoomStart = 1;
+        mindmapContainer.addEventListener('touchstart', (event) => {
+            if (event.touches.length === 2) {
+                initialPinchDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                pinchZoomStart = zoomLevel;
+            }
+        }, { passive: true });
+        mindmapContainer.addEventListener('touchmove', (event) => {
+            if (event.touches.length === 2) {
+                event.preventDefault();
+                const currentDistance = Math.hypot(
+                    event.touches[0].clientX - event.touches[1].clientX,
+                    event.touches[0].clientY - event.touches[1].clientY
+                );
+                zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                applyTransform();
+            }
+        }, { passive: false });
 
     });
 

--- a/Cards/Fallacies/Mindmaps/ru/Fallacies_ru_ext.html
+++ b/Cards/Fallacies/Mindmaps/ru/Fallacies_ru_ext.html
@@ -375,16 +375,13 @@
 
 
         .zoomable {
-            transform-origin: top left;
-            transition: transform 0.3s ease;
+            transform-origin: 0 0;
+            transition: none;
+            cursor: grab;
         }
 
-        .zoom-in {
-            transform: scale(1.2);
-        }
-
-        .zoom-out {
-            transform: scale(0.8);
+        .zoomable.panning {
+            cursor: grabbing;
         }
     </style>
 </head>
@@ -566,18 +563,24 @@
 
                 const mindmapContainer = document.getElementById('mindmap');
                 let zoomLevel = 1;
+                let panX = 0, panY = 0;
+                const MIN_ZOOM = 0.2, MAX_ZOOM = 5;
+
+                function applyTransform() {
+                    mindmapContainer.style.transform = `translate(${panX}px, ${panY}px) scale(${zoomLevel})`;
+                }
 
                 function zoomIn() {
-                    zoomLevel += 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.min(zoomLevel + 0.1, MAX_ZOOM);
+                    applyTransform();
                 }
 
                 function zoomOut() {
-                    zoomLevel -= 0.1;
-                    mindmapContainer.style.transform = `scale(${zoomLevel})`;
+                    zoomLevel = Math.max(zoomLevel - 0.1, MIN_ZOOM);
+                    applyTransform();
                 }
 
-                // Example usage
+                // Keyboard zoom
                 document.addEventListener('keydown', (event) => {
                     if (event.key === '+') {
                         zoomIn();
@@ -585,6 +588,59 @@
                         zoomOut();
                     }
                 });
+
+                // Mouse wheel zoom
+                mindmapContainer.addEventListener('wheel', (event) => {
+                    event.preventDefault();
+                    if (event.deltaY < 0) {
+                        zoomIn();
+                    } else {
+                        zoomOut();
+                    }
+                }, { passive: false });
+
+                // Pan with mouse drag
+                let isPanning = false, panStartX, panStartY;
+                mindmapContainer.addEventListener('mousedown', (event) => {
+                    if (event.button !== 0) return;
+                    isPanning = true;
+                    panStartX = event.clientX - panX;
+                    panStartY = event.clientY - panY;
+                    mindmapContainer.classList.add('panning');
+                });
+                document.addEventListener('mousemove', (event) => {
+                    if (!isPanning) return;
+                    panX = event.clientX - panStartX;
+                    panY = event.clientY - panStartY;
+                    applyTransform();
+                });
+                document.addEventListener('mouseup', () => {
+                    isPanning = false;
+                    mindmapContainer.classList.remove('panning');
+                });
+
+                // Pinch-to-zoom (touch)
+                let initialPinchDistance = 0, pinchZoomStart = 1;
+                mindmapContainer.addEventListener('touchstart', (event) => {
+                    if (event.touches.length === 2) {
+                        initialPinchDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        pinchZoomStart = zoomLevel;
+                    }
+                }, { passive: true });
+                mindmapContainer.addEventListener('touchmove', (event) => {
+                    if (event.touches.length === 2) {
+                        event.preventDefault();
+                        const currentDistance = Math.hypot(
+                            event.touches[0].clientX - event.touches[1].clientX,
+                            event.touches[0].clientY - event.touches[1].clientY
+                        );
+                        zoomLevel = Math.min(Math.max(pinchZoomStart * (currentDistance / initialPinchDistance), MIN_ZOOM), MAX_ZOOM);
+                        applyTransform();
+                    }
+                }, { passive: false });
             });
         });
     </script>

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/MindmapWrapperTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/MindmapWrapperTests.cs
@@ -204,5 +204,132 @@ namespace Argumentum.AssetConverter.VisualTests
             await page.CloseAsync();
         }
 
+        /// <summary>
+        /// Verifies mouse wheel zoom changes the transform on #mindmap.
+        /// Uses the synthetic SVG fixture to keep the test self-contained.
+        /// </summary>
+        [Fact]
+        public async Task Included_Wrapper_Wheel_Zoom_Changes_Transform()
+        {
+            Assert.True(File.Exists(IncludedTemplatePath), $"Missing template: {IncludedTemplatePath}");
+
+            var template = await File.ReadAllTextAsync(IncludedTemplatePath);
+            const string syntheticSvg = @"<svg xmlns=""http://www.w3.org/2000/svg"" width=""400"" height=""200"">
+  <rect x=""10"" y=""10"" width=""380"" height=""180"" fill=""#f0f0f0""/>
+</svg>";
+
+            var wrapperHtml = MindMapHtmlWrapper.FormatWrapper(template, "synthetic.svg", syntheticSvg);
+            var wrapperPath = Path.Combine(_tempDir, "wheel_zoom_test.html");
+            await File.WriteAllTextAsync(wrapperPath, wrapperHtml);
+
+            var page = await _browser.NewPageAsync();
+            await page.GotoAsync("file:///" + wrapperPath.Replace('\\', '/'));
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            // Read initial transform
+            var initialTransform = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"Initial transform: '{initialTransform}'");
+
+            // Simulate mouse wheel up (zoom in) on the mindmap container
+            await page.Locator("#mindmap").EvaluateAsync(@"el => {
+                const event = new WheelEvent('wheel', { deltaY: -100, bubbles: true });
+                el.dispatchEvent(event);
+            }");
+
+            var afterZoomIn = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"After wheel-up (zoom in): '{afterZoomIn}'");
+            Assert.Contains("scale(1.1)", afterZoomIn);
+
+            // Simulate mouse wheel down (zoom out)
+            await page.Locator("#mindmap").EvaluateAsync(@"el => {
+                const event = new WheelEvent('wheel', { deltaY: 100, bubbles: true });
+                el.dispatchEvent(event);
+            }");
+
+            var afterZoomOut = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"After wheel-down (zoom out): '{afterZoomOut}'");
+            Assert.Contains("scale(1)", afterZoomOut);
+
+            await page.CloseAsync();
+        }
+
+        /// <summary>
+        /// Verifies keyboard +/- zoom still works alongside the new wheel zoom.
+        /// </summary>
+        [Fact]
+        public async Task Included_Wrapper_Keyboard_Zoom_Still_Works()
+        {
+            Assert.True(File.Exists(IncludedTemplatePath), $"Missing template: {IncludedTemplatePath}");
+
+            var template = await File.ReadAllTextAsync(IncludedTemplatePath);
+            const string syntheticSvg = @"<svg xmlns=""http://www.w3.org/2000/svg"" width=""400"" height=""200"">
+  <rect x=""10"" y=""10"" width=""380"" height=""180"" fill=""#f0f0f0""/>
+</svg>";
+
+            var wrapperHtml = MindMapHtmlWrapper.FormatWrapper(template, "synthetic.svg", syntheticSvg);
+            var wrapperPath = Path.Combine(_tempDir, "keyboard_zoom_test.html");
+            await File.WriteAllTextAsync(wrapperPath, wrapperHtml);
+
+            var page = await _browser.NewPageAsync();
+            await page.GotoAsync("file:///" + wrapperPath.Replace('\\', '/'));
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            // Press '+' key
+            await page.Keyboard.PressAsync("+");
+            var afterPlus = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"After '+': '{afterPlus}'");
+            Assert.Contains("scale(1.1)", afterPlus);
+
+            // Press '-' key
+            await page.Keyboard.PressAsync("-");
+            var afterMinus = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"After '-': '{afterMinus}'");
+            Assert.Contains("scale(1)", afterMinus);
+
+            await page.CloseAsync();
+        }
+
+        /// <summary>
+        /// Verifies zoom is clamped: cannot go below MIN_ZOOM (0.2) or above MAX_ZOOM (5).
+        /// </summary>
+        [Fact]
+        public async Task Included_Wrapper_Zoom_Clamped_To_Min_Max()
+        {
+            Assert.True(File.Exists(IncludedTemplatePath), $"Missing template: {IncludedTemplatePath}");
+
+            var template = await File.ReadAllTextAsync(IncludedTemplatePath);
+            const string syntheticSvg = @"<svg xmlns=""http://www.w3.org/2000/svg"" width=""400"" height=""200"">
+  <rect x=""10"" y=""10"" width=""380"" height=""180"" fill=""#f0f0f0""/>
+</svg>";
+
+            var wrapperHtml = MindMapHtmlWrapper.FormatWrapper(template, "synthetic.svg", syntheticSvg);
+            var wrapperPath = Path.Combine(_tempDir, "zoom_clamp_test.html");
+            await File.WriteAllTextAsync(wrapperPath, wrapperHtml);
+
+            var page = await _browser.NewPageAsync();
+            await page.GotoAsync("file:///" + wrapperPath.Replace('\\', '/'));
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            // Zoom out 20 times (should clamp at 0.2, not go to 0 or negative)
+            for (int i = 0; i < 20; i++)
+            {
+                await page.Keyboard.PressAsync("-");
+            }
+            var afterMinClamp = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"After 20 zoom-outs: '{afterMinClamp}'");
+            Assert.Contains("scale(0.2)", afterMinClamp);
+
+            // Zoom in 60 times (should clamp at 5, not go higher)
+            for (int i = 0; i < 60; i++)
+            {
+                await page.Keyboard.PressAsync("+");
+            }
+            var afterMaxClamp = await page.Locator("#mindmap").EvaluateAsync<string?>("el => el.style.transform");
+            _output.WriteLine($"After 60 zoom-ins: '{afterMaxClamp}'");
+            Assert.Contains("scale(5)", afterMaxClamp);
+
+            await page.CloseAsync();
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- Add **mouse wheel zoom** (scroll up/down) with clamping (0.2x–5x)
- Add **pan via click-drag** with grab/grabbing cursor feedback
- Add **pinch-to-zoom** for touch devices (2-finger gesture)
- Remove unused `.zoom-in`/`.zoom-out` CSS classes
- Replace `transition: transform 0.3s` (janky animated zoom) with `transition: none` (instant response)
- Change `transform-origin: top left` → `0 0` for correct pan+zoom composition

### Files changed
- 2 source templates: `included.html`, `external.html`
- 16 generated files: `{fr,en,ru,pt}/×{Fallacies,Virtues}{,_ext}.html`

### Keyboard zoom preserved
Existing `+`/`-` key zoom still works — unchanged behavior, now clamped.

Closes #312

## Test plan
- [x] 19/20 MindMap unit tests pass (1 skip: Freeplane GUI, requires interactive)
- [x] Both source templates updated identically (JS + CSS)
- [x] All 16 generated files contain new zoom code
- [ ] Manual verification: open a generated HTML in browser, test wheel zoom, drag pan, keyboard +/- 

🤖 Generated with [Claude Code](https://claude.com/claude-code)