### PR TITLE
feat(config): add Rules + Virtues cascade drift task configs

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -2010,6 +2010,108 @@ public class DatasetUpdaterRootConfig
 				MaxGroupItemNb = 12,
 				WriteOneTargetFileByField = false,
 				MaxChildren = 8
+			},
+			new DatasetUpdaterConfig()
+			{
+				Enabled = false,
+				Name = "Rules cascade drift remap gpt-5.5",
+				SourceDataset = KnownDataSets.Rules,
+				FieldsToInclude = new List<string>()
+				{
+					"pk",
+					"Text",
+					"Text_en","Text_ru","Text_pt","Text_es",
+					"Text_ar","Text_fa","Text_zh",
+				},
+				FieldsToUpdate = new List<string>()
+				{
+					"Text_en","Text_ru","Text_pt","Text_es",
+					"Text_ar","Text_fa","Text_zh",
+				},
+				PrimaryField = "pk",
+				TargetPath = @".\Target\Datasets\Argumentum Rules - Cards.csv",
+				SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+				DialogPrompts = new List<PromptExample>()
+				{
+					new PromptExample()
+					{
+						UserPromptPath = PromptsRootPath + "PromptRulesCascadeDriftUser.txt",
+						AssistantAnswerPath = PromptsRootPath + "PromptRulesCascadeDriftAssistant.txt"
+					}
+				},
+				Model = "gpt-5.5",
+				MaxOutputTokens = 4096,
+				MaxTokensPerMinute = 300000,
+				DivisionMode = DivisionMode.SequentialChunks,
+				ChunkSize = 4,
+				UseFunctionCalling = true,
+				NbMessageCalls = 1,
+				SkipChunkNb = 0,
+				TakeChunkNb = 1,
+				SelectEmptyTargets = false,
+				RandomizeChunks = false,
+				MaxDegreeOfParallelismWebService = 1,
+				CompareMode = false,
+				AutoCompare = false,
+				MaxGroupItemNb = 12,
+				WriteOneTargetFileByField = false,
+				MaxChildren = 8
+			},
+			new DatasetUpdaterConfig()
+			{
+				Enabled = false,
+				Name = "Virtues cascade drift remap gpt-5.5",
+				SourceDataset = KnownDataSets.VirtuesTaxonomy,
+				FieldsToInclude = new List<string>()
+				{
+					"pk",
+					"title_fr","description_fr","remark_fr",
+					"title_en","description_en","remark_en",
+					"title_ru","description_ru","remark_ru",
+					"title_pt","description_pt","remark_pt",
+					"title_es","description_es","remark_es",
+					"title_ar","description_ar","remark_ar",
+					"title_fa","description_fa","remark_fa",
+					"title_zh","description_zh","remark_zh",
+				},
+				FieldsToUpdate = new List<string>()
+				{
+					"title_en","description_en","remark_en",
+					"title_ru","description_ru","remark_ru",
+					"title_pt","description_pt","remark_pt",
+					"title_es","description_es","remark_es",
+					"title_ar","description_ar","remark_ar",
+					"title_fa","description_fa","remark_fa",
+					"title_zh","description_zh","remark_zh",
+				},
+				PrimaryField = "pk",
+				TargetPath = @".\Target\Datasets\Argumentum Virtues - Taxonomy.csv",
+				SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+				DialogPrompts = new List<PromptExample>()
+				{
+					new PromptExample()
+					{
+						UserPromptPath = PromptsRootPath + "PromptVirtuesCascadeDriftUser.txt",
+						AssistantAnswerPath = PromptsRootPath + "PromptVirtuesCascadeDriftAssistant.txt"
+					}
+				},
+				Model = "gpt-5.5",
+				MaxOutputTokens = 8192,
+				MaxTokensPerMinute = 300000,
+				DivisionMode = DivisionMode.SequentialChunks,
+				ChunkSize = 4,
+				UseFunctionCalling = true,
+				NbMessageCalls = 1,
+				SkipChunkNb = 0,
+				TakeChunkNb = 1,
+				SelectEmptyTargets = false,
+				RandomizeChunks = false,
+				MaxDegreeOfParallelismWebService = 1,
+				CompareMode = false,
+				AutoCompare = false,
+				MaxGroupItemNb = 12,
+				WriteOneTargetFileByField = false,
+				MaxChildren = 8
 			}
 		};
 }


### PR DESCRIPTION
## Summary
- Adds two new DatasetUpdater task configs for Rules + Virtues cascade drift remap (gpt-5.5)
- Closes infra gap from PR #369: cascade prompts for all 4 datasets are in master, but only Scenarii + Fallacies had matching task configs
- Both new tasks default `Enabled=false`, no API spend until manually enabled

## Symmetry with existing cascade infra
| Dataset | Cascade prompts (PR #369) | Cascade task config |
|---------|---------------------------|---------------------|
| Scenarii | ✅ | ✅ (existing) |
| Fallacies | ✅ | ✅ (existing) |
| Rules | ✅ | ✅ (this PR) |
| Virtues | ✅ | ✅ (this PR) |

## Configuration notes
- **Rules cascade** — `ChunkSize=4`, `MaxOutputTokens=4096`, 7 fields/record updated (`Text_en/ru/pt/es/ar/fa/zh`), `Text` (FR source) excluded
- **Virtues cascade** — `ChunkSize=4`, `MaxOutputTokens=8192`, 21 fields/record (title/description/remark × 7 langs), `_fr` source excluded
- Both use `DivisionMode=SequentialChunks` (flat PKs), `UseFunctionCalling=true`, `SelectEmptyTargets=false` (cleanup mode)
- `TakeChunkNb=1` ready for smoke-test convergence verification before scale-up

## Test plan
- [x] Build: 0 errors, 18 known warnings
- [x] Tests: 120/125 pass (5 skip GDrive/GUI)
- [ ] Smoke test Rules cascade (TakeChunkNb=1) when ready to validate API quota + cascade pattern
- [ ] Smoke test Virtues cascade (TakeChunkNb=1)

## Context
Per Phase 4 plan (dashboard 2026-05-28), cascade drift remap is used after each dataset's FR clarity pass to propagate clarity improvements to the 7 translation languages. With all 4 FR clarity passes now in master (#366 Rules, #368 Scenarii, #369 Fallacies, #367 Virtues), having all 4 cascade configs ready avoids re-discovering the wiring later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)