### PR TITLE
docs(claude-md): correct stale Scenarii i18n + Fallacies dup-PK status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,7 +464,7 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 10. ~~#211 — Retraduction PT Rules~~ ✅ DONE (closed 2026-05-17), Rules PT 100% sauf row 1 cover (fix PR #306 cycle 47)
 11. #212 — Playwright visual regression tests pour PDFs générés
 12. ~~Virtues i18n — ajouter colonnes _en/_ru/_pt~~ ✅ DONE (April-May 2026, PRs #218/#236/#246/#290/#295) — 100% coverage title/description/remark
-13. Scenarii EN/RU/PT — 76/167 records missing (~46%), Phase 1 EN run via gpt-5.5 (post smoke test cycle 61bis)
+13. ~~Scenarii EN/RU/PT — 76/167 records missing (~46%)~~ ✅ DONE — 167/167 records 100% covered EN/RU/PT (verified cell-by-cell on master `7206f2f9`, 2026-05-24) across all 8 translatable fields; filled via commits `7ed970a3` (EN), `2a1b86bf` (RU), `0dc838fb` (PT) + contamination/BOM fixes
 14. #134 — GitHub Release v0.9.0 (en attente validation docs)
 15. #133 — Publication OWL
 16. #131/#132 — DNN site + déploiement
@@ -488,8 +488,8 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 
 | Issue | Description | Status |
 | ------- | ----------- | ------ |
-| Fallacies duplicate PKs 520, 1000 | Warning surfaces during GSheet sync | Needs upstream fix |
-| Scenarii 54% translated | 76/167 records missing EN/RU/PT (title/context/issue) | Pipeline run via gpt-5.5 (smoke test cycle 61bis in progress) |
+| ~~Fallacies duplicate PKs 520, 1000~~ | Was reported during GSheet sync; **not reproducible on master** — 1408/1408 PKs unique, PK 520 & 1000 appear once each (verified `7206f2f9`, 2026-05-24). Stale warning or GSheet-view artefact | ✅ N/A |
+| ~~Scenarii 54% translated~~ | 167/167 records now 100% covered EN/RU/PT, all 8 fields; substantive fields (context/issue) 0% FR-contaminated, RU 165/167 Cyrillic. Title=FR overlaps (21 EN/11 PT) = legitimate proper nouns (Sherlock, Jeanne d'Arc, Ergo sum…). Verified `7206f2f9`, 2026-05-24 | ✅ DONE |
 | ~~Virtues 0% translated~~ | ✅ Resolved via PRs #218, #236, #246, #290, #295 (April-May 2026) — 100% coverage title/description/remark × 4 languages | DONE |
 | PT Rules row 1 EN contamination | Rules cover showed "Liars 'School" instead of "A Escola dos Mentirosos" | ✅ Fix PR #306 cycle 47 (1 cell CSV, native PT validated po-2023) |
 


### PR DESCRIPTION
## Summary
Two status claims in `CLAUDE.md` were obsolete on master `7206f2f9`. Verified read-only (Python + git, no LLM, no merge) on 2026-05-24:

| Claim (old) | Reality (verified) |
|---|---|
| Scenarii EN/RU/PT 54% — 76/167 missing | **167/167 records 100% covered** across all 8 translatable fields. `context`/`issue` 0% FR-contaminated; RU 165/167 Cyrillic. The 21 EN / 11 PT `title==FR` overlaps are legitimate proper nouns (Sherlock, Jeanne d'Arc, Ergo sum, Star Wars…). Filled via `7ed970a3` (EN), `2a1b86bf` (RU), `0dc838fb` (PT) + contamination/BOM fixes. |
| Fallacies duplicate PKs 520, 1000 — needs upstream fix | **Not reproducible** — 1408/1408 PKs unique; PK 520 & 1000 each appear once. Stale warning or GSheet-view artefact. |

## Why
Same 'CLAUDE.md obsolete on translation state' pattern already corrected for Virtues and Fallacies. Leaving these stale risks a future agent (or po-2023) re-dispatching a phantom Scenarii translation campaign. This confirms the **remaining CSV backlog = exactly the 40-PK Fallacies desc EN/RU/PT drift re-alignment** (#351 ×27 + #308 ×13), nothing in Scenarii.

## Scope
Doc-only (`CLAUDE.md`, 3 lines). No code, no pipeline, no regen impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)