### PR TITLE
doc(publication): catalogue cartes FR+EN + scaffold livret

### DIFF
--- a/docs/publication/README.en.md
+++ b/docs/publication/README.en.md
@@ -1,0 +1,41 @@
+# Argumentum Publication — Documentation
+
+> **Audience.** Maintainers, contributors, printing/distribution partners.
+> **Purpose.** Describe what is published, in what form and for which channel.
+
+## Bilingual status
+
+| Language | Status |
+|---|---|
+| French (`*.fr.md`) | ✅ Canonical (cycle 2026‑05) |
+| English (`*.en.md`) | ✅ Mirror |
+| Other languages (ru/pt/es/ar/fa/zh) | ⏳ TODO — see [Argumentum CLAUDE.md §8‑Language Extension](../../CLAUDE.md) |
+
+Any substantive update to an FR document must be mirrored in the EN counterpart within the same PR. Non‑FR/EN languages are handled separately via the translation pipelines (`DatasetUpdater`).
+
+## Document inventory
+
+### 1. Card catalog and formats
+
+- **[cards-catalog.en.md](cards-catalog.en.md)** — exhaustive inventory of `CardSetDocuments` (Tarot, Poker, Print&Play, Web A0/A4/Thumbnails), physical dimensions, recommendations by audience.
+- **[cards-catalog.fr.md](cards-catalog.fr.md)** — French source.
+
+### 2. "The Liars' School" booklet
+
+- **[booklet.en.md](booklet.en.md)** — *placeholder* pending scope clarification (the external LaTeX repo could not be located under `ArgumentumGames`).
+- **[booklet.fr.md](booklet.fr.md)** — French placeholder.
+
+> This section will be completed once the booklet's source repository is identified (cf. `[ASK]` message dated 2026‑05‑30 on the workspace dashboard).
+
+## Conventions
+
+- Documents take the ISO language code as suffix: `*.fr.md`, `*.en.md`.
+- Dimensions are expressed in **millimetres** (consistent with `WebBasedGeneratorConfig.cs`).
+- Card names (`Tarot`, `Poker`, `Print&Play`, `Web A0`, `Thumbnails`) mirror the `DocumentName` entries in the C# configuration — single source of truth.
+- To modify dimensions, formats or add a deliverable, **edit the C# code** first (`AssetConverterConfig.cs` or `WebBasedGeneratorConfig.cs`), never the generated JSON.
+
+## Related resources
+
+- [CLAUDE.md](../../CLAUDE.md) — pipeline instructions and recovery history.
+- [ARCHITECTURE_PIPELINE.md](../../Generation/Documentation/ARCHITECTURE_PIPELINE.md) — detailed technical pipeline.
+- [README.md](../../README.md) — repository overview.

--- a/docs/publication/README.fr.md
+++ b/docs/publication/README.fr.md
@@ -1,0 +1,41 @@
+# Publication Argumentum — Documentation
+
+> **Audience.** Mainteneurs, contributeurs, partenaires impression/distribution.
+> **Objet.** Décrire ce qui est publié, sous quelle forme et pour quel canal.
+
+## Statut bilingue
+
+| Langue | Statut |
+|---|---|
+| Français (`*.fr.md`) | ✅ Canonique (cycle 2026‑05) |
+| English (`*.en.md`) | ✅ Miroir |
+| Autres langues (ru/pt/es/ar/fa/zh) | ⏳ TODO — voir [Argumentum CLAUDE.md §8‑Language Extension](../../CLAUDE.md) |
+
+Toute mise à jour matérielle d'un document FR doit être répliquée dans le miroir EN dans le même PR. Les langues hors FR/EN sont gérées séparément via les pipelines de traduction (`DatasetUpdater`).
+
+## Inventaire des documents
+
+### 1. Catalogue des cartes et formats
+
+- **[cards-catalog.fr.md](cards-catalog.fr.md)** — inventaire exhaustif des `CardSetDocuments` (Tarot, Poker, Print&Play, Web A0/A4/Thumbnails), dimensions physiques, recommandations par audience.
+- **[cards-catalog.en.md](cards-catalog.en.md)** — English mirror.
+
+### 2. Livret « The Liars' School »
+
+- **[booklet.fr.md](booklet.fr.md)** — *placeholder* en attente de précision de scope (le dépôt LaTeX externe est introuvable côté `ArgumentumGames`).
+- **[booklet.en.md](booklet.en.md)** — English mirror placeholder.
+
+> Cette section sera complétée une fois le dépôt source du livret identifié (cf. message `[ASK]` 2026‑05‑30 sur le dashboard workspace).
+
+## Conventions
+
+- Les documents prennent le code de langue ISO en suffixe : `*.fr.md`, `*.en.md`.
+- Les dimensions sont exprimées en **millimètres** (cohérent avec `WebBasedGeneratorConfig.cs`).
+- Les noms de cartes (`Tarot`, `Poker`, `Print&Play`, `Web A0`, `Thumbnails`) reprennent les `DocumentName` de la configuration C# — source de vérité unique.
+- Pour modifier les dimensions, formats ou ajouter un livrable, **éditer le code C#** d'abord (`AssetConverterConfig.cs` ou `WebBasedGeneratorConfig.cs`), jamais le JSON généré.
+
+## Ressources liées
+
+- [CLAUDE.md](../../CLAUDE.md) — instructions pipeline et historique de récupération.
+- [ARCHITECTURE_PIPELINE.md](../../Generation/Documentation/ARCHITECTURE_PIPELINE.md) — pipeline technique détaillé.
+- [README.md](../../README.md) — vue d'ensemble du dépôt.

--- a/docs/publication/booklet.en.md
+++ b/docs/publication/booklet.en.md
@@ -1,0 +1,40 @@
+# Publication Booklet — *placeholder*
+
+> ⏳ **Pending scope clarification** — ai‑01 dispatch 2026‑05‑30, `[ASK]` message posted on the workspace dashboard.
+
+## Context
+
+The initial dispatch mentioned a LaTeX‑compiled PDF booklet, titled "The Liars' School", hosted in a **separate repository** under the `ArgumentumGames` GitHub organisation.
+
+## State‑of‑play inventory (2026‑05‑30)
+
+| Verified source | Result |
+|---|---|
+| `gh repo list ArgumentumGames` | Only 2 repos: `Argumentum` (this one) and `Fallacies` (Python, last update 2017) |
+| `gh search repos "argumentum" --owner=ArgumentumGames` | Same, 1 result |
+| Search for `*.tex`, `Liar*`, `livret*`, `booklet*` in this repo | 0 results |
+| Mention in `README.md`, `CLAUDE.md`, `docs/` | None |
+
+## Hypotheses pending arbitration
+
+1. **Personal repo.** The booklet could live under an individual maintainer (jsboige or another handle).
+2. **Not yet created.** Track 1 = define a spec for a future booklet.
+3. **Off‑Git.** The booklet exists in Drive/locally, and this doc should describe the integration workflow.
+4. **Semantic renaming.** The word "booklet" may actually refer to the printed rules (`Argumentum_Rules.csv` → Rules cards in the Tarot deck).
+
+## Action plan once scope is clarified
+
+To be completed later; expected structure:
+
+- **Identity.** Title, subtitle, author(s), possible ISBN.
+- **Source.** Repo URL, canonical branch, root LaTeX file, bibliography files.
+- **Build.** Required LaTeX distribution (TeX Live / MiKTeX), compile commands, graphical dependencies (TikZ, fonts).
+- **Versions.** Versioning policy (git tag, publication date, possible ISSN/DOI).
+- **Distribution.** Channels (site `argumentum.games`, GitHub Release, print‑on‑demand).
+- **Localisation.** Multilingual policy (FR canonical, EN mirror, other languages TODO).
+- **Link with cards.** How the booklet references the card catalog ([cards-catalog.en.md](cards-catalog.en.md)).
+
+## Dispatch reference
+
+- **Workspace dashboard** — `[ACK]` then `[ASK]` messages on 2026‑05‑30 by `po-2023`.
+- **Associated doc-only PR** — this file.

--- a/docs/publication/booklet.fr.md
+++ b/docs/publication/booklet.fr.md
@@ -1,0 +1,40 @@
+# Livret de publication — *placeholder*
+
+> ⏳ **En attente de clarification de scope** — dispatch ai‑01 2026‑05‑30, message `[ASK]` posté sur le dashboard workspace.
+
+## Contexte
+
+Le dispatch initial mentionnait un livret PDF compilé via LaTeX, intitulé « The Liars' School », hébergé dans un **dépôt distinct** de l'organisation `ArgumentumGames` sur GitHub.
+
+## Constat de l'état des lieux (2026‑05‑30)
+
+| Source vérifiée | Résultat |
+|---|---|
+| `gh repo list ArgumentumGames` | 2 dépôts seulement : `Argumentum` (ce dépôt) et `Fallacies` (Python, dernière maj 2017) |
+| `gh search repos "argumentum" --owner=ArgumentumGames` | Idem, 1 résultat |
+| Recherche `*.tex`, `Liar*`, `livret*`, `booklet*` dans ce dépôt | 0 résultat |
+| Mention dans `README.md`, `CLAUDE.md`, `docs/` | Aucune |
+
+## Hypothèses en attente d'arbitrage
+
+1. **Dépôt personnel.** Le livret pourrait être chez un mainteneur individuel (jsboige ou autre handle).
+2. **Pas encore créé.** Volet 1 = définir un cahier des charges pour un livret futur.
+3. **Hors Git.** Le livret existe en Drive/local et ce document doit décrire le workflow d'intégration.
+4. **Renommage sémantique.** Le terme « livret » pourrait désigner en réalité les règles imprimées (`Argumentum_Rules.csv` → cartes Rules dans le deck Tarot).
+
+## Plan d'action une fois le scope précisé
+
+À compléter par la suite ; structure prévue :
+
+- **Identité.** Titre, sous‑titre, auteur·rice·s, ISBN éventuel.
+- **Source.** URL du dépôt, branche canonique, fichier LaTeX racine, fichiers de bibliographie.
+- **Build.** Distribution LaTeX requise (TeX Live / MiKTeX), commandes de compilation, dépendances graphiques (TikZ, fontes).
+- **Versions.** Politique de versioning (tag git, date de publication, ISSN/DOI éventuel).
+- **Distribution.** Canaux (site `argumentum.games`, GitHub Release, impression à la demande).
+- **Localisation.** Politique multilingue (FR canonique, EN miroir, autres langues TODO).
+- **Lien avec les cartes.** Comment le livret référence le catalogue de cartes ([cards-catalog.fr.md](cards-catalog.fr.md)).
+
+## Référence dispatch
+
+- **Dashboard workspace** — message `[ACK]` puis `[ASK]` 2026‑05‑30 par `po-2023`.
+- **PR doc-only associée** — ce fichier.

--- a/docs/publication/cards-catalog.en.md
+++ b/docs/publication/cards-catalog.en.md
@@ -1,0 +1,128 @@
+# Argumentum Card Catalog — Publishable Formats
+
+> **Source of truth.** [`WebBasedGeneratorConfig.cs`](../../Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs) — `CardSetDocuments` section.
+> **Inventory date.** 2026‑05‑30 (branch `master`, commit `1811afc4`).
+
+Argumentum is a **dual‑deck** game: a large‑card deck (fallacies/virtues) and a small‑card deck (scenarios). The repository's generation produces **eight PDF deliverables** enabled by default, from the same CSV sources (`Cards/Fallacies/`, `Cards/Scenarii/`, `Cards/Rules/`).
+
+All formats are localized in **8 languages**: `fr` (canonical) + `en`, `ru`, `pt`, `es`, `ar`, `fa`, `zh` (translations).
+
+## Summary table
+
+| Deliverable | Cards included | Dimensions (mm) | CMYK? | Page | Target audience |
+|---|---|---|---|---|---|
+| **Professional Tarot** (`Argumentum_TarotCards_fr.pdf`) | Rules + Memo×7 + Fallacies | 60×113 | ✅ | Tarot trim | Pro print / publisher |
+| **Virtues Tarot** (`Argumentum_TarotCards_Virtues_fr.pdf`) | Virtues | 60×113 | ✅ | Tarot trim | Pro print / publisher |
+| **Scenarios Poker** (`Argumentum_PokerCards_fr.pdf`) | Scenarii | 63.5×88.9 (2.5″×3.5″ standard) | ✅ | Poker trim | Pro print / publisher |
+| **Print&Play Tarot A4** (`Argumentum_TarotCards_Print&Play_A4_fr.pdf`) | Rules + Fallacies + Virtues + Memo×5 | 60×113 | RGB | A4 | Player, home printer |
+| **Print&Play Poker A4** (`Argumentum_PokerCards_Print&Play_A4_fr.pdf`) | Scenarii | 63.5×88.9 | RGB | A4 | Player, home printer |
+| **Web A4 — Fallacies** (`Argumentum_Fallacies_Web_A4_fr.pdf`) | FallaciesWeb (no back) | 66×66 | RGB | A4 | Discovery / pedagogy |
+| **A0 Poster — Fallacies** (`Argumentum_Fallacies_Web_A0_fr.pdf`) | FallaciesWeb (no back) | 69×69 — 12 columns — header logo+QR | ✅ | A0 (841×1189) | Wall display / education |
+| **A4 Thumbnails** (`Argumentum_Fallacies_Web_Thumbnails_A4_fr.pdf`) | FallaciesWebThumbnails | 50×50 (front) / 72×72 (back) | RGB | A4 | Visual index / reference |
+
+> Two additional deliverables (`TarotCards_2`, `TarotCards_3`) exist in code but are **disabled** (`Enabled = false`). They correspond to future taxonomy extensions (`Fallacies2`, `Fallacies3`).
+
+## Per‑deliverable details
+
+### 1. Professional Tarot — `Argumentum_TarotCards_fr.pdf`
+
+- **Cards**: Rules (24) + Memo (×7 copies) + Fallacies (full taxonomy).
+- **Dimensions**: 60×113 mm (standard Tarot trim, no bleed).
+- **Color profile**: CMYK (printer proof).
+- **FR volume**: ~177 Fallacies + 24 Rules + ~7 Memo ≈ **208 cards**.
+- **Use**: hand off to a professional printer for Tarot deck production.
+
+### 2. Virtues Tarot — `Argumentum_TarotCards_Virtues_fr.pdf`
+
+- **Cards**: Virtues (223 records).
+- **Dimensions**: 60×113 mm — CMYK.
+- **Use**: companion deck dedicated to argumentative virtues.
+
+### 3. Scenarios Poker — `Argumentum_PokerCards_fr.pdf`
+
+- **Cards**: Scenarii (167 records).
+- **Dimensions**: 63.5×88.9 mm (standard poker, 2.5″×3.5″) — CMYK.
+- **Use**: small scenario deck, traditional poker format.
+
+### 4. Print&Play Tarot A4 — `Argumentum_TarotCards_Print&Play_A4_fr.pdf`
+
+- **Cards**: Rules (P&P) + Fallacies (P&P) + Virtues + Memo (×5 P&P).
+- **Card dimensions**: 60×113 mm, **RGB** with no CMYK conversion.
+- **Page**: A4.
+- **Use**: print at home (laser/inkjet), cut, play.
+
+### 5. Print&Play Poker A4 — `Argumentum_PokerCards_Print&Play_A4_fr.pdf`
+
+- **Cards**: Scenarii (P&P).
+- **Card dimensions**: 63.5×88.9 mm, RGB.
+- **Page**: A4.
+
+### 6. Web A4 — Fallacies — `Argumentum_Fallacies_Web_A4_fr.pdf`
+
+- **Cards**: FallaciesWeb (web variant, no back).
+- **Dimensions**: 66×66 mm, RGB, no back (`NoBack = true`).
+- **Use**: pedagogical printable on A4, square format, for handing out in class or training.
+
+### 7. A0 Poster — Fallacies — `Argumentum_Fallacies_Web_A0_fr.pdf`
+
+- **Cards**: FallaciesWeb (poster‑assembled).
+- **Dimensions**: 69×69 mm — **12 columns** — CMYK — no back — header `Logo_Argumentum & QRCode.png` — 2 mm padding.
+- **Page**: A0 (841×1189 mm — single page).
+- **Use**: display poster (classroom, event, exhibition). The header QR code links to the website.
+
+### 8. A4 Thumbnails — `Argumentum_Fallacies_Web_Thumbnails_A4_fr.pdf`
+
+- **Cards**: FallaciesWebThumbnails (mini thumbnails).
+- **Dimensions**: 50×50 mm (front), 72×72 mm (back), RGB, back not published.
+- **Use**: compact visual index, reference sheet for a binder.
+
+## Recommendation by audience and channel
+
+| Audience | Channel | Recommended format | Reason |
+|---|---|---|---|
+| Curious player | Web / download | **Print&Play Tarot A4** + **Print&Play Poker A4** | Home‑printable, RGB, standard A4 |
+| Teacher / trainer | Classroom | **Web A4 Fallacies** + **A4 Thumbnails** | Pedagogical, hand‑outable, no back |
+| Educational institution | Wall / room | **A0 Poster Fallacies** | Persistent reference, QR to resources |
+| Publisher / commercial partner | Industry | **Tarot** + **Virtues Tarot** + **Scenarios Poker** | CMYK, pro print dimensions |
+| Translation contributor | Reference | **A4 Thumbnails** | Overview for proofreading |
+| Library / non‑profit | Loan | **Print&Play Tarot A4** + **Poker A4** assembled and laminated | Reproducible at marginal cost |
+
+## Additional versioned artifacts
+
+Beyond the generated PDFs, the repository versions several directly publishable artifacts:
+
+### Mind maps (4 languages × 5 files)
+
+- `Cards/Fallacies/Mindmaps/{fr,en,ru,pt}/Fallacies_*.svg` (3 views: `.svg`, `.content.svg`, `.links.svg`)
+- `Cards/Fallacies/Mindmaps/{fr,en,ru,pt}/Argumentum_Virtues_MindMap_*.{content,links}.svg`
+- FreeMind source: `Cards/Fallacies/Mindmaps/fallacy_map.mm`
+- Interactive HTML wrappers: `Cards/Fallacies/Mindmaps/*/Fallacies_*.html`
+
+### OWL ontology
+
+- Target: OWL ontology with SKOS annotations (cf. [CLAUDE.md §Mind Maps & SVGs](../../CLAUDE.md)).
+
+### Box packaging
+
+- `Cards/Packaging/FCPM_065 - CLOCHE - 121x126x26mm.svg` — physical box template (lid).
+- `Cards/Packaging/FCPM_065 - FOND - 117x122x28mm.svg` — physical box template (base).
+
+## How to regenerate
+
+See [README.md §Generating Cards images and documents](../../README.md) for the full commands. Summary:
+
+```bash
+dotnet run --project "Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj"
+```
+
+Generated PDFs appear in `Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0/Target/{lang}/Documents/`.
+
+> **Note.** The pipeline skips existing files — to regenerate a specific deliverable, delete the target PDF.
+
+## How to add or modify a format
+
+1. **Edit** `WebBasedGeneratorConfig.cs` (never the generated JSON).
+2. **Add** a `CardSetDocumentConfig` entry to the `CardSetDocuments` list.
+3. **Test** generation on a subset.
+4. **Update** this catalog (`cards-catalog.fr.md` + `cards-catalog.en.md` simultaneously).
+5. **PR** with a screenshot of a representative page.

--- a/docs/publication/cards-catalog.fr.md
+++ b/docs/publication/cards-catalog.fr.md
@@ -1,0 +1,128 @@
+# Catalogue des cartes Argumentum — formats publiables
+
+> **Source de vérité.** [`WebBasedGeneratorConfig.cs`](../../Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs) — section `CardSetDocuments`.
+> **Date de l'inventaire.** 2026‑05‑30 (branche `master`, commit `1811afc4`).
+
+Argumentum est un jeu **à double deck** : un deck de grandes cartes (sophismes/vertus) et un deck de petites cartes (scénarios). La génération du dépôt produit **huit livrables PDF** activés par défaut, à partir des mêmes sources CSV (`Cards/Fallacies/`, `Cards/Scenarii/`, `Cards/Rules/`).
+
+Tous les formats sont déclinés en **8 langues** : `fr` (canonique) + `en`, `ru`, `pt`, `es`, `ar`, `fa`, `zh` (traductions).
+
+## Tableau récapitulatif
+
+| Livrable | Cartes incluses | Dimensions (mm) | CMYK ? | Page | Public cible |
+|---|---|---|---|---|---|
+| **Tarot professionnel** (`Argumentum_TarotCards_fr.pdf`) | Rules + Memo×7 + Fallacies | 60×113 | ✅ | Découpe Tarot | Print pro / éditeur |
+| **Tarot Vertus** (`Argumentum_TarotCards_Virtues_fr.pdf`) | Virtues | 60×113 | ✅ | Découpe Tarot | Print pro / éditeur |
+| **Poker scénarios** (`Argumentum_PokerCards_fr.pdf`) | Scenarii | 63.5×88.9 (2.5″×3.5″ standard) | ✅ | Découpe Poker | Print pro / éditeur |
+| **Print&Play Tarot A4** (`Argumentum_TarotCards_Print&Play_A4_fr.pdf`) | Rules + Fallacies + Virtues + Memo×5 | 60×113 | RGB | A4 | Joueur, imprimante perso |
+| **Print&Play Poker A4** (`Argumentum_PokerCards_Print&Play_A4_fr.pdf`) | Scenarii | 63.5×88.9 | RGB | A4 | Joueur, imprimante perso |
+| **Web A4 — Fallacies** (`Argumentum_Fallacies_Web_A4_fr.pdf`) | FallaciesWeb (sans dos) | 66×66 | RGB | A4 | Découverte / pédagogie |
+| **Poster A0 — Fallacies** (`Argumentum_Fallacies_Web_A0_fr.pdf`) | FallaciesWeb (sans dos) | 69×69 — 12 colonnes — entête logo+QR | ✅ | A0 (841×1189) | Affichage mural / éducation |
+| **Vignettes A4** (`Argumentum_Fallacies_Web_Thumbnails_A4_fr.pdf`) | FallaciesWebThumbnails | 50×50 (face) / 72×72 (dos) | RGB | A4 | Index visuel / référence |
+
+> Deux livrables additionnels (`TarotCards_2`, `TarotCards_3`) existent dans le code mais sont **désactivés** (`Enabled = false`). Ils correspondent à des extensions futures de la taxonomie (`Fallacies2`, `Fallacies3`).
+
+## Détails par livrable
+
+### 1. Tarot professionnel — `Argumentum_TarotCards_fr.pdf`
+
+- **Cartes** : Rules (24) + Memo (×7 copies) + Fallacies (taxonomie complète).
+- **Dimensions** : 60×113 mm (format tarot standard, sans marge de découpe).
+- **Profil couleur** : CMYK (épreuve imprimeur).
+- **Volume FR** : ~177 cartes Fallacies + 24 Rules + ~7 Memo ≈ **208 cartes**.
+- **Usage** : remise à un imprimeur professionnel pour fabrication d'un deck Tarot.
+
+### 2. Tarot Vertus — `Argumentum_TarotCards_Virtues_fr.pdf`
+
+- **Cartes** : Virtues (223 records).
+- **Dimensions** : 60×113 mm — CMYK.
+- **Usage** : deck complémentaire dédié aux vertus argumentatives.
+
+### 3. Poker scénarios — `Argumentum_PokerCards_fr.pdf`
+
+- **Cartes** : Scenarii (167 records).
+- **Dimensions** : 63.5×88.9 mm (standard poker, 2.5″×3.5″) — CMYK.
+- **Usage** : petit deck de scénarios, format poker traditionnel.
+
+### 4. Print&Play Tarot A4 — `Argumentum_TarotCards_Print&Play_A4_fr.pdf`
+
+- **Cartes** : Rules (P&P) + Fallacies (P&P) + Virtues + Memo (×5 P&P).
+- **Dimensions cartes** : 60×113 mm, **RGB** sans conversion CMYK.
+- **Page** : A4.
+- **Usage** : imprimer chez soi (laser/jet d'encre), découper et jouer.
+
+### 5. Print&Play Poker A4 — `Argumentum_PokerCards_Print&Play_A4_fr.pdf`
+
+- **Cartes** : Scenarii (P&P).
+- **Dimensions cartes** : 63.5×88.9 mm, RGB.
+- **Page** : A4.
+
+### 6. Web A4 — Fallacies — `Argumentum_Fallacies_Web_A4_fr.pdf`
+
+- **Cartes** : FallaciesWeb (variante web sans dos).
+- **Dimensions** : 66×66 mm, RGB, sans dos (`NoBack = true`).
+- **Usage** : support pédagogique imprimable sur A4, format carré, à distribuer en classe ou en formation.
+
+### 7. Poster A0 — Fallacies — `Argumentum_Fallacies_Web_A0_fr.pdf`
+
+- **Cartes** : FallaciesWeb (poster monté).
+- **Dimensions** : 69×69 mm — **12 colonnes** — CMYK — sans dos — entête `Logo_Argumentum & QRCode.png` — padding 2 mm.
+- **Page** : A0 (841×1189 mm — 1 page).
+- **Usage** : poster d'affichage (salle de classe, événement, exposition). Le QR code en entête redirige vers le site.
+
+### 8. Vignettes A4 — `Argumentum_Fallacies_Web_Thumbnails_A4_fr.pdf`
+
+- **Cartes** : FallaciesWebThumbnails (mini‑vignettes).
+- **Dimensions** : 50×50 mm (face), 72×72 mm (dos), RGB, sans dos publié.
+- **Usage** : index visuel compact, fiche de référence à glisser dans un classeur.
+
+## Recommandation par audience et canal
+
+| Audience | Canal | Format recommandé | Raison |
+|---|---|---|---|
+| Joueur curieux | Web / téléchargement | **Print&Play Tarot A4** + **Print&Play Poker A4** | Imprimable maison, RGB, A4 standard |
+| Enseignant / formateur | Salle | **Web A4 Fallacies** + **Vignettes A4** | Pédagogique, distribuable, sans dos |
+| Établissement scolaire | Mur / salle | **Poster A0 Fallacies** | Référence permanente, QR vers ressources |
+| Éditeur / partenaire commercial | Industrie | **Tarot** + **Tarot Vertus** + **Poker scénarios** | CMYK, dimensions print pro |
+| Contributeur traduction | Référence | **Vignettes A4** | Vue d'ensemble pour relecture |
+| Bibliothèque associative | Prêt | **Print&Play Tarot A4** + **Poker A4** assemblés et plastifiés | Reproductible à coût marginal |
+
+## Artefacts complémentaires versionnés
+
+Au‑delà des PDF générés, le dépôt versionne plusieurs artefacts directement publiables :
+
+### Mind maps (4 langues × 5 fichiers)
+
+- `Cards/Fallacies/Mindmaps/{fr,en,ru,pt}/Fallacies_*.svg` (3 vues : `.svg`, `.content.svg`, `.links.svg`)
+- `Cards/Fallacies/Mindmaps/{fr,en,ru,pt}/Argumentum_Virtues_MindMap_*.{content,links}.svg`
+- Source FreeMind : `Cards/Fallacies/Mindmaps/fallacy_map.mm`
+- Wrappers HTML interactifs : `Cards/Fallacies/Mindmaps/*/Fallacies_*.html`
+
+### Ontologie OWL
+
+- Cible : ontologie OWL avec annotations SKOS (cf. [CLAUDE.md §Mind Maps & SVGs](../../CLAUDE.md)).
+
+### Packaging boîte
+
+- `Cards/Packaging/FCPM_065 - CLOCHE - 121x126x26mm.svg` — gabarit physique boîte (cloche).
+- `Cards/Packaging/FCPM_065 - FOND - 117x122x28mm.svg` — gabarit physique boîte (fond).
+
+## Comment régénérer
+
+Voir [README.md §Generating Cards images and documents](../../README.md) pour les commandes complètes. Résumé :
+
+```bash
+dotnet run --project "Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj"
+```
+
+Les PDF générés apparaissent dans `Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0/Target/{lang}/Documents/`.
+
+> **Note.** Le pipeline saute les fichiers existants — pour régénérer un livrable précis, supprimer le PDF cible.
+
+## Pour ajouter ou modifier un format
+
+1. **Éditer** `WebBasedGeneratorConfig.cs` (jamais le JSON généré).
+2. **Ajouter** une entrée `CardSetDocumentConfig` dans la liste `CardSetDocuments`.
+3. **Tester** la génération sur un sous‑ensemble.
+4. **Mettre à jour** ce catalogue (`cards-catalog.fr.md` + `cards-catalog.en.md` simultanément).
+5. **PR** avec capture d'écran d'une page représentative.


### PR DESCRIPTION
**Dispatch ai-01 2026-05-30 09:02** — Documentation de publication FR+EN.

## Volet 2 — Catalogue cartes ✅

`docs/publication/cards-catalog.{fr,en}.md` documente les **8 livrables PDF** activés dans `WebBasedGeneratorConfig.cs` :

| Livrable | Dimensions | CMYK | Page | Audience |
|---|---|---|---|---|
| Tarot pro (Rules+Memo+Fallacies) | 60×113mm | ✅ | Tarot | Print pro |
| Tarot Vertus | 60×113mm | ✅ | Tarot | Print pro |
| Poker scénarios | 63.5×88.9mm | ✅ | Poker | Print pro |
| P&P A4 Tarot | 60×113mm | RGB | A4 | Joueur maison |
| P&P A4 Poker | 63.5×88.9mm | RGB | A4 | Joueur maison |
| Web A4 Fallacies | 66×66mm | RGB | A4 | Pédagogie |
| Poster A0 Fallacies | 69×69mm, 12 cols | ✅ | A0 | Affichage mural |
| Vignettes A4 | 50×50mm / 72×72mm | RGB | A4 | Index visuel |

Inclut : recommandations par audience/canal, artefacts complémentaires versionnés (mindmaps 4 langs, ontologie OWL, packaging boîte), procédure d'ajout/modification.

## Volet 1 — Livret LaTeX ⏳ placeholder

`docs/publication/booklet.{fr,en}.md` documente l'**état des lieux** : le dépôt LaTeX externe « The Liars' School » n'a pas pu être localisé dans l'organisation `ArgumentumGames` (seulement 2 dépôts : `Argumentum` et `Fallacies` archivé 2017).

`[ASK]` posté sur le dashboard workspace pour clarifier le scope (dépôt personnel ? pas encore créé ? hors Git ? renommage sémantique de « livret » = règles imprimées ?). Le placeholder liste 4 hypothèses et un plan d'action une fois le scope arbitré.

## Bilingue

- FR canonique, EN miroir (mise à jour synchrone obligatoire dans le même PR).
- Autres langues (ru/pt/es/ar/fa/zh) : TODO documenté dans le README.

## NO MERGE

Doc-only. PR pour review ai-01 — coordinator gère le merge.

🤖 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>