### PR TITLE
fix(i18n): complete _fr. class substitution for AR/FA/ZH

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -222,7 +222,7 @@ namespace Argumentum.AssetConverter
 						nameof(DocumentConfig.DocumentName)
 					}),
 					StaticConversions = new List<(string sourceText, List<(string Language, string destText)> textConversions)>(new[]{
-						("_fr.", new List<(string Language, string destText)>(new []{("en", "_en."), ("ru", "_ru."), ("pt", "_pt."), ("es", "_es.") }) )
+						("_fr.", new List<(string Language, string destText)>(new []{("en", "_en."), ("ru", "_ru."), ("pt", "_pt."), ("es", "_es."), ("ar", "_ar."), ("fa", "_fa."), ("zh", "_zh.") }) )
 					}),
 				}
 			})


### PR DESCRIPTION
## Summary

Add missing `("ar", "_ar."), ("fa", "_fa."), ("zh", "_zh.")` tuples to `StaticConversions` in `AssetConverterConfig.cs`.

Without this fix, CSS class `desc_fr` was not rewritten to `desc_ar`/`desc_fa`/`desc_zh` during localized rendering, causing RTL/CJK CSS rules to never match Arabic/Farsi/Chinese content.

Identified by ai-01 during PR #359 review (Gap 1).

## Test plan
- [x] Build: 0 errors

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>