### PR TITLE
feat(dataset-updater): salvage v2 cascade prompt criteria (decoupled from stale #384/#385/#386)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptFallaciesCascadeDriftUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptFallaciesCascadeDriftUser.txt
@@ -26,6 +26,7 @@ Le texte français (`text_fr`, `desc_fr`, `example_fr`) vient d'être affiné en
    - **Style** : la traduction ne reflète pas la nouvelle clarté/précision FR (lourdeur, ambiguïté que le FR a résolue)
    - **Fidélité incarnée** (exemples) : l'exemple ne mime plus la situation FR de manière vivante
    - **Cohérence cross-langue** : une langue diverge clairement des autres alors que toutes devraient miroiter le FR
+   - **Drift sémantique structurel** : la `desc_*` traduite porte un concept différent de `desc_fr`. Exemple observé : `desc_fr="Vous confondez votre perspective individuelle avec une objectivité universelle"` mais `desc_en="Confusing subjective experience of reality with the essence of that which is being observed"` (concept différent — plus proche de William James). Si la traduction est conceptuellement plus précise mais ne correspond plus au FR : ALIGNER sur le FR (la taxonomie FR fait foi). Si toutes les langues divergent dans la même direction : signaler sans corriger.
 
 5. **Ne PAS toucher** :
    - Traductions où le sens est correctement aligné (la majorité)

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesCascadeDriftUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptVirtuesCascadeDriftUser.txt
@@ -21,6 +21,7 @@ Les champs français `title_fr`, `description_fr`, `remark_fr` viennent d'être 
    - **Style** : titre/description ne reflète pas la nouvelle punchiness/clarté FR
    - **Fidélité concrète** (remarks) : l'exemple ne mime plus la situation FR
    - **Cohérence cross-langue** : une langue diverge nettement des autres
+   - **Re-conceptualisation des titres** : le titre traduit a glissé vers un concept différent du `title_fr`. Exemple observé : `title_fr="Indépendance des événements"` (le concept lui-même) mais `title_en="Assessment of independence"` (l'évaluation du concept). À corriger pour aligner sur le concept FR exact, sauf si toutes les langues divergent dans la même direction (auquel cas le FR est peut-être à reconsidérer — signaler sans corriger).
 
 5. **Ne PAS toucher** :
    - Traductions alignées (la majorité)


### PR DESCRIPTION
## What

Cherry-picks the **clean, reusable prompt-engineering** out of the now-stale stacked PRs #384/#385/#386, separated from their conflicting data payloads. These two v2 criteria are the genuinely valuable, conflict-free "good content" from that trio; the data portions are being salvaged surgically on the post-audit baseline by po-2023.

## Changes (additive, +2 lines, 0 data touched)

- **PromptFallaciesCascadeDriftUser.txt** — new criterion **"Drift sémantique structurel"**: when a translated `desc_*` carries a *different concept* than `desc_fr` (even if more precise), realign on FR (taxonomy FR fait foi). Caught e.g. PK Sophisme du psychologue.
- **PromptVirtuesCascadeDriftUser.txt** — new criterion **"Re-conceptualisation des titres"**: when a translated title drifted to a different concept than `title_fr` (e.g. `title_fr="Indépendance des événements"` → `title_en="Assessment of independence"`), realign on the exact FR concept.

## Safety

- Both files are already referenced by the cascade task configs merged in **#370**; all cascade tasks remain `Enabled = false`.
- Byte-identical to the prompt content validated in #386. No CSV / no code / no config touched → no conflict, mergeable.

## Context

Coordinator decision (jsboige 2026-05-29): surgically salvage the good content from the stale PR stack rather than rebase. This PR captures the prompt half; the data half (valid multilang cells excluding audit-reverted PKs) follows in a separate po-2023 PR. #384/#385/#386 to be closed as-superseded once both halves land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)