### PR TITLE
feat(i18n): add DatasetUpdater tasks for Rules AR/ES/FA/ZH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,10 @@ _ref_preview/
 # Claude Code session artifacts in subdirectories (not root .claude/)
 Generation/**/.claude/
 .keys/
+
+# Local ai-01 cycle scratch directories (specs, drafts, logs, screenshots)
+/cycle*/
+/MASTER-INDEX.md
+/cycle*.jpeg
+/cycle*.png
+/title_repro_shot.png

--- a/Cards/Rules/Argumentum Rules - Cards.csv
+++ b/Cards/Rules/Argumentum Rules - Cards.csv
@@ -3,7 +3,11 @@ Rules_01,"# Argumentum
 ## L'école des menteurs","# Argumentum
 ## The school of liars","# Argumentum
 ## Школа лжецов","# Argumentum
-## A Escola dos Mentirosos",,,,,
+## A Escola dos Mentirosos",,"# Argumentum
+## مدرسة الكاذبين","# Argumentum
+## La escuela de los mentirosos","# Argumentum
+## 说谎者学校","# Argumentum
+## مدرسهٔ دروغ‌پردازان"
 Rules_02,"*Règles du jeu : de 4 à 8 joueurs*
 
 ## Matériel
@@ -56,7 +60,59 @@ Argumentum is based on a classification of fallacious arguments, arranged in ord
 
 Os jogadores, por sua vez, tentarão adivinhar um cartão de argumento falacioso com a maioria dos outros jogadores, durante um SayNet de improvisação de um cenário aleatório. Enquanto se divertem, os jogadores aprendem a reconhecer, decodificar e, portanto, desconstruir os argumentos falaciosos.
 
-Argumentum é baseado na classificação desses argumentos falaciosos, organizados em ordens e famílias que são indicadas no topo do mapa. Por exemplo, a Flatterie é uma sub -categoria da chamada para emoções. Os cartões de memorando resumem essa classificação.",,,,,
+Argumentum é baseado na classificação desses argumentos falaciosos, organizados em ordens e famílias que são indicadas no topo do mapa. Por exemplo, a Flatterie é uma sub -categoria da chamada para emoções. Os cartões de memorando resumem essa classificação.",,"*قواعد اللعبة: من 4 إلى 8 لاعبين*
+
+## المواد
+
+* رزمة واحدة من بطاقات الحجج المغلوطة منظَّمة في 7 فئات لونية، موزعة كل منها إلى 3 رتب ثم إلى 3 عائلات.
+* رزمة واحدة من بطاقات السيناريو منظَّمة في 7 موضوعات يمكن تمييزها من ظهرها
+* 5 بطاقات تذكير
+* قواعد اللعبة
+   
+## ملخص اللعبة
+
+يتناوب اللاعبون على محاولة جعل أغلبية اللاعبين الآخرين تخمّن بطاقةً من بطاقات الحجج المغلوطة، وذلك خلال مشهد تمثيلي مرتجل انطلاقًا من سيناريو يُسحب عشوائيًا. وبذلك، يتعلم اللاعبون في الوقت نفسه، وبطريقة ممتعة، كيف يتعرّفون على الحجج المغلوطة ويفكون شيفرتها، ومن ثم يفككونها.
+
+يرتكز Argumentum على تصنيف لهذه الحجج المغلوطة، مرتبة في رتب وعائلات، ويُشار إليها في أعلى البطاقة. فمثلًا، يُعدّ التملق فئةً فرعية من النداء إلى العواطف. وتلخّص بطاقات التذكير هذا التصنيف.","*Reglas del juego: de 4 a 8 jugadores*
+
+## Material
+
+* 1 mazo de cartas de argumento falaz organizadas en 7 clases de colores, cada una dividida en 3 órdenes y luego en 3 familias.
+* 1 mazo de cartas de escenario organizadas en 7 temas identificables en el dorso
+* 5 cartas recordatorio
+* Reglas del juego
+   
+## Resumen del juego
+
+Los jugadores, por turnos, intentan hacer adivinar una carta de argumento falaz a la mayoría de los demás jugadores, durante una pequeña escena de improvisación a partir de un escenario elegido al azar. Mientras se divierten, los jugadores aprenden así a reconocer, descifrar y, por tanto, desmontar los argumentos falaces.
+
+Argumentum se apoya en una clasificación de estos argumentos falaces, ordenados en órdenes y familias, que se indican en la parte superior de la carta. Por ejemplo, la adulación es una subcategoría de la apelación a las emociones. Las cartas recordatorio resumen esta clasificación.","*游戏规则：4至8名玩家*
+
+## 材料
+
+* 1副诡辩卡牌，按7种颜色类别组织，每种再分为3个阶层，再分为3个家族。
+* 1副情景卡牌，按7个主题组织，背面可识别
+* 5张提示卡
+* 游戏规则
+   
+## 游戏概述
+
+玩家将轮流在一段即兴小剧中，利用随机抽取的情景，设法让多数其他玩家猜出一张诡辩卡。这样一边玩，一边学习如何识别、解读，从而拆解诡辩。
+
+Argumentum 依据对这些诡辩的分类体系，将它们按阶层和家族归类，并标注在卡牌顶部。例如，“奉承”是“诉诸情绪”的一个子类别。提示卡对这一分类作了摘要。","*قوانین بازی: از ۴ تا ۸ بازیکن*
+
+## تجهیزات
+
+* ۱ دسته کارتِ استدلال‌های مغالطی که در ۷ ردهٔ رنگی سازمان‌دهی شده‌اند، و هر رده به ۳ مرتبه و سپس به ۳ خانواده تقسیم می‌شود.
+* ۱ دسته کارتِ سناریو که در ۷ مضمونِ قابل‌شناسایی از پشت سازمان‌دهی شده‌اند
+* ۵ کارتِ یادآور
+* قوانین بازی
+   
+## خلاصهٔ بازی
+
+بازیکنان به نوبت تلاش می‌کنند در خلال یک صحنه‌پردازیِ بداهه، و بر پایهٔ یک سناریوی تصادفی، یک کارتِ استدلالِ مغالطی را به اکثریتِ بازیکنانِ دیگر حدس‌زدنی کنند. بدین‌ترتیب، بازیکنان ضمن سرگرم شدن، یاد می‌گیرند این استدلال‌های مغالطی را تشخیص دهند، رمزگشایی کنند و در نتیجه از هم بگشایند.
+
+Argumentum بر طبقه‌بندیِ این استدلال‌های مغالطی تکیه دارد که بر حسب مرتبه‌ها و خانواده‌ها مرتب شده‌اند و در بالای کارت مشخص شده‌اند. برای نمونه، چاپلوسی زیرمجموعهٔ توسل به احساسات است. کارت‌های یادآور این طبقه‌بندی را به‌اختصار خلاصه می‌کنند."
 Rules_03,"## Installation
 
 Selon le nombre de joueurs et le niveau de difficulté voulu, on constitue la pioche des cartes d’arguments fallacieux en ajoutant les niveaux indiqués en bas à droite des cartes par ordre croissant. Il en faut au minimum 7 x le nombre de joueurs.
@@ -97,7 +153,39 @@ Escolhemos a duração do jogo. Isso inclui uma sucessão de rodadas de cerca de
 
 Constituímos 2 desenhos de cartões de cartão de cenário colocados no meio da mesa. Cada jogador é distribuído a 5 argumentos falaciosos que ele mantém para ele. O restante dos cartões constitui a reserva.
 
-Cada jogador tem um pequeno objeto único (moeda, feijão, etc.) para a votação. O primeiro puxador é quem primeiro se lembra de um argumento enganoso.",,,,,
+Cada jogador tem um pequeno objeto único (moeda, feijão, etc.) para a votação. O primeiro puxador é quem primeiro se lembra de um argumento enganoso.",,"## الإعداد
+
+بحسب عدد اللاعبين ومستوى الصعوبة المرغوب فيه، تُشكَّل رزمة سحب بطاقات الحجج المغلوطة بإضافة المستويات المشار إليها في أسفل يمين البطاقات تصاعديًا. ويلزم لذلك حدًّا أدنى قدره 7 × عدد اللاعبين.
+
+يُختار زمن اللعب. ويتألف هذا الزمن من تعاقب جولات مدتها نحو 7 دقائق. وعند انتهاء الوقت المخصص، تُستكمل الجولة الجارية، ويحرز اللاعب الذي جمع أكبر عدد من النقاط الفوزَ في اللعبة. وتُخلط بطاقات الحجج المغلوطة، وكذلك بطاقات السيناريو.
+
+تُشكَّل رُزمتان من بطاقات السيناريو وتوضعان في وسط الطاولة. ويُوزَّع على كل لاعب 5 بطاقات من بطاقات الحجج المغلوطة يحتفظ بها لنفسه. أما بقية البطاقات فتشكّل المخزون.
+
+يأخذ كل لاعب معه شيئًا صغيرًا مميزًا وفريدًا (عملة معدنية، حبة فاصوليا...) للتصويت. وأول من يسحب بطاقة هو أول من يتذكر حجةً خادعة.","## Preparación
+
+Según el número de jugadores y el nivel de dificultad deseado, se forma el mazo de cartas de argumentos falaces añadiendo los niveles indicados en la parte inferior derecha de las cartas por orden creciente. Se necesitan al menos 7 x el número de jugadores.
+
+Se decide la duración de la partida. Esta consta de una sucesión de rondas de unos 7 minutos. Al término del tiempo asignado, se termina la ronda en curso y el jugador con más puntos gana la partida. Se barajan las cartas de argumentos falaces, así como las cartas de escenario.
+
+Se forman 2 mazos de cartas de escenario colocados en el centro de la mesa. Se reparten a cada jugador 5 cartas de argumentos falaces que conserva para sí. El resto de las cartas constituye la reserva.
+
+Cada jugador se equipa con un pequeño objeto único (moneda, alubia...) para la votación. El primer jugador en robar es quien recuerde primero un argumento engañoso.","## 设置
+
+根据玩家人数和所需难度，通过按递增顺序加入右下角标示的等级，来构成谬误论证牌堆。所需数量至少为玩家人数的 7 倍。
+
+先决定对局时长。整局由一连串约 7 分钟的回合组成。时间一到，当前回合结束，得分最高的玩家获胜。谬误论证牌和情景牌都要洗匀。
+
+在桌子中央放置 2 堆情景牌。每位玩家发 5 张谬误论证牌，自己保留。其余牌作为备用牌堆。
+
+每位玩家准备一个独一无二的小物件（硬币、豆子等）用于投票。首位抽牌者是第一个想到某个误导性论证的人。","## آماده‌سازی
+
+بسته به تعداد بازیکنان و سطح دشواریِ موردنظر، دستهٔ کارت‌های استدلالِ مغالطی را با افزودنِ سطح‌هایی که در پایینِ سمت راستِ کارت‌ها مشخص شده‌اند، به ترتیبِ صعودی تشکیل می‌دهیم. حداقل به ۷ برابرِ تعدادِ بازیکنان کارت نیاز است.
+
+مدتِ بازی را انتخاب می‌کنیم. این بازی از رشته‌ای از دورهای حدوداً ۷ دقیقه‌ای تشکیل می‌شود. با پایانِ زمانِ تعیین‌شده، دورِ در جریان را به پایان می‌رسانیم و بازیکنی که بیشترین امتیاز را دارد برندهٔ بازی می‌شود. کارت‌های استدلالِ مغالطی و همچنین کارت‌های سناریو را بُر می‌زنیم.
+
+۲ دستهٔ کارتِ سناریو تشکیل می‌دهیم و آن‌ها را در وسطِ میز قرار می‌دهیم. به هر بازیکن ۵ کارتِ استدلالِ مغالطی می‌دهیم که نزدِ خود نگه می‌دارد. بقیهٔ کارت‌ها ذخیره را تشکیل می‌دهند.
+
+هر بازیکن یک شیء کوچک و یکتا برای رأی‌گیری همراه دارد (سکه، لوبیا، …). نخستین کشندهٔ کارت کسی است که زودتر از همه یک استدلالِ فریبنده را به یاد بیاورد."
 Rules_04,"## Déroulé de la manche
 
 ### 1.       Le piocheur
@@ -154,7 +242,63 @@ O papel de Embromador é designado para o primeiro jogador que posa, em frente a
 
 ### 3. SayNet
 
-O puxador inicia o debate como ele deseja. Ele pode retomar a sugestão de primeira réplica em itálico na parte inferior do cartão de cenário. O embromador e o puxador têm um minuto máximo para improvisar uma discussão durante a qual o embromador tentará usar o tipo de argumento indicado pelo cartão que ele escolheu.",,,,,
+O puxador inicia o debate como ele deseja. Ele pode retomar a sugestão de primeira réplica em itálico na parte inferior do cartão de cenário. O embromador e o puxador têm um minuto máximo para improvisar uma discussão durante a qual o embromador tentará usar o tipo de argumento indicado pelo cartão que ele escolheu.",,"## سير الجولة
+
+### 1.       الساحب
+
+يسحب الساحب بطاقة سيناريو من بين مجموعتي السحب المتاحتين ويقرأها بصوت عالٍ، باستثناء الجملة الأخيرة المكتوبة بالخط المائل في أسفل البطاقة.
+
+### 2.       المراوغ
+
+يتولى المراوغ قيادة المحاججة حول السيناريو، لتجسيد إحدى بطاقات الحُجج المغلوطة لديه. وهدفه أن يجعل أغلبية اللاعبين الآخرين تخمّن هذه البطاقة.
+
+يُسنَد دور المراوغ إلى أول لاعب يضع، مقلوبًا ومخفيًا، بطاقة الحجة المغلوطة التي يعتزم لعبها. وإلا، فإن اللاعب الذي يجلس إلى يسار الساحب يُعيَّن مراوغًا ويضع بطاقته.
+
+### 3.       المشهد التمثيلي
+
+يفتتح الساحب النقاش بالطريقة التي يشاء. ويمكنه أن يستند إلى اقتراح الجملة الأولى المكتوبة بالخط المائل في أسفل بطاقة السيناريو. ثم يُتاح للمراوغ والساحب حدٌّ أقصى قدره دقيقة واحدة لارتجال حوار، يسعى خلاله المراوغ إلى استخدام نوع الحجة المشار إليه في البطاقة التي اختارها. ","## Desarrollo de la ronda
+
+### 1.       El robador
+
+El robador saca una carta de escenario de entre los dos mazos disponibles y la lee en voz alta, salvo la última frase en cursiva en la parte inferior de la carta.
+
+### 2.       El embromador
+
+El embromador será el encargado de conducir la argumentación del escenario, para ilustrar una de sus cartas de argumento falaz. Su objetivo será hacer adivinar esa carta a la mayoría de los demás jugadores.
+
+El papel de embromador se asigna al primer jugador que coloca, boca abajo, la carta de argumento falaz que piensa jugar. En su defecto, el jugador a la izquierda del robador es designado embromador y coloca su carta.
+
+### 3.       La escena
+
+El robador inicia el debate como quiera. Puede retomar la sugerencia de primera réplica en cursiva al final de la carta de escenario. El embromador y el robador disponen entonces de un máximo de un minuto para improvisar una conversación durante la cual el embromador tratará de utilizar el tipo de argumento indicado por la carta que ha elegido. ","## 本轮流程
+
+### 1.       抽牌者
+
+抽牌者从两个可用牌堆中抽取一张情景牌，并大声朗读，除了牌面底部斜体字的最后一句。
+
+### 2.       扯皮者
+
+扯皮者负责推动该情景的论辩，用来演绎自己的一张诡辩牌。其目标是让多数其他玩家猜出这张牌。
+
+扯皮者这一角色由第一个将自己打算使用的诡辩牌面朝下放出的玩家担任。若无人这样做，则由抽牌者左侧的玩家指定为扯皮者，并放出自己的牌。
+
+### 3.       即兴短剧
+
+抽牌者按自己想要的方式引出辩论，也可以直接采用情景牌底部斜体字中的第一句台词建议。随后，扯皮者和抽牌者最多有一分钟时间即兴对话，在此期间扯皮者要尽量使用其所选牌面所示的论证类型。 ","## روند دور
+
+### 1.       کارت‌کش
+
+کارت‌کش یک کارت سناریو را از میان دو دسته‌ی موجود برمی‌دارد و با صدای بلند می‌خواند، به‌استثنای جمله‌ی پایانیِ مورب در پایین کارت.
+
+### 2.       منصرف‌کننده
+
+منصرف‌کننده مسئول پیش بردن استدلالِ سناریو خواهد بود تا یکی از کارت‌های استدلالِ مغالطه‌آمیز خود را به تصویر بکشد. هدف او این است که این کارت را برای اکثریتِ بازیکنان دیگر قابل حدس کند.
+
+نقشِ منصرف‌کننده به نخستین بازیکنی داده می‌شود که کارتِ استدلالِ مغالطه‌آمیزِ مورد نظرش را به‌صورتِ رو به پایین می‌گذارد. در غیر این صورت، بازیکنِ سمت چپِ کارت‌کش به‌عنوان منصرف‌کننده تعیین می‌شود و کارت خود را می‌گذارد.
+
+### 3.       نمایش کوتاه
+
+کارت‌کش بحث را هرطور که بخواهد آغاز می‌کند. او می‌تواند پیشنهادِ نخستین جمله‌ی مورب در پایینِ کارت سناریو را تکرار کند. سپس منصرف‌کننده و کارت‌کش حداکثر یک دقیقه فرصت دارند تا گفت‌وگویی بداهه اجرا کنند؛ در این مدت، منصرف‌کننده تلاش می‌کند از نوع استدلالی که کارتِ انتخابی‌اش مشخص کرده استفاده کند."
 Rules_05,"Le embromador expose ses arguments et le piocheur lui donne la réplique sans chercher à dominer la scène. Le embromador peut choisir d’écourter la saynète quand il le souhaite.
 
 ### 4.       Le jury
@@ -207,7 +351,59 @@ Quando o júri estiver pronto, sem consulta, cada um de seus membros designa sim
 ### 5. A contagem
 
 O vencedor do canal é aquele cujo cartão obteve o maior número de votos, embromador ou membro do júri (🥇👇👇… ➜).
-Ele então mantém seu cartão, que vale 1 ponto e o rosto visível e deitado na frente dele.",,,,,
+Ele então mantém seu cartão, que vale 1 ponto e o rosto visível e deitado na frente dele.",,"المراوغ يَعرِض حججه، ويُعارِضه الساحب من دون أن يسعى إلى السيطرة على المشهد. ويجوز للمراوغ أن يختصر المشهد متى شاء.
+
+### 4.       هيئة المحلّفين
+
+جميع اللاعبين باستثناء المراوغ، بما في ذلك الساحب، يشكّلون هيئة المحلّفين. في نهاية المشهد، يختار كل محلف من بين بطاقاته الخاصة البطاقة التي تقترب أكثر ما يكون من المحاججة التي سمعها، ويضعها مقلوبةً مع بطاقة المراوغ. وعند 3 أو 4 لاعبين، يختار المحلفون بطاقتين.
+
+يجمع المراوغ البطاقات، ويخلطها ثم يكشفها في وسط الطاولة. يطّلع المحلفون على البطاقات المكشوفة، ويمكن لأحد المحلفين أن يتلوها بصوت عالٍ. ويرفع كل واحد من المحلفين إصبعه للدلالة على أنه مستعد للتصويت.
+
+عندما تكون هيئة المحلّفين مستعدة، ومن دون تشاور، يعيّن كل عضو فيها في الوقت نفسه البطاقة التي يظن أنها كانت هي البطاقة التي لعبها المراوغ، وذلك بوضع غرضه الصغير المميز عليها (أو، عند عدم توافره، بوضع إصبعه عليها).
+
+### 5.       احتساب النقاط
+
+الفائز بالجولة هو صاحب البطاقة التي نالت أكبر عدد من الأصوات، سواء كان المراوغ أو أحد أعضاء هيئة المحلّفين (🥇👇👇…➜🏆). 
+وعندئذٍ يحتفظ ببطاقته التي تساوي نقطة واحدة، ويضعها أمامه مكشوفة.","El embromador expone sus argumentos y el robador le responde sin intentar monopolizar la escena. El embromador puede optar por acortar la escena cuando quiera.
+
+### 4.       El jurado
+
+Todos los jugadores, salvo el embromador, pero incluido el robador, constituyen el jurado. Al final de la escena, cada jurado elige entre sus propias cartas aquella que mejor se acerca a la argumentación escuchada y la coloca boca abajo junto con la del embromador. A 3 o 4 jugadores, los jurados eligen 2 cartas.
+
+El embromador recoge las cartas, las mezcla y las revela en el centro de la mesa. Los jurados toman conocimiento de las cartas reveladas; un jurado puede leerlas en voz alta. Cada uno de los jurados levanta el dedo para indicar cuándo está listo para votar.
+
+Cuando el jurado esté listo, sin ponerse de acuerdo, cada uno de sus miembros señala simultáneamente la carta que cree que ha sido jugada por el embromador, colocando sobre ella su pequeño objeto único (o, en su defecto, poniendo el dedo).
+
+### 5.       El recuento
+
+El vencedor de la ronda es aquel cuya carta haya obtenido el mayor número de votos, embromador o miembro del jurado (🥇👇👇…➜🏆). 
+Entonces se queda con su carta, que vale 1 punto, y la coloca boca arriba delante de él.","扯皮者陈述自己的论点，抽牌者则与之接话，但不刻意争夺舞台主导权。扯皮者可以在任何时候选择提前结束短剧。
+
+### 4.       评审团
+
+除扯皮者外的所有玩家（包括抽牌者）都构成评审团。短剧结束时，每位评审从自己的手牌中选出一张最接近刚才听到的论证的牌，并与扯皮者的牌一起面朝下放出。若为 3 人或 4 人游戏，评审需选择 2 张牌。
+
+扯皮者收起这些牌，洗混后将它们翻开，放在桌子中央。评审们先查看这些公开的牌，也可以由其中一位评审大声读出。每位评审在准备好投票时举手示意。
+
+当评审团准备就绪后，无需商量，每位成员同时指出自己认为是扯皮者打出的那张牌，并把自己的小独特物件放在该牌上（或者在无法使用物件时，用手指指向它）。
+
+### 5.       计分
+
+本轮获胜者是其牌获得最多票数的人，无论是扯皮者还是评审团成员（🥇👇👇…➜🏆）。
+然后他保留这张牌，计 1 分，并将其正面朝上放在自己面前。","منصرف‌کننده استدلال‌هایش را مطرح می‌کند و کارت‌کش بدون آن‌که بخواهد صحنه را در اختیار بگیرد به او پاسخ می‌دهد. منصرف‌کننده می‌تواند هر زمان که بخواهد نمایش کوتاه را زودتر تمام کند.
+
+### 4.       هیئت داوران
+
+همه‌ی بازیکنان به‌جز منصرف‌کننده، اما از جمله کارت‌کش، هیئت داوران را تشکیل می‌دهند. در پایانِ نمایش کوتاه، هر داور از میان کارت‌های خودش کارتی را برمی‌گزیند که بیشترین نزدیکی را به استدلال شنیده‌شده دارد و آن را همراه با کارتِ منصرف‌کننده به‌صورت رو به پایین می‌گذارد. در بازیِ 3 یا 4 نفره، داوران 2 کارت برمی‌گزینند.
+
+منصرف‌کننده کارت‌ها را جمع می‌کند، آن‌ها را مخلوط می‌کند و در وسط میز رو می‌کند. داوران کارت‌های رو شده را بررسی می‌کنند؛ یک داور می‌تواند آن‌ها را با صدای بلند بخواند. هر یک از داوران برای اعلام آمادگیِ خود برای رأی‌دادن، انگشتش را بالا می‌برد.
+
+وقتی هیئت داوران آماده شد، بدون هیچ مشورتی، هر یک از اعضا هم‌زمان کارتی را که فکر می‌کند توسط منصرف‌کننده بازی شده است با گذاشتنِ شیء کوچکِ منحصربه‌فردِ خود روی آن مشخص می‌کند (یا در صورت نبودِ آن، با گذاشتنِ انگشت).
+
+### 5.       شمارش امتیاز
+
+برنده‌ی دور کسی است که کارتش بیشترین تعداد رأی را به‌دست آورده باشد، چه منصرف‌کننده باشد چه یکی از اعضای هیئت داوران (🥇👇👇…➜🏆). 
+سپس کارت خود را نگه می‌دارد؛ این کارت 1 امتیاز دارد و آن را به‌صورت رو به رو جلوی خود می‌گذارد."
 Rules_06,"En cas d’égalité (🥈👇👇≟🥈👇👇), le embromador l'emporte (✅🎭➜🎭🏆), et à défaut (❌🎭), les jurés plébiscités qui ont trouvé la carte du embromador sont tous déclarés vainqueurs (✅👇🎭➜👇🏆). Si aucun des jurés concernés ne l'a trouvée, c'est le embromador qui l’emporte (❌👇🎭➜🎭🏆).
 
 ### 6.       Les pioches
@@ -280,12 +476,96 @@ Depois que o vencedor for designado, os jogadores desenham uma série de cartas 
 * Picher tem o direito de designar diretamente o embromador do canal.
 * Se o puxador vencer, ele também vence o cartão Embromador.
 * O embromador pode definir vários cartões. Muitos vencedores de votação são declarados, o Embromador que pode ganhar todas ou parte de suas cartas.
-* O vencedor do jogo deve incorporar o embromador de um cenário final, onde ele deve colocar em jogo todas as cartas que ganhou durante o jogo.",,,,,
+* O vencedor do jogo deve incorporar o embromador de um cenário final, onde ele deve colocar em jogo todas as cartas que ganhou durante o jogo.",,"في حال التعادل (🥈👇👇≟🥈👇👇)، يفوز المراوغ (✅🎭➜🎭🏆)، وإذا لم يحدث ذلك (❌🎭)، فإن المحلفين الذين أصابوا واختاروا بطاقة المراوغ يُعلَنون جميعًا فائزين (✅👇🎭➜👇🏆). وإذا لم يعثر أيٌّ من المحلفين المعنيين عليها، يفوز المراوغ (❌👇🎭➜🎭🏆).
+
+### 6.       السحوبات
+
+بعد تحديد الفائز، يسحب اللاعبون من الرصيد عددًا معينًا من البطاقات:
+
+* الفائز بالجولة لا يسحب بطاقة جديدة. (✅🏆➜❌0🎴)
+* جميع اللاعبين الآخرين يسحبون بطاقة واحدة (❌🏆➜✅1🎴)، أو بطاقتين عند 3 أو 4 لاعبين
+* أعضاء هيئة المحلّفين الذين حصلوا على أصوات يسحبون بطاقة إضافية (✅🧲👇➜✅ 1🎴)
+* المحلفون الذين وجدوا بطاقة المراوغ يسحبون بطاقة إضافية (✅👇🎭➜✅ 1🎴)
+* تُعاد البطاقات التي استُخدمت إلى الرصيد.
+* يصبح الجار الأيسر للفائز هو الساحب في الجولة التالية.
+
+## بدائل:
+
+*إذا حدّدت هيئة المحلّفين بأكملها بطاقة المراوغ، فإنه لا يفوز بالجولة، ويسحب كل لاعب بطاقة من الرصيد باستثناء المراوغ.
+* خلال المشهد، يمكن لأي عضو من هيئة المحلّفين أن يستخدم بطاقة من يده للتدخل في دور الساحب. فإذا جسّد تدخّله بطاقته على نحو جيّد، يسحب بطاقة أخرى ويُعيَّن الساحب التالي، وإلا خسر بطاقته واستمرّت اللعبة من حيث توقفت.
+* يحقّ للساحب أن يعيّن مباشرةً المراوغ الخاص بالجولة.
+* إذا فاز الساحب، فإنه يفوز أيضًا ببطاقة المراوغ.
+* يجوز للمراوغ أن يضع عدة بطاقات. ويُعلَن عدد من الفائزين يساوي عدد الأصوات، وقد يفوز المراوغ بكل بطاقاته أو ببعضها.
+* يجب على الفائز باللعبة أن يتقمّص دور المراوغ في سيناريو أخير، حيث يتعيّن عليه إخراج جميع البطاقات التي ربحها خلال اللعبة.","En caso de empate (🥈👇👇≟🥈👇👇), gana el embromador (✅🎭➜🎭🏆), y en su defecto (❌🎭), los jurados mayoritarios que hayan encontrado la carta del embromador son declarados vencedores todos ellos (✅👇🎭➜👇🏆). Si ninguno de los jurados implicados la ha encontrado, es el embromador quien gana (❌👇🎭➜🎭🏆).
+
+### 6.       Los mazos
+
+Una vez designado el vencedor, los jugadores roban de la reserva un cierto número de cartas:
+
+* El vencedor de la ronda no roba ninguna carta nueva. (✅🏆➜❌0🎴)
+* Todos los demás jugadores roban una carta (❌🏆➜✅1🎴), o 2 cartas a 3 o 4 jugadores
+* Los miembros del jurado que hayan obtenido votos roban una carta más (✅🧲👇➜✅ 1🎴)
+* Los jurados que hayan encontrado la carta del embromador roban una carta más (✅👇🎭➜✅ 1🎴)
+* Las cartas jugadas se devuelven a la reserva.
+* El vecino de la izquierda del vencedor se convierte en el robador de la siguiente ronda.
+
+## Variantes :
+
+*Si la carta del embromador es señalada por todo el jurado, no gana la ronda, cada uno roba una carta de la reserva salvo el embromador.
+* Durante la escena, cualquier miembro del jurado puede usar una carta de su mano para intervenir en el papel del robador. Si su intervención ilustra bien su carta, roba otra y será designado el siguiente robador; si no, pierde su carta y la partida reanuda su curso.
+* El robador tiene derecho a designar directamente al embromador de la ronda.
+* Si gana el robador, también se lleva la carta del embromador.
+* El embromador puede jugar varias cartas. Se declaran tantos vencedores como votos haya; el embromador puede llevarse todas o parte de sus cartas.
+* El vencedor de la partida deberá encarnar al embromador de un último escenario en el que tendrá que poner en juego todas las cartas que haya ganado durante la partida.","若出现平票（🥈👇👇≟🥈👇👇），则扯皮者获胜（✅🎭➜🎭🏆）；若非如此（❌🎭），所有猜中扯皮者牌面的中选评审都被宣布为获胜者（✅👇🎭➜👇🏆）。如果相关评审中没有人猜中，则由扯皮者获胜（❌👇🎭➜🎭🏆）。
+
+### 6.       补牌
+
+一旦获胜者确定，玩家便从牌库中抽取若干张牌:
+
+* 本轮获胜者不抽新牌。 (✅🏆➜❌0🎴)
+* 其他所有玩家抽 1 张牌（❌🏆➜✅1🎴），或在 3 人或 4 人游戏中抽 2 张牌
+* 获得投票的评审团成员额外抽 1 张牌（✅🧲👇➜✅ 1🎴)
+* 猜中扯皮者牌面的评审额外抽 1 张牌（✅👇🎭➜✅ 1🎴)
+* 已打出的牌放回牌库。
+* 获胜者左侧的邻座成为下一轮的抽牌者。
+
+## 变体：
+
+*如果全体评审都指认出扯皮者的牌，则他不能赢得本轮，除扯皮者外每位玩家都从牌库抽 1 张牌。
+* 在短剧进行过程中，评审团中的任何成员都可以打出自己手牌中的一张牌，以抽牌者的身份插话。如果他的插话确实很好地体现了该牌内容，他就再抽 1 张牌，并成为下一位抽牌者；否则，他失去这张牌，游戏继续进行。
+* 抽牌者有权直接指定本轮的扯皮者。
+* 如果抽牌者获胜，他也会赢得扯皮者的牌。
+* 扯皮者可以打出多张牌。会按照获得投票的数量宣布相应数量的获胜者，扯皮者可以赢走自己全部或部分牌。
+* 本局最终胜者必须扮演终极情景中的扯皮者，在该情景中他必须打出自己整局游戏中赢得的所有牌。","در صورت تساوی (🥈👇👇≟🥈👇👇)، منصرف‌کننده برنده می‌شود (✅🎭➜🎭🏆)، و در غیر این صورت (❌🎭)، داورانِ مورد اقبال که کارتِ منصرف‌کننده را درست حدس زده‌اند همگی برنده اعلام می‌شوند (✅👇🎭➜👇🏆). اگر هیچ‌یک از داورانِ مربوطه آن را درست حدس نزده باشند، برنده منصرف‌کننده است (❌👇🎭➜🎭🏆).
+
+### 6.       دسته‌ها
+
+پس از تعیین برنده، بازیکنان از ذخیره به تعداد مشخصی کارت برمی‌دارند:
+
+* برنده‌ی دور کارت جدیدی برنمی‌دارد. (✅🏆➜❌0🎴)
+* همه‌ی بازیکنان دیگر یک کارت برمی‌دارند (❌🏆➜✅1🎴)، یا در بازیِ 3 یا 4 نفره 2 کارت
+* اعضای هیئت داورانی که رأی گرفته‌اند یک کارتِ اضافه برمی‌دارند (✅🧲👇➜✅ 1🎴)
+* داورانی که کارتِ منصرف‌کننده را درست حدس زده‌اند یک کارتِ اضافه برمی‌دارند (✅👇🎭➜✅ 1🎴)
+* کارت‌های بازی‌شده به ذخیره بازگردانده می‌شوند.
+* همسایه‌ی سمت چپِ برنده، کارت‌کشِ دور بعدی می‌شود.
+
+## گونه‌ها:
+
+*اگر کارتِ منصرف‌کننده به‌وسیله‌ی همه‌ی هیئت داوران تشخیص داده شود، او دور را نمی‌برد و همه به‌جز منصرف‌کننده یک کارت از ذخیره برمی‌دارند.
+* در طولِ نمایش کوتاه، هر عضو هیئت داوران می‌تواند از کارت‌های خود استفاده کند و در نقشِ کارت‌کش وارد بحث شود. اگر مداخله‌اش کارتِ خودش را خوب نشان دهد، یک کارت دیگر می‌کشد و به‌عنوان کارت‌کشِ بعدی تعیین می‌شود؛ در غیر این صورت، کارت خود را از دست می‌دهد و بازی از سر گرفته می‌شود.
+* کارت‌کش حق دارد مستقیماً منصرف‌کننده‌ی دور را تعیین کند.
+* اگر کارت‌کش برنده شود، کارتِ منصرف‌کننده را هم می‌برد.
+* منصرف‌کننده می‌تواند چند کارت بگذارد. به تعدادِ رأی‌ها، چند برنده اعلام می‌شوند و منصرف‌کننده می‌تواند همه یا بخشی از کارت‌هایش را ببرد.
+* برنده‌ی بازی باید در نقشِ منصرف‌کننده‌ی یک سناریوی نهایی ظاهر شود که در آن باید همه‌ی کارت‌هایی را که طی بازی به‌دست آورده، به میدان بیاورد."
 Rules_07,"# Argumentum
 ## Le Bingo mixologie argumentative","# Argumentum
 ## The school of liars","# Argumentum
 ## Школа лжецов","# Argumentum
-## a mixologia de bingo argumentativa",,,,,
+## a mixologia de bingo argumentativa",,"# Argumentum
+## بينغو الخلط البلاغي الحِجاجي","# Argumentum
+## El bingo de la mixología argumentativa","# Argumentum
+## 论证式酒吧宾果","# Argumentum
+## بینگوِ استدلال‌های مغالطه‌آمیز"
 Rules_08,"*Règles du jeu :  de 1 à 20 joueurs*
 
 ## Matériel
@@ -354,7 +634,75 @@ Sob os termos do debate, o jogador que viu o maior número de argumentos falacio
 ## Instalação
 
 Dividimos aleatoriamente todos os argumentos falaciosos disponíveis entre todos os jogadores, até 10 cartas por pessoa.
-Cada jogador obtém nota de suas cartas, garantindo -as que eles tenham em mente e se estabelecem para participar do debate.",,,,,
+Cada jogador obtém nota de suas cartas, garantindo -as que eles tenham em mente e se estabelecem para participar do debate.",,"*قواعد اللعبة: من 1 إلى 20 لاعبًا*
+
+## المواد
+
+* مناظرة واحدة أو خطاب واحد سيحضره اللاعبون معًا ويمكن إعادة مشاهدته.
+* ما يلزم لتدوين الملاحظات، ووسيلة لتسجيل الزمن المنقضي منذ بداية المناظرة.
+* مجموعة واحدة أو أكثر من بطاقات الحجج المغلوطة
+
+   
+## ملخص اللعبة
+
+مسلحين بشبكة بينغو تتكوّن من بطاقات الحجج المغلوطة المسحوبة عشوائيًا، سيحاول اللاعبون رصد البطاقات المصوَّرة المطابقة لها أثناء المناظرة. 
+في ختام المناظرة، يفوز اللاعب الذي يكون قد رصد أكبر عدد من الحجج المغلوطة، بعد اعتماد ذلك من أغلبية اللاعبين الآخرين.
+
+## الإعداد
+
+تُقسَّم عشوائيًا جميع بطاقات الحجج المغلوطة المتاحة بين اللاعبين جميعًا، بمعدل 10 بطاقات لكل شخص.
+يطلع كل لاعب على بطاقاته، ويضعها أمامه مع الحرص على إبقائها قدر الإمكان في ذاكرته، ثم يستقر لمتابعة المناظرة.","*Reglas del juego: de 1 a 20 jugadores*
+
+## Material
+
+* 1 debate o 1 discurso al que los jugadores asistirán juntos y que podrá revisarse más tarde.
+* Material para tomar notas y un medio para anotar el tiempo transcurrido desde el inicio del debate.
+* 1 o varios mazos de cartas de falacias argumentativas
+
+   
+## Resumen del juego
+
+Munidos de una cuadrícula de bingo formada por las cartas de falacias argumentativas sorteadas, los jugadores tratarán de identificar las que aparecen en sus cartas ilustradas durante el debate. 
+Al término del debate, el jugador que haya identificado el mayor número de falacias argumentativas, tras la validación por parte de la mayoría de los demás jugadores, gana la partida.
+
+## Preparación
+
+Se reparte al azar el conjunto de cartas de falacias argumentativas disponibles entre todos los jugadores, a razón de 10 cartas por persona.
+Cada jugador toma conocimiento de sus cartas, las coloca procurando tenerlas lo mejor posible en mente y se dispone a asistir al debate.","*游戏规则：1至20名玩家*
+
+## 材料
+
+* 1场辩论或1场演讲，所有玩家将一起观看，并且可以回放复看。
+* 记录用的东西，以及一种记录自辩论开始以来所经过时间的方法。
+* 1套或多套谬误论证卡牌
+
+   
+## 游戏简介
+
+玩家手持一张由随机抽取的谬误论证卡牌组成的宾果表，在辩论过程中设法找出对应于自己图示卡牌的内容。
+辩论结束时，经其他玩家多数确认后，找出最多谬误论证的玩家获胜。
+
+## 准备
+
+将现有的所有谬误论证卡牌随机分给所有玩家，每人10张。
+每位玩家查看自己的卡牌，将其摆好并尽量记住，然后坐好准备观看辩论。","*قوانین بازی: ۱ تا ۲۰ بازیکن*
+
+## وسایل
+
+* ۱ مناظره یا ۱ سخنرانی که بازیکنان قرار است همگی با هم در آن شرکت کنند و امکان بازبینی دوبارهٔ آن هم وجود داشته باشد.
+* وسیله‌ای برای یادداشت‌برداری، و ابزاری برای ثبت زمانِ سپری‌شده از آغاز مناظره.
+* ۱ یا چند دسته از کارت‌های استدلالِ مغالطه‌آمیز
+
+   
+## خلاصهٔ بازی
+
+بازیکنان با در دست داشتن یک جدول بینگو که از کارت‌های استدلالِ مغالطه‌آمیزِ به‌تصادف کشیده‌شده تشکیل شده است، تلاش می‌کنند کارت‌های مصوّرِ خود را در طول مناظره شناسایی کنند. 
+در پایان مناظره، بازیکنی که بیشترین تعداد استدلالِ مغالطه‌آمیز را شناسایی کرده باشد، پس از تأییدِ اکثریتِ سایر بازیکنان، برندهٔ بازی می‌شود.
+
+## چیدمان
+
+تمام کارت‌های استدلالِ مغالطه‌آمیزِ موجود به‌طور تصادفی میان همهٔ بازیکنان تقسیم می‌شود، به‌طوری‌که به هر نفر ۱۰ کارت برسد.
+هر بازیکن کارت‌های خود را می‌خواند، آن‌ها را طوری می‌چیند که تا حد ممکن در ذهنش بمانند، و برای تماشای مناظره مستقر می‌شود."
 Rules_09,"## Pendant le débat
 
 Chaque joueur écoute les arguments formulés. S'il repère un argument qui relève de l'une des cartes de sa grille de bingo, il note le temps écoulé, un début de citation qui permettra de retrouver le bon passage, et le nom de sa carte accompagné au besoin d'un peu de contexte pour pouvoir restituer plus tard à l'oral son analyse.
@@ -420,12 +768,84 @@ A Assembléia vota manualmente para validar ou não sua análise.
 A pontuação final dos jogadores é o número de suas cartas validadas pela Assembléia
 Se no final de uma primeira declaração, outros jogadores não realizados agora são encontrados com mais cartas do que a melhor pontuação validada, eles serão validados e assim por diante até que a melhor pontuação validada não seja mais questionável.
 
-Jogadores que obtiveram a melhor pontuação são declarados vencedores",,,,,
+Jogadores que obtiveram a melhor pontuação são declarados vencedores",,"## أثناء المناظرة
+
+ينصت كل لاعب إلى الحجج المطروحة. فإذا رصد حجةً تندرج ضمن إحدى بطاقات شبكة البينغو الخاصة به، دوَّن الزمن المنقضي، وبدايةَ اقتباس تُمكّنه من العثور على المقطع الصحيح، واسم بطاقته، مع إضافة شيء من السياق عند الحاجة ليتمكن لاحقًا من عرض تحليله شفهيًا.
+
+## التحقق بعد المناظرة
+
+يُختار اللاعبون الذين يدّعون أكبر عدد من البطاقات المستخدمة للتحقق.
+
+ويُعتمد على ملاحظاتهم وعلى التسجيل لترتيب تسلسل اللحظات التي استُخدمت فيها كل بطاقة من بطاقاتهم. 
+وبالنسبة إلى كل بطاقة، يُعاد عرض اللحظة المعنية، ويشرح اللاعب لماذا تندرج الحجة ضمن بطاقته.
+تصوّت الجمعية برفع الأيدي لاعتماد تحليله أو عدم اعتماده.
+
+## شروط الفوز
+
+النتيجة النهائية للاعبين هي عدد بطاقاتهم التي اعتمدتها الجمعية
+إذا تبيّن، عند نهاية أول إحصاء، أن لاعبين آخرين غير مختارين أصبح لديهم عدد بطاقات يفوق أفضل نتيجة معتمدة، تُستكمل عملية التحقق منهم، وهكذا دواليك حتى تصبح أفضل نتيجة معتمدة غير قابلة للطعن.
+
+يُعلَن اللاعبون الذين حققوا أفضل نتيجة فائزين","## Durante el debate
+
+Cada jugador escucha los argumentos formulados. Si detecta un argumento que corresponde a una de las cartas de su cuadrícula de bingo, anota el tiempo transcurrido, el inicio de una cita que permitirá encontrar el pasaje correcto y el nombre de su carta, acompañado si hace falta de un poco de contexto para poder exponer después oralmente su análisis.
+
+## Validaciones posteriores al debate
+
+Los jugadores que reclamen el mayor número de cartas utilizadas son seleccionados para su validación.
+
+A partir de sus notas y de la grabación, se establece la secuencia de los momentos en que se utilizó cada una de sus cartas. 
+Para cada una de las cartas, se vuelve a escuchar el momento en cuestión y el jugador explica por qué la argumentación corresponde a su carta.
+La asamblea vota a mano alzada para validar o no su análisis.
+
+## Condiciones de victoria
+
+La puntuación final de los jugadores es el número de sus cartas validadas por la asamblea
+Si, tras un primer recuento, otros jugadores no seleccionados pasan a tener más cartas que la mejor puntuación validada, se procede a su validación, y así sucesivamente hasta que la mejor puntuación validada ya no pueda ser cuestionada.
+
+Los jugadores que hayan obtenido la mejor puntuación son declarados vencedores","## 辩论过程中
+
+每位玩家聆听发言内容。如果他识别出某个论证属于自己宾果表中的某张卡牌，就记录下经过的时间、能帮助找到对应片段的引语开头，以及该卡牌的名称；必要时再补充一点上下文，以便之后能够口头复述自己的分析。
+
+## 辩论后确认
+
+主张使用卡牌数量最多的玩家会被选出进行确认。
+
+根据他们的笔记和录音，整理出各自卡牌被使用的时间顺序。
+对于每一张卡牌，重放对应片段，并由玩家说明为什么这段论证属于他的卡牌。
+全体玩家举手表决，决定是否认可其分析。
+
+## 胜利条件
+
+玩家的最终得分等于其获得全体认可的卡牌数量。
+如果在第一轮统计后，其他未被选中的玩家如今拥有的卡牌数量超过了最高已确认得分，就对他们进行确认，如此类推，直到最高已确认得分不再存在争议。
+
+获得最高得分的玩家被宣布为胜者","## حین مناظره
+
+هر بازیکن استدلال‌های مطرح‌شده را گوش می‌دهد. اگر استدلالی را تشخیص دهد که با یکی از کارت‌های جدول بینگوی او مطابقت دارد، زمانِ سپری‌شده، بخشی از نقل‌قول را یادداشت می‌کند تا بتوان بخش درست را دوباره پیدا کرد، و نام کارت خود را همراه با اندکی زمینه می‌نویسد تا بعداً بتواند تحلیلش را به‌صورت شفاهی بازگو کند.
+
+## تأییدهای پس از مناظره
+
+بازیکنانی که بیشترین تعداد کارتِ به‌کاررفته را ادعا کرده‌اند، برای تأیید انتخاب می‌شوند.
+
+بر پایهٔ یادداشت‌های آن‌ها و ضبط، توالیِ لحظه‌هایی که هر یک از کارت‌هایشان به‌کار رفته است تعیین می‌شود. 
+برای هر کارت، لحظهٔ موردنظر دوباره مرور می‌شود و بازیکن توضیح می‌دهد که چرا آن استدلال با کارت او مطابقت دارد.
+جمع حاضر با رأیِ دست‌بالا تصمیم می‌گیرد که تحلیل او تأیید شود یا نه.
+
+## شرایط پیروزی
+
+امتیاز نهایی بازیکنان برابر است با تعداد کارت‌هایی که از سوی جمع تأیید شده‌اند.
+اگر پس از نخستین شمارش، بازیکنانِ دیگری که انتخاب نشده‌اند اکنون بیش از بالاترین امتیازِ تأییدشده کارت داشته باشند، تأیید آن‌ها نیز انجام می‌شود، و همین‌طور ادامه می‌یابد تا زمانی که بالاترین امتیازِ تأییدشده دیگر قابلِ اعتراض نباشد.
+
+بازیکنانی که بالاترین امتیاز را کسب کرده‌اند، برنده اعلام می‌شوند"
 Rules_10,"# Argumentum
 ## Le dernier beau parleur","# Argumentum
 ## The last beautiful speaker","# Argumentum
 ## Последний оратор","# Argumentum
-## o último lindas orador",,,,,
+## o último lindas orador",,"# Argumentum
+## آخر متكلم بارع","# Argumentum
+## El último gran orador","# Argumentum
+## 最后胜出的巧舌如簧者","# Argumentum
+## آخرین خوش‌سخن"
 Rules_11,"*Règles du jeu : de 1 à 8 joueurs*
 
 ## Matériel
@@ -471,7 +891,51 @@ The players will in turn offer arguments around scenarios drawn at each round an
    
 ## Resumo do jogo
 
-Os jogadores, por sua vez, oferecerão argumentos em torno de cenários desenhados a cada rodada e tentarão se livrar de suas cartas, identificando os argumentos falaciosos usados ​​por outros jogadores. Além de reconhecer os argumentos falaciosos, os jogadores treinam para evitar cometê -los.",,,,,
+Os jogadores, por sua vez, oferecerão argumentos em torno de cenários desenhados a cada rodada e tentarão se livrar de suas cartas, identificando os argumentos falaciosos usados ​​por outros jogadores. Além de reconhecer os argumentos falaciosos, os jogadores treinam para evitar cometê -los.",,"*قواعد اللعبة: من 1 إلى 8 لاعبين*
+
+## المعدات
+
+* حزمة واحدة من بطاقات الحجج المغالِطة منظَّمة في 7 فئات لونية، وكل فئة مقسَّمة إلى 3 رتب ثم إلى 3 عائلات.
+* حزمة واحدة من بطاقات السيناريو منظَّمة في 7 موضوعات يمكن تمييزها من ظهرها
+* 5 بطاقات تذكير
+* قواعد اللعب
+   
+## ملخص اللعبة
+
+يتناوب اللاعبون على طرح حجج حول سيناريوهات تُسحب في كل جولة، ويحاولون التخلّص من بطاقاتهم عبر رصد الحجج المغالِطة التي يستخدمها اللاعبون الآخرون. وإلى جانب التعرّف على الحجج المغالِطة، يتدرّب اللاعبون على تجنّب الوقوع فيها.","*Reglas del juego: de 1 a 8 jugadores*
+
+## Material
+
+* 1 mazo de cartas de argumento falaz organizadas en 7 clases de colores, cada una dividida en 3 órdenes y luego en 3 familias.
+* 1 mazo de cartas de escenario organizadas en 7 temas identificables en el reverso
+* 5 cartas recordatorio
+* Reglas del juego
+   
+## Resumen del juego
+
+Los jugadores, por turnos, irán proponiendo argumentos en torno a los escenarios extraídos en cada ronda e intentarán deshacerse de sus cartas detectando los argumentos falaces utilizados por los demás jugadores. Además de reconocer los argumentos falaces, los jugadores se entrenan para evitar cometerlos.","*游戏规则：1至8名玩家*
+
+## 材料
+
+* 1副谬误论证卡，分为7种颜色类别，每种又分为3个等级，再分为3个家族。
+* 1副情景卡，分为7个主题，背面可识别
+* 5张备忘卡
+* 游戏规则
+   
+## 游戏概述
+
+玩家将轮流围绕每一局抽到的情景提出论点，并设法打出手中的卡牌，同时识别其他玩家使用的谬误论证。除了识别谬误论证外，玩家还会训练自己避免犯下这类谬误。","*قوانین بازی: ۱ تا ۸ بازیکن*
+
+## محتویات
+
+* ۱ دسته کارتِ استدلالِ مغالطه‌آمیز که در ۷ کلاس رنگی سازمان‌دهی شده‌اند، و هر کدام خود به ۳ مرتبه و سپس به ۳ خانواده تقسیم می‌شوند.
+* ۱ دسته کارتِ سناریو که در ۷ تم قابل‌تشخیص از روی پشت کارت‌ها سازمان‌دهی شده‌اند
+* ۵ کارت یادآور
+* قوانین بازی
+   
+## خلاصه بازی
+
+بازیکنان به نوبت، پیرامون سناریوهایی که در هر دور کشیده می‌شوند استدلال مطرح می‌کنند و تلاش می‌کنند با شناسایی استدلال‌های مغالطه‌آمیزی که دیگر بازیکنان به کار می‌برند، از شرِ کارت‌های خود خلاص شوند. افزون بر تشخیص استدلال‌های مغالطه‌آمیز، بازیکنان تمرین می‌کنند که خود نیز مرتکب آن‌ها نشوند."
 Rules_12,"## Installation
 
 Selon le nombre de joueurs et le niveau de difficulté voulu, on constitue la pioche des cartes d’argument fallacieux en ajoutant les niveaux indiqués en bas à droite des cartes par ordre croissant. On choisit le nombre maximum de manches de quelques minutes qui seront jouées.
@@ -496,7 +960,31 @@ Dependendo do número de jogadores e do nível de dificuldade desejado, constitu
 
 Os cartões de argumento falaciosos são misturados, bem como os cartões de cenário. Constituímos 2 escolhas de cartas de cenário colocadas no meio da mesa. Cada jogador é distribuído para 5 cartões de argumento falaciosos que ele mantém para ele. O restante dos cartões é a escolha.
 
-O primeiro puxador é aquele que foi influenciado por um chamado à emoção.",,,,,
+O primeiro puxador é aquele que foi influenciado por um chamado à emoção.",,"## الإعداد
+
+بحسب عدد اللاعبين ومستوى الصعوبة المطلوب، تُشكَّل رزمة بطاقات الحجج المغالِطة بإضافة المستويات المشار إليها أسفل يمين البطاقات بترتيب تصاعدي. ثم يُختار الحدّ الأقصى لعدد الجولات، على أن تستغرق كل جولة بضع دقائق.
+
+تُخلط بطاقات الحجج المغالِطة وكذلك بطاقات السيناريو. ثم تُنشأ رُزمتان من بطاقات السيناريو وتوضعان في وسط الطاولة. ويُوزَّع على كل لاعب 5 بطاقات من بطاقات الحجج المغالِطة يحتفظ بها لنفسه. أمّا بقية البطاقات فتشكّل رزمة السحب.
+
+أول من يسحب هو آخر مَن تأثر بدعوة إلى العاطفة.","## Preparación
+
+Según el número de jugadores y el nivel de dificultad deseado, se constituye el mazo de cartas de argumento falaz añadiendo los niveles indicados en la parte inferior derecha de las cartas en orden creciente. Se elige el número máximo de rondas de unos minutos que se jugarán.
+
+Se barajan las cartas de argumento falaz, así como las cartas de escenario. Se forman 2 mazos de cartas de escenario colocados en el centro de la mesa. Se reparten a cada jugador 5 cartas de argumento falaz que guarda para sí. El resto de las cartas constituye el mazo.
+
+El primer jugador en robar es quien se ha dejado influir por última vez por una apelación a la emoción.","## 准备
+
+根据玩家人数和期望的难度，按卡牌右下角标注的等级由低到高，将相应等级的诡辩卡加入牌堆。确定将要进行的最多几局，每局持续几分钟。
+
+将诡辩卡和情景卡分别洗匀。将2叠情景卡牌堆放在桌子中央。给每位玩家发5张诡辩卡，玩家将其保密留在手中。其余卡牌作为抽牌堆。
+
+第一个抽牌的人，是最后一次被情绪诉求影响的人。","## آماده‌سازی
+
+بسته به تعداد بازیکنان و سطح دشواریِ مورد نظر، دستهٔ کارت‌های استدلالِ مغالطه‌آمیز را با افزودن سطوحی که در پایینِ سمت راستِ کارت‌ها با ترتیبِ صعودی مشخص شده‌اند، تشکیل می‌دهیم. حداکثر تعداد دورهای چنددقیقه‌ای را که قرار است بازی شوند انتخاب می‌کنیم.
+
+کارت‌های استدلالِ مغالطه‌آمیز و نیز کارت‌های سناریو بُر زده می‌شوند. سپس ۲ دستهٔ کارتِ سناریو در وسطِ میز قرار می‌دهیم. به هر بازیکن ۵ کارتِ استدلالِ مغالطه‌آمیز می‌دهیم که آن‌ها را نزد خود نگه می‌دارد. باقیِ کارت‌ها دستهٔ کشش را تشکیل می‌دهند. 
+
+اولین کسی که کارت می‌کشد، کسی است که آخرین بار تحت تأثیرِ یک appeal به احساسات قرار گرفته است."
 Rules_13,"## Déroulé de la manche
 
 ### 1.       Le piocheur
@@ -557,7 +1045,67 @@ Se um jogador não encontrar mais um novo argumento após 10 segundos, ele desen
 
 ### 3. Fim da rodada
 
-A manga para quando há apenas uma pessoa está em jogo. O vizinho à esquerda do puxador se torna o novo puxador e puxa o cenário da próxima rodada.",,,,,
+A manga para quando há apenas uma pessoa está em jogo. O vizinho à esquerda do puxador se torna o novo puxador e puxa o cenário da próxima rodada.",,"## سير الجولة
+
+### 1.       الساحب
+
+يسحب الساحب بطاقة سيناريو من بين مجموعتي السحب المتاحتين ويقرأها بصوت عالٍ، باستثناء الجملة الأخيرة المكتوبة بالخط المائل في أسفل البطاقة.
+
+
+### 2.       جولة الحجج
+
+ابتداءً من الجار الأيسر للساحب، يجب على كل لاعب أن يقترح حجة تستجيب لأمر السيناريو. إذا لاحظ لاعب إحدى بطاقاته ضمن الحجج المقدَّمة، فإنه يعطي بطاقته لمن استخدمها ويخرجها من الجولة.  
+إذا لم يعد لاعب يجد حجة جديدة بعد 10 ثوانٍ، فإنه يسحب بطاقة جديدة ويُستبعَد من الجولة.
+
+
+### 3.       نهاية الجولة
+
+تتوقف الجولة عندما لا يبقى في اللعب سوى شخص واحد. يصبح الجار الأيسر للساحب هو الساحب الجديد، ويسحب سيناريو الجولة التالية.  ","## Desarrollo de la ronda
+
+### 1.       El robador
+
+El robador saca una carta de escenario de entre los dos mazos disponibles y la lee en voz alta, con la excepción de la última frase en cursiva que aparece en la parte inferior de la carta.
+
+
+### 2.       La ronda de argumentos
+
+Empezando por el jugador situado a la izquierda del robador, cada jugador debe proponer un argumento que responda a la consigna del escenario. Si un jugador reconoce una de sus cartas entre los argumentos dados, se la entrega a quien la ha utilizado y queda fuera de la ronda.  
+Si un jugador no encuentra ningún argumento nuevo al cabo de 10 segundos, roba una nueva carta y queda excluido de la ronda.
+
+
+### 3.       Fin de la ronda
+
+La ronda termina cuando solo queda una persona en juego. El jugador situado a la izquierda del robador se convierte en el nuevo robador y saca el escenario de la siguiente ronda.  ","## 回合流程
+
+### 1.       抽牌者
+
+抽牌者从两个可用牌堆中抽一张情景牌，并大声朗读，唯独牌面底部斜体的最后一句除外。
+
+
+### 2.       论点轮
+
+从抽牌者左手边的玩家开始，每位玩家都必须提出一个符合情景指令的论点。若某位玩家在他人给出的论点中认出自己的某张牌，他就把那张牌交给使用它的人，并将其从本回合中移除。  
+如果某位玩家在10秒内再也想不出新的论点，他就抽一张新牌，并被排除出本回合。
+
+
+### 3.       回合结束
+
+当场上只剩下一名玩家时，本回合结束。抽牌者左手边的玩家成为新的抽牌者，并抽取下一回合的情景牌。  ","## روندِ دور
+
+### 1.       کارت‌کش
+
+کارت‌کش یکی از دو دستهٔ کارتِ سناریو را برمی‌دارد و با صدای بلند می‌خواند، به‌جز آخرین جملهٔ ایتالیکِ پایینِ کارت.
+
+
+### 2.       دورِ استدلال‌ها
+
+با شروع از همسایهٔ سمتِ چپِ کارت‌کش، هر بازیکن باید استدلالی ارائه دهد که به دستورِ سناریو پاسخ بدهد. اگر بازیکنی یکی از کارت‌های خودش را در استدلال‌های گفته‌شده تشخیص دهد، کارتِ خود را به کسی می‌دهد که از آن استفاده کرده و از این دور خارج می‌شود.  
+اگر بازیکنی پس از ۱۰ ثانیه دیگر هیچ استدلالِ تازه‌ای پیدا نکند، یک کارتِ جدید می‌کشد و از این دور کنار گذاشته می‌شود.
+
+
+### 3.       پایانِ دور
+
+دور زمانی تمام می‌شود که فقط یک نفر در بازی باقی بماند. همسایهٔ سمتِ چپِ کارت‌کش، کارت‌کشِ جدید می‌شود و سناریوی دورِ بعد را می‌کشد.  "
 Rules_14,"##       Fin de partie et décompte
 
 
@@ -574,12 +1122,32 @@ Otherwise the game stops at the end of the number of sleeves initially planned. 
 
 
 Se um jogador consegue se livrar de todas as suas cartas, ele vence o jogo.
-Caso contrário, o jogo para no final do número de mangas inicialmente planejado. O vencedor é quem tem menos cartas.",,,,,
+Caso contrário, o jogo para no final do número de mangas inicialmente planejado. O vencedor é quem tem menos cartas.",,"##       نهاية اللعبة والاحتساب
+
+
+إذا تمكن لاعب من التخلّص من جميع بطاقاته، فإنه يفوز باللعبة. 
+وإلا، تنتهي اللعبة بعد عدد الجولات المحدد مسبقًا. الفائز هو من يملك في يده أقل عدد من البطاقات.","##       Fin de la partida y recuento
+
+
+Si un jugador consigue deshacerse de todas sus cartas, gana la partida. 
+Si no, la partida termina al cabo del número de rondas previsto inicialmente. El ganador es quien tenga menos cartas en la mano.","##       游戏结束与计分
+
+
+如果某位玩家成功摆脱所有手牌，他就赢得比赛。 
+否则，比赛会在预先设定的回合数结束后终止。胜者是手牌最少的玩家。","##       پایانِ بازی و امتیازشماری
+
+
+اگر بازیکنی موفق شود از همهٔ کارت‌هایش خلاص شود، برندهٔ بازی است. 
+در غیر این صورت، بازی پس از تعدادِ دورهایی که از پیش تعیین شده بود به پایان می‌رسد. برنده کسی است که در دستش کمترین تعدادِ کارت را داشته باشد."
 Rules_15,"# Argumentum
 ## Le moulin à baratin","# Argumentum
 ## The Smooth-Talk Mill","# Argumentum
 ## Мели, Емеля","# Argumentum
-## O Moinho de Embromada",,,,,
+## O Moinho de Embromada",,"# Argumentum
+## طاحونة الثرثرة","# Argumentum
+## El maestro del cuento","# Argumentum
+## 花言巧语机器","# Argumentum
+## کارخانهٔ یاوه‌گویی"
 Rules_16,"*Règles du jeu : de 2 à 8 joueurs*
 
 ## Matériel
@@ -626,7 +1194,51 @@ With each round, on a scenario drawn, one of the players finds in a limited time
    
 ## Resumo do jogo
 
-A cada rodada, em um cenário desenhado, um dos jogadores encontra em um tempo limitado o maior número de argumentos falaciosos que ilustram as cartas desenhadas em sequência.",,,,,
+A cada rodada, em um cenário desenhado, um dos jogadores encontra em um tempo limitado o maior número de argumentos falaciosos que ilustram as cartas desenhadas em sequência.",,"*قواعد اللعبة: من 2 إلى 8 لاعبين*
+
+## المواد
+
+* رزمة واحدة من بطاقات الحِجاج المغلوطة منظَّمة في 7 فئات لونية، يندرج كلٌّ منها إلى 3 رتب ثم إلى 3 عائلات.
+* رزمة واحدة من بطاقات السيناريو منظَّمة في 7 موضوعات يمكن التعرّف عليها من ظهرها
+* 5 بطاقات تذكير
+* قواعد اللعبة
+   
+## ملخص اللعبة
+
+في كل جولة، وعلى سيناريو يُسحب عشوائيًا، يعثر أحد اللاعبين خلال وقت محدود على أكبر عدد ممكن من الحجج المغلوطة التي تُجسّد البطاقات المسحوبة تباعًا.","*Reglas del juego: de 2 a 8 jugadores*
+
+## Material
+
+* 1 mazo de cartas de argumento falaz organizadas en 7 clases de colores, cada una dividida en 3 órdenes y luego en 3 familias.
+* 1 mazo de cartas de escenario organizadas en 7 temas identificables en su reverso
+* 5 cartas de ayuda
+* Reglas del juego
+   
+## Resumen del juego
+
+En cada ronda, sobre un escenario elegido al azar, uno de los jugadores encuentra en un tiempo limitado el mayor número de argumentos falaces que ilustren las cartas robadas en secuencia.","*游戏规则：2至8名玩家*
+
+## 材料
+
+* 1套论证谬误卡牌，按7种颜色分类，每种颜色再分为3个等级，然后再分为3个家族。
+* 1套情景卡，按7个主题分类，可从背面识别
+* 5张备忘卡
+* 游戏规则
+   
+## 游戏概述
+
+每一轮中，在随机抽取的情景下，一名玩家需要在限定时间内找出尽可能多的论证谬误，以说明连续抽到的卡牌。","*قوانین بازی: از ۲ تا ۸ بازیکن*
+
+## محتویات
+
+* ۱ بسته کارتِ استدلالِ مغالطه‌آمیز که در ۷ دستهٔ رنگی سازمان‌دهی شده‌اند، هر دسته نیز به ۳ مرتبه و سپس به ۳ خانواده تقسیم می‌شود.
+* ۱ بسته کارتِ سناریو که در ۷ مضمون قابل شناسایی از پشت کارت‌ها سازمان‌دهی شده‌اند
+* ۵ کارتِ یادآور
+* قوانین بازی
+   
+## خلاصهٔ بازی
+
+در هر دور، روی یک سناریوی تصادفی، یکی از بازیکنان در زمانی محدود بیشترین تعداد استدلالِ مغالطه‌آمیز را که کارت‌های کشیده‌شده را به‌صورت پی‌درپی نشان می‌دهند، پیدا می‌کند."
 Rules_17,"## Installation
 
 Selon le nombre de joueurs et le niveau de difficulté voulu, on constitue la pioche des cartes d’argument fallacieux en ajoutant les niveaux indiqués en bas à droite des cartes par ordre croissant. On choisit le nombre maximum de manches de 3 minutes par joueur qui seront jouées.
@@ -651,7 +1263,31 @@ Dependendo do número de jogadores e do nível de dificuldade desejado, constitu
 
 Os cartões de argumento falaciosos são misturados, bem como os cartões de cenário. Constituímos 2 escolhas de cartas de cenário e 1 picada de argumento falaciosa, colocada no meio da mesa.
 
-A primeira picareta é quem premiou uma discussão pela última vez.",,,,,
+A primeira picareta é quem premiou uma discussão pela última vez.",,"## الإعداد
+
+بحسب عدد اللاعبين ومستوى الصعوبة المطلوب، تُكوَّن رزمة بطاقات الحِجاج المغلوطة بإضافة المستويات المشار إليها في أسفل يمين البطاقات وفق ترتيب تصاعدي. ويُحدَّد الحدّ الأقصى لعدد الجولات ذات الـ 3 دقائق لكل لاعب والتي ستُلعب.
+
+تُخلط بطاقات الحجج المغلوطة، وكذلك بطاقات السيناريو. ثم تُنشأ رُزمتان من بطاقات السيناريو ورزمة واحدة من بطاقات الحجج المغلوطة، وتوضع جميعها في وسط الطاولة.
+
+أوّل من يبدأ السحب هو آخر من تنازل عن حجةٍ تحت الإلحاح.","## Preparación
+
+Según el número de jugadores y el nivel de dificultad deseado, se constituye el mazo de cartas de argumento falaz añadiendo los niveles indicados en la parte inferior derecha de las cartas por orden creciente. Se elige el número máximo de rondas de 3 minutos por jugador que se van a jugar.
+
+Las cartas de argumento falaz se barajan, igual que las cartas de escenario. Se constituyen 2 mazos de cartas de escenario y 1 mazo de argumento falaz, colocados en el centro de la mesa. 
+
+El primer robador es quien haya cedido por última vez ante un argumento por desgaste.","## 准备
+
+根据玩家人数和想要的难度，将卡牌右下角标注的等级按从低到高的顺序加入“论证谬误”牌堆中，组成抽牌堆。然后确定要进行的回合总数，每位玩家进行的回合时长为3分钟。
+
+将“论证谬误”卡和情景卡分别洗牌。将两叠情景卡和一叠“论证谬误”卡放在桌子中央。 
+
+最后一次让步于争辩的人先抽牌。","## راه‌اندازی
+
+بسته به تعداد بازیکنان و سطح دشواریِ موردنظر، دستهٔ کارت‌های استدلالِ مغالطه‌آمیز را با افزودن سطح‌هایی که در پایینِ سمت راستِ کارت‌ها به‌ترتیب صعودی مشخص شده‌اند، تشکیل می‌دهیم. حداکثر تعداد دورهای ۳ دقیقه‌ای برای هر بازیکن که قرار است بازی شوند، انتخاب می‌شود.
+
+کارت‌های استدلالِ مغالطه‌آمیز و همچنین کارت‌های سناریو خوب بر زده می‌شوند. سپس ۲ دستهٔ کارت سناریو و ۱ دستهٔ کارت استدلالِ مغالطه‌آمیز تشکیل می‌دهیم و آن‌ها را در وسط میز قرار می‌دهیم.
+
+نخستین کارت‌کش کسی است که آخرین بار یک استدلال را از سرِ فرسودگی پذیرفته است."
 Rules_18,"## Déroulé de la manche
 
 ### 1.       Le piocheur
@@ -718,7 +1354,75 @@ Ele começa a desenhar argumentos falaciosos. Para cada cartão, ele deve oferec
 
 ### 3. Fim da rodada
 
-A manga para no final do tempo alocada, o embromador obtém em pontos o número de cartas varridas na manga. Ele se torna exigente com a próxima rodada.",,,,,
+A manga para no final do tempo alocada, o embromador obtém em pontos o número de cartas varridas na manga. Ele se torna exigente com a próxima rodada.",,"## سير الجولة
+
+### 1.       الساحب
+
+يسحب الساحب بطاقة سيناريو من بين الرزمتين المتاحتين ويقرأها بصوت عالٍ، باستثناء الجملة الأخيرة المكتوبة بالخط المائل في أسفل البطاقة.
+
+
+### 2.       سباق السرعة
+
+جار الساحب على اليسار هو المُثرثر..
+يُضبط مؤقّت على 3 دقائق.
+
+يبدأ بسحب بطاقات الحجج المغلوطة. ولكل بطاقة، عليه أن يقدّم حجةً تُجسّد البطاقة لتنفيذ السيناريو. فإذا نجح في ذلك، فاز بالبطاقة؛ وإلا فبوسعه أيضًا أن يمرّ، بحدّ أقصى 3 جكرات في كل جولة، ثم يسحب البطاقة التالية.
+
+
+### 3.       نهاية الجولة
+
+تنتهي الجولة عند انقضاء الوقت المحدد، ويحصل المُثرثر على عدد البطاقات التي كسبها في هذه الجولة كنقاط. ثم يصبح هو الساحب في الجولة التالية.","## Desarrollo de la ronda
+
+### 1.       El robador
+
+El robador saca una carta de escenario de entre los dos mazos disponibles y la lee en voz alta, con la excepción de la última frase en cursiva situada en la parte inferior de la carta.
+
+
+### 2.       La carrera de velocidad
+
+El jugador a la izquierda del robador es el embromador.
+Se prepara un temporizador de 3 minutos.
+
+Empieza a robar cartas de argumento falaz. Por cada carta, debe proponer un argumento que ilustre la carta para encajar el escenario. Si lo consigue, se lleva la carta; si no, también puede pasar, con un límite de 3 comodines por ronda, y robar la siguiente.
+
+
+### 3.       Fin de la ronda
+
+La ronda termina cuando se agota el tiempo. El embromador obtiene como puntos el número de cartas ganadas durante la ronda. Pasa a ser el robador de la siguiente ronda.","## 回合流程
+
+### 1.       抽牌者
+
+抽牌者从两叠可用的牌堆中抽取一张情景卡，并大声读出，除去卡片底部斜体字的最后一句。
+
+
+### 2.       速度比拼
+
+抽牌者左边的玩家是胡搅蛮缠者。
+准备一个3分钟计时器。
+
+他开始抽取“论证谬误”卡。每抽到一张卡，他都必须提出一个能体现该卡内容、并推进情景的论证。如果成功，他就赢得这张卡；否则，他也可以选择跳过，每轮最多可使用3次跳过，然后继续抽下一张。
+
+
+### 3.       回合结束
+
+回合在规定时间结束后停止。胡搅蛮缠者获得本轮赢得的卡牌数量作为分数。下一回合，他成为抽牌者。","## روند دور
+
+### 1.       کارت‌کش
+
+کارت‌کش یکی از دو دستهٔ موجود، یک کارت سناریو برمی‌دارد و آن را با صدای بلند می‌خواند، به‌جز آخرین جملهٔ ایتالیک در پایین کارت.
+
+
+### 2.       مسابقهٔ سرعت
+
+همسایهٔ سمتِ چپِ کارت‌کش، باراتی‌نوی است..
+یک زمان‌سنج ۳ دقیقه‌ای آماده می‌شود.
+
+او شروع به کشیدن کارت‌های استدلالِ مغالطه‌آمیز می‌کند. برای هر کارت، باید استدلالی پیشنهاد دهد که کارت را برای پیشبرد سناریو نشان دهد. اگر موفق شود، آن کارت را می‌برد؛ در غیر این صورت، می‌تواند با استفاده از ۳ جوکر در هر دور، رد شود و کارت بعدی را بردارد.
+
+
+### 3.       پایان دور
+
+دور پس از پایان زمانِ تعیین‌شده متوقف می‌شود، باراتی‌نو از نظر امتیاز، تعداد کارت‌های برده‌شده در آن دور را به‌دست می‌آورد. او در دور بعدی کارت‌کش می‌شود."
 Rules_19,"##       Fin de partie
 
 
@@ -751,12 +1455,48 @@ O primeiro jogador que chega a 20 pontos leva o jogo
 ## variantes
 
 * Em cada carta de desenho, após o argumento do Embromador, os outros jogadores podem oferecer outra ilustração do cartão. Para cada nova proposta, a Assembléia vota se for considerada melhor que os anteriores, e o autor da melhor proposta manteve o cartão.
-",,,,,
+",,"##       نهاية اللعبة
+
+
+يفوز أول لاعب يصل إلى 20 نقطة بالمباراة
+
+## المتغيرات
+
+* في كل مرة تُسحب فيها بطاقة، وبعد حجة الـ embromador، يمكن لكلٍّ من اللاعبين الآخرين أن يقترح صورة أخرى للبطاقة. ولكل اقتراح جديد، تصوّت الجمعية على ما إذا كان أفضل من الاقتراحات السابقة، ويفوز صاحب أفضل اقتراح مُعتمد بالبطاقة. 
+","##       Fin de partida
+
+
+El primer jugador que llegue a 20 puntos gana la partida
+
+## Variantes
+
+* Cada vez que se roba una carta, después del argumento del *embromador*, los demás jugadores pueden proponer una nueva interpretación de la carta. Por cada nueva propuesta, la asamblea vota si la considera mejor que las anteriores, y el autor de la mejor propuesta retenida gana la carta. 
+","##       游戏结束
+
+
+第一个达到20分的玩家赢得本局
+
+## 变体
+
+* 每次抽到一张牌后，在煽动者的论证之后，其余玩家都可以各自为这张牌提出另一种解读。每出现一个新提案，大家就投票判断它是否比之前的提案更好；最终采纳的最佳提案作者赢得这张牌。 
+","##       پایان بازی
+
+
+اولین بازیکنی که به ۲۰ امتیاز برسد، بازی را می‌برد
+
+## گونه‌ها
+
+* هر بار که کارتی کشیده می‌شود، پس از استدلالِ امبروما‌دور، سایر بازیکنان می‌توانند هر کدام یک تصویرسازی دیگر برای کارت پیشنهاد کنند. برای هر پیشنهاد جدید، مجمع رأی می‌دهد که آیا از پیشنهادهای قبلی بهتر است یا نه، و نویسندهٔ بهترین پیشنهادِ پذیرفته‌شده کارت را می‌برد. 
+"
 Rules_20,"# Argumentum
 ## La parlote coinchée","# Argumentum
 ## The Coinched Chat","# Argumentum
 ## Косноязычное красноречие","# Argumentum
-## O Papo Engatilhado",,,,,
+## O Papo Engatilhado",,"# Argumentum
+## الثرثرة المتعثرة","# Argumentum
+## La parlanchina encallada","# Argumentum
+## 卡壳胡侃","# Argumentum
+## زبان‌بازیِ گره‌خورده"
 Rules_21,"*Règles du jeu : 4 joueurs*
 
 ## Matériel
@@ -803,7 +1543,51 @@ In a succession of sleeves between 2 teams of 2 players facing each other, they 
    
 ## Resumo do jogo
 
-Em uma sucessão de mangas entre 2 equipes de 2 jogadores que se enfrentam, eles serão distribuídos por belos argumentos falaciosos para usar em uma sucessão de torres em um cenário desenhado. O nível de especificidade das cartas constitui sua força e 2 cores de ativos chamadas podem ser reproduzidas a qualquer momento e prevalecem sobre outras cores. Além de reconhecer os argumentos falaciosos, os jogadores treinam para avaliar o nível de especificidade dos cartões e cooperar.",,,,,
+Em uma sucessão de mangas entre 2 equipes de 2 jogadores que se enfrentam, eles serão distribuídos por belos argumentos falaciosos para usar em uma sucessão de torres em um cenário desenhado. O nível de especificidade das cartas constitui sua força e 2 cores de ativos chamadas podem ser reproduzidas a qualquer momento e prevalecem sobre outras cores. Além de reconhecer os argumentos falaciosos, os jogadores treinam para avaliar o nível de especificidade dos cartões e cooperar.",,"*قواعد اللعبة: 4 لاعبين*
+
+## المعدات
+
+* حزمة واحدة من بطاقات الحُجج المغالِطة منظَّمة في 7 فئات لونية، كلٌّ منها مقسّم إلى 3 رُتب ثم إلى 3 عائلات. اختيار من 32 بطاقة
+* حزمة واحدة من بطاقات السيناريو منظَّمة في 7 موضوعات يمكن التعرّف عليها من ظهرها
+* 5 بطاقات تذكير
+* قواعد اللعبة
+   
+## ملخص اللعبة
+
+في سلسلة من الجولات تتواجه فيها فريقان من لاعبين اثنين متقابلين، سيُوزَّع عليهم أيدٍ من الحجج المغالِطة لاستخدامها في سلسلة من الأدوار على سيناريو يُسحب عشوائيًا. ويشكّل مستوى تخصيص البطاقات مصدرَ قوتها، كما يمكن لعب لونين يُعدّان من ألوان الرابح في أي وقت، وهما يتفوّقان على الألوان الأخرى. وإلى جانب التعرّف على الحجج المغالِطة، يتدرّب اللاعبون على تقييم مستوى تخصيص البطاقات، وعلى التعاون.","*Reglas del juego: 4 jugadores*
+
+## Material
+
+* 1 mazo de cartas de argumento falaz organizadas en 7 clases de colores, cada una dividida en 3 órdenes y luego en 3 familias. Una selección de 32 cartas
+* 1 mazo de cartas de escenario organizadas en 7 temas identificables por su reverso
+* 5 cartas de memo
+* Reglas del juego
+   
+## Resumen del juego
+
+En una sucesión de rondas que enfrentan a 2 equipos de 2 jugadores colocados uno frente al otro, se les repartirán manos de argumentos falaces para utilizar en una sucesión de turnos sobre un escenario sorteado al azar. El nivel de especificidad de las cartas constituye su fuerza y 2 colores, llamados de triunfo, pueden jugarse en cualquier momento y vencen a los demás colores. Además de reconocer los argumentos falaces, los jugadores se entrenan para evaluar el nivel de especificidad de las cartas y para cooperar.","*游戏规则：4名玩家*
+
+## 材料
+
+* 1副谬误论证卡牌，按7个颜色类别组织，每个类别再分为3个阶层，再分为3个家族。共选用32张牌
+* 1副场景卡牌，按7个主题组织，背面可识别
+* 5张备忘卡
+* 游戏规则
+   
+## 游戏概述
+
+在一系列回合中，两支由2名玩家组成、面对面的队伍彼此对抗。他们将获得一手谬误论证牌，在抽取的场景上连续多个回合中使用。卡牌的具体程度决定其强度，而两种称为王牌的颜色可以在任何时候打出，并且会压过其他颜色。除了识别谬误论证外，玩家还要练习评估卡牌的具体程度，并学会合作。","*قوانین بازی: ۴ بازیکن*
+
+## تجهیزات
+
+* ۱ دسته کارتِ استدلالِ مغالطی، سازمان‌یافته در ۷ ردهٔ رنگی، که هرکدام به ۳ مرتبه و سپس ۳ خانواده تقسیم می‌شوند. گزیده‌ای از ۳۲ کارت
+* ۱ دسته کارتِ سناریو، سازمان‌یافته در ۷ مضمون که از پشت قابل شناسایی‌اند
+* ۵ کارتِ یادآور
+* قوانین بازی
+   
+## خلاصهٔ بازی
+
+در رشته‌ای از دورها که در آن دو تیمِ ۲ نفره روبه‌روی هم قرار می‌گیرند، به آن‌ها دست‌هایی از استدلال‌های مغالطی داده می‌شود تا در پیاپیِ نوبت‌ها روی یک سناریوی قرعه‌کشی‌شده به کار ببرند. میزانِ اختصاصی‌بودنِ کارت‌ها، قدرت آن‌ها را تعیین می‌کند و ۲ رنگِ موسوم به برگِ برنده را می‌توان در هر لحظه بازی کرد و این دو رنگ بر سایر رنگ‌ها غلبه می‌کنند. افزون بر شناساییِ استدلال‌های مغالطی، بازیکنان تمرین می‌کنند که سطحِ اختصاصی‌بودنِ کارت‌ها را ارزیابی کنند و همکاری کنند."
 Rules_22,"## Installation
 
 On sélectionne 28 cartes d'arguments fallacieux pour la partie, soit 4 par couleur.
@@ -828,7 +1612,31 @@ Selecionamos 28 cartões de argumentos falaciosos para o jogo, 4 por cor.
 
 Os cartões de argumento falaciosos são misturados, bem como os cartões de cenário. Constituímos 2 escolhas de cartas de cenário colocadas no meio da mesa.
 
-A primeira picareta é a que mais se esforçou.",,,,,
+A primeira picareta é a que mais se esforçou.",,"## الإعداد
+
+نختار 28 بطاقةً من بطاقات الحجج المغلوطة للّعبة، أي 4 بطاقات لكل لون.
+
+تُخلط بطاقات الحجج المغلوطة، وكذلك بطاقات السيناريو. ثم نُكوِّن رُزمتين لسحب بطاقات السيناريو توضعان في وسط الطاولة.
+
+أول من يسحب هو اللاعب الذي كذب آخر مرة.","## Preparación
+
+Se seleccionan 28 cartas de argumentos falaces para la partida, es decir, 4 por color.
+
+Las cartas de argumentos falaces se barajan, al igual que las cartas de escenario. Se forman 2 mazos de cartas de escenario colocados en el centro de la mesa. 
+
+El primer jugador en robar es el que haya mentido más recientemente.","## 设置
+
+本局选择 28 张谬误论证卡参与游戏，即每种颜色 4 张。
+
+将谬误论证卡和情景卡分别洗匀，并在桌子中央摆出 2 堆情景卡牌堆。
+
+第一位抽牌者是上一位说谎的人。","## چیدمان
+
+برای این دور، ۲۸ کارتِ استدلالِ مغالطه‌آمیز انتخاب می‌شود؛ یعنی ۴ کارت از هر رنگ.
+
+کارت‌های استدلالِ مغالطه‌آمیز و همچنین کارت‌های سناریو با هم بُر زده می‌شوند. سپس ۲ دستهٔ کارتِ سناریو در وسط میز قرار می‌گیرد.
+
+اولین کارت‌کش کسی است که آخرین بار دروغ گفته است."
 Rules_23,"## Début de la manche
 
 ### 1.       Le piocheur
@@ -945,7 +1753,131 @@ Se nenhum jogador oferece uma discussão, a melhor carta vence.
 
 
 
-  ",,,,,
+  ",,"## بداية الجولة
+
+### 1.       الساحب
+
+يسحب الساحب بطاقة سيناريو من بين رزمتي السحب المتاحتين ويقرأها بصوت عالٍ، باستثناء الجملة الأخيرة المكتوبة بالخط المائل في أسفل البطاقة.
+ثم يخلط ويوزع بطاقات الحجج المغلوطة الـ28 على اللاعبين الأربعة.
+
+### 2.       المزادات على العَطَف
+
+بدءًا من الجار الأيسر للساحب، يختار اللاعبون إما أن يرفعوا الرهان أو لا، لتحديد لوني العَطَف في الجولة. تتيح بطاقات العَطَف التفوق على الأنواع الأخرى من البطاقات، كما تمنح نقاطًا أكثر عند احتساب نتيجة الجولة.
+تبدأ المزاد على العَطَف عند 80، وتزداد المزايدات بمقدار 10 في كل مرة.
+
+في أي وقت، يمكن لأحد عضوي الفريق أن يقول ""je coinche"" ليُنهي المزادات مع مضاعفة رهان الجولة.
+عندما لا يعود أحد يرفع الرهان، يُحدَّد لونا العَطَف للجولة ويمكن أن تبدأ مرحلة اللعب.
+
+
+### 2.       أدوار اللعب
+
+على مدى 7 أدوار متتالية، سيواجه اللاعبون بعضهم عبر تقديم بطاقة واحدة من بطاقات الحجج المغلوطة على السيناريو.
+وبدءًا من الجار الأيسر للساحب، على كل لاعب أن يقدّم بطاقة وأن يلعب حجةً توضيحية تستجيب لمطلب السيناريو.
+
+إذا لم تُلعب أي بطاقة عَطَف، فإن البطاقة ذات أعلى مستوى من العمق تفوز باللَّفّة.
+وإذا استُخدمت بطاقات العَطَف، فإن بطاقة العَطَف ذات أدنى مستوى من العمق تفوز باللَّفّة.
+ويتقاسم اللاعبون المنتمون إلى الفريق نفسه اللَّفات التي يربحونها.
+
+ولكي يفوز لاعبٌ بلَّفة، يجب أن يصرّح بحجةٍ تتوافق مع البطاقة.
+إذا لم يقدّم أي لاعب حجةً، فالبطاقة الأفضل هي التي تفوز.
+
+
+
+
+  ","## Inicio de la ronda
+
+### 1.       El jugador que roba
+
+El jugador que roba saca una carta de escenario de entre los dos mazos disponibles y la lee en voz alta, con excepción de la última frase en cursiva situada al pie de la carta.
+Después baraja y reparte las 28 cartas de argumentos falaces entre los 4 jugadores.
+
+### 2.       La subasta de triunfo
+
+Empezando por el vecino de la izquierda del jugador que roba, los jugadores deciden si pujan o no para designar los 2 colores de triunfo de la ronda. Las cartas de triunfo permiten ganar frente a otros tipos de cartas, y además valen más puntos en el recuento de la ronda.
+La puja inicial de triunfo es de 80 y las pujas suben de 10 en 10. 
+
+En cualquier momento, uno de los dos miembros de un equipo puede decir ""je coinche"" y poner fin a las pujas, duplicando al mismo tiempo la apuesta de la ronda.
+Cuando nadie puja más, se designan los dos colores de triunfo para la ronda y puede comenzar la fase de juego.
+
+
+### 2.       Las bazas
+
+A lo largo de una sucesión de 7 bazas, los jugadores confrontarán una carta de argumento falaz cada uno sobre el escenario.
+Empezando por el vecino de la izquierda del jugador que roba, cada jugador debe proponer una carta y jugar un argumento ilustrativo que responda a la indicación del escenario. 
+
+Si no se juega ninguna carta de triunfo, la carta con mayor nivel de profundidad gana la baza.
+Si se juegan triunfos, la carta de triunfo con menor nivel de profundidad gana la baza.
+Los jugadores del mismo equipo comparten las bazas que ganan.
+
+Para ganar una baza, un jugador debe explicitar un argumento correspondiente a la carta. 
+Si ningún jugador propone un argumento, gana la mejor carta.
+
+
+
+
+  ","## 回合开始
+
+### 1.       抽牌者
+
+抽牌者从可用的两叠牌堆中抽取一张情景牌，并大声读出，除了牌面底部斜体的最后一句话。
+然后他将 28 张谬误论证卡洗匀，发给 4 名玩家。
+
+### 2.       将牌加倍
+
+从抽牌者左手边的玩家开始，玩家可以选择是否加注，以确定本回合的 2 种王牌颜色。王牌卡可以战胜其他类型的卡牌，并且在回合计分时价值更高。
+王牌的起始叫价为 80，每次加注增加 10。
+
+在任何时候，任一队伍的成员都可以说“我 coinche”并终止叫价，同时将本回合的赌注翻倍。
+当不再有人加注时，本回合的两种王牌颜色就确定了，游戏阶段可以开始。
+
+
+### 2.       出牌回合
+
+在连续 7 个回合中，玩家将各自打出 1 张谬误论证卡来应对情景。
+从抽牌者左手边的玩家开始，每位玩家必须打出一张卡牌，并依据情景要求提出一个示例性的论证。
+
+如果没有打出任何王牌，则最大深度等级的卡牌赢得该墩。
+如果打出了王牌，则深度等级最低的王牌卡赢得该墩。
+同一队的玩家共享他们赢得的墩数。
+
+要赢得一墩，玩家必须阐明一个与所出卡牌相对应的论证。
+如果没有玩家提出论证，则牌面最强的卡获胜。
+
+
+
+
+  ","## آغاز دور
+
+### 1.       کارت‌کش
+
+کارت‌کش یکی از دو دستهٔ کارتِ سناریوی موجود را برمی‌دارد و با صدای بلند می‌خواند، به‌جز آخرین جملهٔ ایتالیک در پایین کارت.
+سپس ۲۸ کارتِ استدلالِ مغالطه‌آمیز را بر می‌زند و بین ۴ بازیکن توزیع می‌کند.
+
+### 2.       مزایدهٔ اَتو
+
+با شروع از همسایهٔ سمت چپِ کارت‌کش، بازیکنان می‌توانند برای تعیین ۲ رنگِ اَتوِ این دور، مزایده را ادامه دهند یا نه. کارت‌های اَتو می‌توانند بر انواع دیگر کارت‌ها غلبه کنند و همچنین در شمارش امتیازِ دور، ارزش بیشتری دارند.
+حداقل پیشنهاد برای مزایدهٔ اَتو ۸۰ است و پیشنهادها هر بار ۱۰ تا ۱۰ بالا می‌رود. 
+
+در هر لحظه، یکی از دو عضوِ یک تیم می‌تواند بگوید ""je coinche"" و با دو برابر کردنِ مبلغِ دور، مزایده را پایان دهد.
+وقتی دیگر کسی پیشنهاد را بالاتر نبرد، دو رنگِ اَتو برای این دور تعیین می‌شوند و مرحلهٔ بازی می‌تواند آغاز شود.
+
+
+### 2.       نوبت‌های بازی
+
+در طول ۷ نوبتِ پیاپی، بازیکنان هر کدام ۱ کارتِ استدلالِ مغالطه‌آمیز را روی سناریو رو می‌کنند.
+با شروع از همسایهٔ سمت چپِ کارت‌کش، هر بازیکن باید یک کارت پیشنهاد کند و یک استدلالِ مثالی بازی کند که به دستورِ سناریو پاسخ می‌دهد. 
+
+اگر هیچ کارتِ اَتو بازی نشود، کارتی که بالاترین سطحِ عمق را دارد برندهٔ دست می‌شود.
+اگر کارت‌های اَتو بازی شوند، کارتِ اَتوی با پایین‌ترین سطحِ عمق برندهٔ دست می‌شود.
+بازیکنانِ یک تیم، دست‌هایی را که می‌برند با هم شریک می‌شوند.
+
+برای بردنِ یک دست، بازیکن باید استدلالی را که با کارت هماهنگ است توضیح دهد. 
+اگر هیچ بازیکنی استدلالی ارائه نکند، بهترین کارت برنده می‌شود.
+
+
+
+
+  "
 Rules_24,"### 3.       Décompte de la manche
 
 La manche s'arrête quand tous les plis ont été joués.
@@ -1006,4 +1938,64 @@ Se os leilões fossem cantos, as pontuações são dobradas.
 
 ## final do jogo e contagem
 
-A equipe que prevalece é a primeira a exceder 1000 pontos",,,,,
+A equipe que prevalece é a primeira a exceder 1000 pontos",,"### 3.       احتساب نتيجة الجولة
+
+تنتهي الجولة عندما تُلعب جميع اللَّفات.
+
+ثم تُحتسب نقاط الفريقين.
+بالنسبة إلى البطاقات خارج ألوان العَطَف، تساوي كل بطاقة نقطتين مضروبتين في مستوى عمقها.
+أما بالنسبة إلى البطاقات من لون العَطَف، فتساوي كل بطاقة 12 - (نقطتين مضروبتين في مستوى عمقها)
+
+إذا كان الفريق الذي فاز بمزايدة العَطَف قد أوفى بعقده مع نتيجة أعلى، فإنه يحرز من النقاط مقدار مزايدته إضافةً إلى النقاط التي ربحها فعليًا.
+أما إذا فاز الفريق الآخر، فإنه يحرز 160 نقطة بالإضافة إلى مقدار المزايدة التي لم تُوفَ. 
+
+إذا كانت المزايدات قد قوطِعت بـ coinche، فتُضاعَف النتائج.
+
+##       نهاية اللعبة واحتساب النتيجة
+
+الفريق الفائز هو أول فريق يتجاوز 1000 نقطة","### 3.       Recuento de la ronda
+
+La ronda termina cuando se han jugado todas las bazas.
+
+A continuación se cuentan los puntos de los dos equipos.
+Para las cartas que no sean de triunfo, cada carta vale 2 puntos por cada nivel de profundidad.
+Para las cartas del color de triunfo, cada carta vale 12 - (2 veces su nivel de profundidad)
+
+Si el equipo que ganó la subasta de triunfo cumple su contrato con una puntuación superior, se lleva en puntos el importe de su puja más los puntos realmente obtenidos.
+Si es el otro equipo el que gana, entonces se lleva 160 puntos más el importe de la puja que no se haya cumplido. 
+
+Si las pujas fueron coinchées, las puntuaciones se duplican.
+
+##       Fin de la partida y recuento
+
+Gana el equipo que primero supera los 1000 puntos","### 3.       回合计分
+
+当所有墩都已打完时，本回合结束。
+
+随后计算两队的得分。
+对于非王牌颜色的卡牌，每张卡的分值等于其深度等级的 2 倍。
+对于王牌颜色的卡牌，每张卡的分值等于 12 -（其深度等级的 2 倍）
+
+如果赢得王牌叫价的队伍按要求完成了合约，并且得分更高，则其获得的分数为叫价分数加上实际赢得的分数。
+如果是另一队获胜，则该队获得 160 分加上未能履约的叫价分数。 
+
+如果叫价过程中出现 coinche，则分数翻倍。
+
+##       游戏结束与总计分
+
+率先超过 1000 分的队伍获胜","### 3.       شمارش امتیاز دور
+
+دور وقتی تمام می‌شود که همهٔ تریک‌ها بازی شده باشند.
+
+سپس امتیازهای دو تیم شمرده می‌شود.
+برای کارت‌های خارج از خالِ حکم، هر کارت به اندازهٔ ۲ برابرِ سطحِ عمقِ خودش امتیاز دارد.
+برای کارت‌های خالِ حکم، هر کارت برابر است با ۱۲ - (۲ برابرِ سطحِ عمقِ خودش)
+
+اگر تیمی که مزایدهٔ حکم را برده است، قراردادش را با امتیازی بالاتر از حد لازم انجام دهد، به اندازهٔ مبلغِ مزایده‌اش به‌علاوهٔ امتیازهایی که واقعاً به‌دست آورده، امتیاز می‌گیرد.
+اگر تیم دیگر برنده شود، همان تیم ۱۶۰ امتیاز به‌علاوهٔ مبلغِ مزایده‌ای را که برآورده نشده است، به دست می‌آورد. 
+
+اگر مزایده‌ها کوئینشه شده باشند، امتیازها دو برابر می‌شوند.
+
+##       پایان بازی و شمارش امتیاز
+
+تیمی که برنده می‌شود، نخستین تیمی است که از ۱۰۰۰ امتیاز عبور کند"

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -222,7 +222,7 @@ namespace Argumentum.AssetConverter
 						nameof(DocumentConfig.DocumentName)
 					}),
 					StaticConversions = new List<(string sourceText, List<(string Language, string destText)> textConversions)>(new[]{
-						("_fr.", new List<(string Language, string destText)>(new []{("en", "_en."), ("ru", "_ru."), ("pt", "_pt."), ("es", "_es.") }) )
+						("_fr.", new List<(string Language, string destText)>(new []{("en", "_en."), ("ru", "_ru."), ("pt", "_pt."), ("es", "_es."), ("ar", "_ar."), ("fa", "_fa."), ("zh", "_zh.") }) )
 					}),
 				}
 			})

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Argumentum.AssetConverter.DatasetUpdater;
@@ -953,6 +953,178 @@ public class DatasetUpdaterRootConfig
 			MaxGroupItemNb = 12,
 			WriteOneTargetFileByField = true,
 			MaxChildren = 8
+			},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Rules to Spanish by chunk 0-shot",
+			SourceDataset = KnownDataSets.Rules,
+			FieldsToInclude = new List<string>()
+			{
+				"pk",
+				"Text",
+				"Text_es"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"Text_es"
+			},
+			PrimaryField = "pk",
+			TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptRulesTranslateEsUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateEsAssistant.txt"
+				}
+			},
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 3,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = false,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 3,
+			CompareMode = false,
+			AutoCompare = false,
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = false,
+			MaxChildren = 8
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Rules to Arabic by chunk 0-shot",
+			SourceDataset = KnownDataSets.Rules,
+			FieldsToInclude = new List<string>()
+			{
+				"pk",
+				"Text",
+				"Text_ar"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"Text_ar"
+			},
+			PrimaryField = "pk",
+			TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptRulesTranslateArUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateArAssistant.txt"
+				}
+			},
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 3,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = false,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 3,
+			CompareMode = false,
+			AutoCompare = false,
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = false,
+			MaxChildren = 8
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Rules to Farsi by chunk 0-shot",
+			SourceDataset = KnownDataSets.Rules,
+			FieldsToInclude = new List<string>()
+			{
+				"pk",
+				"Text",
+				"Text_fa"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"Text_fa"
+			},
+			PrimaryField = "pk",
+			TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptRulesTranslateFaUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateFaAssistant.txt"
+				}
+			},
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 3,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = false,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 3,
+			CompareMode = false,
+			AutoCompare = false,
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = false,
+			MaxChildren = 8
+		},
+		new DatasetUpdaterConfig()
+		{
+			Enabled = false,
+			Name = "Translate Rules to Chinese Simplified by chunk 0-shot",
+			SourceDataset = KnownDataSets.Rules,
+			FieldsToInclude = new List<string>()
+			{
+				"pk",
+				"Text",
+				"Text_zh"
+			},
+			FieldsToUpdate = new List<string>()
+			{
+				"Text_zh"
+			},
+			PrimaryField = "pk",
+			TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
+			SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+			DialogPrompts = new List<PromptExample>()
+			{
+				new PromptExample()
+				{
+					UserPromptPath = PromptsRootPath + "PromptRulesTranslateZhUser.txt",
+					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateZhAssistant.txt"
+				}
+			},
+			Model = "gpt-5.4-mini",
+			MaxTokensPerMinute = 70000,
+			DivisionMode = DivisionMode.SequentialChunks,
+			ChunkSize = 3,
+			UseFunctionCalling = true,
+			NbMessageCalls = 1,
+			SkipChunkNb = 0,
+			TakeChunkNb = -1,
+			SelectEmptyTargets = false,
+			RandomizeChunks = false,
+			MaxDegreeOfParallelismWebService = 3,
+			CompareMode = false,
+			AutoCompare = false,
+			MaxGroupItemNb = 12,
+			WriteOneTargetFileByField = false,
+			MaxChildren = 8
 		}
-	};
+		};
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/RecordsUpdater.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/RecordsUpdater.cs
@@ -18,7 +18,11 @@ public class RecordsUpdater
 		var targetRecord = Records.FirstOrDefault(x => x[PrimaryKeyField].ToString() == primaryKey);
 		if (targetRecord == null)
 		{
-			return "target record not found";
+			return $"target record not found for pk={primaryKey}";
+		}
+		if (!targetRecord.ContainsKey(fieldName))
+		{
+			return $"field '{fieldName}' not found in record {primaryKey}. Available: {string.Join(", ", targetRecord.Keys)}";
 		}
 		var existingValue = targetRecord[fieldName];
 		targetRecord[fieldName] = newValue;

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateArAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateArAssistant.txt
@@ -1,0 +1,3 @@
+J'ai bien pris note des instructions détaillées. Je me concentrerai sur la traduction vers l'arabe standard moderne des règles du jeu Argumentum, en préservant le formatage markdown, les termes propres du jeu et les symboles. J'utiliserai le function-calling pour proposer chacune de mes modifications.
+
+Prêt à recevoir les données pour la traduction.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateArUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateArUser.txt
@@ -1,0 +1,17 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de sections de règles du jeu de cartes Argumentum, comportant chacune les champs "pk" (identifiant), "Text" (texte source en français) et "Text_ar" (texte cible en arabe).
+
+Ta tâche consiste à traduire ou retraduire en arabe standard moderne (MSA) le contenu du champ "Text" pour le placer dans le champ "Text_ar".
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord` disponible dans ton prompt système. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Format du texte :** Les règles contiennent du markdown (titres ##, listes à puces *, gras **, italique *, séparateurs ---). Préserve exactement ce formatage.
+
+3. **Termes du jeu :** "Argumentum" (nom du jeu) reste "Argumentum". Les noms des familles de cartes (en français) sont des noms propres — conserve-les en français. Les rôles comme "Baratineur" et "Mixologue" doivent être traduits en équivalents arabes naturels.
+
+4. **Langue cible :** Arabe standard moderne (MSA, فصحى). Traduis de manière naturelle et idiomatique, pas mot à mot. Le texte arabe sera affiché de droite à gauche (RTL).
+
+5. **Symboles et emoji :** Conserve exactement tous les symboles (🎲, 🃏, 🎭, 🥈, 👇, ✅, ❌, etc.).
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateEsAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateEsAssistant.txt
@@ -1,0 +1,3 @@
+J'ai bien pris note des instructions détaillées. Je me concentrerai sur la traduction vers l'espagnol des règles du jeu Argumentum, en préservant le formatage markdown, les termes propres du jeu et les symboles. J'utiliserai le function-calling pour proposer chacune de mes modifications.
+
+Prêt à recevoir les données pour la traduction.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateEsUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateEsUser.txt
@@ -1,0 +1,17 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de sections de règles du jeu de cartes Argumentum, comportant chacune les champs "pk" (identifiant), "Text" (texte source en français) et "Text_es" (texte cible en espagnol).
+
+Ta tâche consiste à traduire ou retraduire en espagnol (es-ES) le contenu du champ "Text" pour le placer dans le champ "Text_es".
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord` disponible dans ton prompt système. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Format du texte :** Les règles contiennent du markdown (titres ##, listes à puces *, gras **, italique *, séparateurs ---). Préserve exactement ce formatage.
+
+3. **Termes du jeu :** "Argumentum" (nom du jeu) reste "Argumentum". Les noms des familles de cartes (en français) sont des noms propres — conserve-les en français. Les rôles comme "Baratineur" et "Mixologue" doivent être traduits en équivalents espagnols naturels.
+
+4. **Langue cible :** Espagnol (es-ES). Traduis de manière naturelle et idiomatique, pas mot à mot.
+
+5. **Symboles et emoji :** Conserve exactement tous les symboles (🎲, 🃏, 🎭, 🥈, 👇, ✅, ❌, etc.).
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateFaAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateFaAssistant.txt
@@ -1,0 +1,3 @@
+J'ai bien pris note des instructions détaillées. Je me concentrerai sur la traduction vers le persan/farsi des règles du jeu Argumentum, en préservant le formatage markdown, les termes propres du jeu et les symboles. J'utiliserai le function-calling pour proposer chacune de mes modifications.
+
+Prêt à recevoir les données pour la traduction.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateFaUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateFaUser.txt
@@ -1,0 +1,17 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de sections de règles du jeu de cartes Argumentum, comportant chacune les champs "pk" (identifiant), "Text" (texte source en français) et "Text_fa" (texte cible en farsi).
+
+Ta tâche consiste à traduire ou retraduire en persan/farsi le contenu du champ "Text" pour le placer dans le champ "Text_fa".
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord` disponible dans ton prompt système. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Format du texte :** Les règles contiennent du markdown (titres ##, listes à puces *, gras **, italique *, séparateurs ---). Préserve exactement ce formatage.
+
+3. **Termes du jeu :** "Argumentum" (nom du jeu) reste "Argumentum". Les noms des familles de cartes (en français) sont des noms propres — conserve-les en français. Les rôles comme "Baratineur" et "Mixologue" doivent être traduits en équivalents persans naturels.
+
+4. **Langue cible :** Persan/farsi (فارسی). Traduis de manière naturelle et idiomatique, pas mot à mot. Le texte farsi sera affiché de droite à gauche (RTL).
+
+5. **Symboles et emoji :** Conserve exactement tous les symboles (🎲, 🃏, 🎭, 🥈, 👇, ✅, ❌, etc.).
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateZhAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateZhAssistant.txt
@@ -1,0 +1,3 @@
+J'ai bien pris note des instructions détaillées. Je me concentrerai sur la traduction vers le chinois simplifié des règles du jeu Argumentum, en préservant le formatage markdown, les termes propres du jeu et les symboles. J'utiliserai le function-calling pour proposer chacune de mes modifications.
+
+Prêt à recevoir les données pour la traduction.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateZhUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptRulesTranslateZhUser.txt
@@ -1,0 +1,17 @@
+**Instructions de Traduction :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de sections de règles du jeu de cartes Argumentum, comportant chacune les champs "pk" (identifiant), "Text" (texte source en français) et "Text_zh" (texte cible en chinois simplifié).
+
+Ta tâche consiste à traduire ou retraduire en chinois simplifié (zh-CN) le contenu du champ "Text" pour le placer dans le champ "Text_zh".
+
+1. **Utilisation du Function calling :** Pour chaque mise à jour, utilise un appel à la fonction `UpdateRecord` disponible dans ton prompt système. N'écris pas de texte libre. Utilise autant d'appels de fonction que nécessaire.
+
+2. **Format du texte :** Les règles contiennent du markdown (titres ##, listes à puces *, gras **, italique *, séparateurs ---). Préserve exactement ce formatage.
+
+3. **Termes du jeu :** "Argumentum" (nom du jeu) reste "Argumentum". Les noms des familles de cartes (en français) sont des noms propres — conserve-les en français. Les rôles comme "Baratineur" et "Mixologue" doivent être traduits en équivalents chinois naturels.
+
+4. **Langue cible :** Chinois simplifié (简体中文, zh-CN). Traduis de manière naturelle et idiomatique, pas mot à mot.
+
+5. **Symboles et emoji :** Conserve exactement tous les symboles (🎲, 🃏, 🎭, 🥈, 👇, ✅, ❌, etc.).
+
+Es-tu prêt à recevoir les données ?


### PR DESCRIPTION
## Summary

Add 4 new DatasetUpdater task configs + 8 prompt files for translating Rules to Spanish, Arabic, Farsi, and Chinese Simplified.

- Task configs: sequential chunks of 3, gpt-5.4-mini, function calling enabled
- Prompts follow the existing PT Rules translation pattern
- All tasks start `Enabled = false` — ready to activate one at a time

## Test plan
- [x] Build: 0 errors

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>