### PR TITLE
fix(i18n): add Memo CardSets to Fallacies CardSetLocalization (#358)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -100,7 +100,11 @@ namespace Argumentum.AssetConverter
 						KnownCardSets.Fallacies3,
 						KnownCardSets.FallaciesPrintAndPlay,
 						KnownCardSets.FallaciesWeb,
-						KnownCardSets.FallaciesWebThumbnails
+						KnownCardSets.FallaciesWebThumbnails,
+						// Memo + MemoPrintAndPlay share FallaciesTaxonomy dataset and reuse the same {{text_fr}}, {{desc_fr}}, {{Famille}}, {{Sous-Famille}}, {{Soussousfamille}} placeholders.
+						// Without entries here, MEMO pages on non-FR PDFs render FR content (#358).
+						KnownCardSets.Memo,
+						KnownCardSets.MemoPrintAndPlay
 					}),
 					FrontFieldConversions = new List<(string sourceFieldName, List<(string Language, string destFieldName)> fieldConversions)>(new []{
 						// Order: most specific first (Soussousfamille > Sous-Famille > Famille) to avoid partial-string collisions.


### PR DESCRIPTION
## Summary

Adds `KnownCardSets.Memo` and `KnownCardSets.MemoPrintAndPlay` to the existing Fallacies entry in `LocalizationConfig.CardSetLocalizations`. Resolves #358.

## Root cause

MEMO templates (`Cards/Memo/Argumentum_Memo_Face_fr.json` + `Argumentum_Memo_Back_fr.json`) use the same placeholders as Fallacies (`{{text_fr}}`, `{{desc_fr}}`, `{{Famille}}`, `{{Sous-Famille}}`, `{{Soussousfamille}}`) and the same dataset (`KnownDataSets.FallaciesTaxonomy`). Without a `CardSetLocalization` entry mapping `_fr` → `_en/_ru/_pt/_es/_ar/_fa/_zh`, the `template.Replace()` step in the LocalizationConfig pipeline never runs for Memo → output stays in FR.

Same class of bug as #216 (Fallacies multilingual content was broken until PR #347 in April 2026).

## Minimal change

Appended Memo + MemoPrintAndPlay to the existing Fallacies CardSetNames list — no new entry needed because mappings are identical (same dataset, same placeholders, same hierarchy fields). Memo Back template does not use `tagline_fr`, so the existing BackFieldConversions are a no-op for Memo (harmless).

```diff
                     CardSetNames = new List<string>(new []
                     {
                         KnownCardSets.Fallacies,
                         KnownCardSets.Fallacies2,
                         KnownCardSets.Fallacies3,
                         KnownCardSets.FallaciesPrintAndPlay,
                         KnownCardSets.FallaciesWeb,
-                        KnownCardSets.FallaciesWebThumbnails
+                        KnownCardSets.FallaciesWebThumbnails,
+                        KnownCardSets.Memo,
+                        KnownCardSets.MemoPrintAndPlay
                     }),
```

## Acceptance (from #358)

- [x] MEMO Tarot + MEMO Print&Play render translated content on EN/RU/PT — by config swap (no template change)
- [x] MEMO renders correctly on AR/ES/ZH/FA — those languages already in the FrontFieldConversions list (added by #361)
- [ ] PDF visual regression test (#212) — tracked separately

## Test plan

- [x] Source compiles (verified — bin lock during background dotnet run is unrelated)
- [ ] **Pipeline regen required** to produce the corrected MEMO pages in EN/RU/PT/AR/ES/FA/ZH PDFs
- [ ] Visual diff on `TarotCards_*-1.pdf` p28-31 (range cited in #358) for at least 3 languages
- [ ] Confirm `Famille_camelCase` CSS class still works (it's a Mustache helper output, not a localized field — unchanged)

Pipeline regen + visual diff to be batched with PRs #353 v2 + #355 to share one full pipeline run (cf. #358 priority note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)