### PR TITLE
fix(cardpen): auto-shrink overflowing card titles before capture (#316)

### DIFF
--- a/Generation/CardPen/js/frame.js
+++ b/Generation/CardPen/js/frame.js
@@ -5,6 +5,65 @@ var cards = [];
 var nodes = [];
 
 
+// ---------------------------------------------------------------------------
+// Auto-shrink des titres (Option B — issue #316)
+// Réduit dynamiquement la taille de police d'un titre qui déborde son conteneur
+// AVANT la capture domtoimage. No-op si le titre tient déjà (cas Latin courant) :
+// n'agit que sur les débordements horizontaux (mots longs non sécables — p.ex.
+// cyrillique RU "НЕЙРОЛИНГВИСТИЧЕСКОЕ ПРОГРАММИРОВАНИЕ" — qui, avec
+// overflow-wrap:normal, sont rognés au lieu de revenir à la ligne).
+// Indépendant de la langue et du gabarit : ne touche que ce qui déborde.
+// ---------------------------------------------------------------------------
+
+// Vrai si le contenu de l'élément (et de ses descendants) tient sans débordement
+// horizontal. Tolérance de 1px pour les arrondis sub-pixels.
+function titleContentFits(el) {
+    if (el.scrollWidth > el.clientWidth + 1) {
+        return false;
+    }
+    var descendants = el.getElementsByTagName('*');
+    for (var i = 0; i < descendants.length; i++) {
+        if (descendants[i].scrollWidth > descendants[i].clientWidth + 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Recherche dichotomique de la plus grande taille de police qui tient.
+function autoFitTitle(title, minFontPx) {
+    minFontPx = minFontPx || 8;
+    // Repartir de la taille définie par le template (idempotent si rappelé).
+    title.style.fontSize = '';
+    var naturalPx = parseFloat(window.getComputedStyle(title).fontSize);
+    if (!naturalPx || titleContentFits(title)) {
+        return; // Tient déjà : aucun changement (cas le plus fréquent).
+    }
+    var lo = minFontPx;
+    var hi = naturalPx;
+    var best = minFontPx;
+    for (var iter = 0; iter < 12; iter++) {
+        var mid = (lo + hi) / 2;
+        title.style.fontSize = mid + 'px';
+        if (titleContentFits(title)) {
+            best = mid;   // tient → viser plus grand
+            lo = mid;
+        } else {
+            hi = mid;     // déborde → réduire
+        }
+    }
+    title.style.fontSize = best + 'px';
+}
+
+// Applique l'auto-shrink à tous les titres d'une carte avant sa capture.
+function autoFitCardTitles(cardNode) {
+    var titles = cardNode.querySelectorAll('.title');
+    for (var t = 0; t < titles.length; t++) {
+        autoFitTitle(titles[t]);
+    }
+}
+
+
 async function generateImages() {
     var zipButton = document.getElementById('zipButton');
     if (zipButton) {
@@ -19,6 +78,7 @@ async function generateImages() {
     nodes = document.getElementsByTagName("card");
        for (var n = 0; n < nodes.length; n++) {
            //imaginer(nodes[n],n);
+           autoFitCardTitles(nodes[n]);   // Option B (#316) : ajuster les titres débordants avant capture
            await imaginerSync(nodes[n], n);
        }
     if (zipButton) {


### PR DESCRIPTION
## Contexte — issue #316 (overflow titre RU)

Les titres de carte longs et **non sécables** débordaient leur conteneur `.title` et étaient **rognés en plein mot**. Cas emblématique : les composés cyrilliques RU comme `НЕЙРОЛИНГВИСТИЧЕСКОЕ ПРОГРАММИРОВАНИЕ`. Cause : l'élément interne `.title > div` utilise `overflow-wrap: normal` (les mots longs ne reviennent pas à la ligne et débordent → rognage par l'ancêtre `overflow:hidden`).

## Décision — Option B (et pas Option A)

Conformément à l'arbitrage acté (#303 / #353, disposition coordinateur jsboige 2026‑05‑29 : **« HOLD → Option B »**), ce PR implémente l'**auto‑shrink JS dans CardPen**, retenu plutôt qu'une classe CSS `lang-ru` (-14%) parce qu'il est **indépendant de la langue ET du gabarit** : il agit sur *tout* titre qui déborde, peu importe le script.

## Changement

Un seul fichier : [`Generation/CardPen/js/frame.js`](../blob/fix/cardpen-title-autoshrink/Generation/CardPen/js/frame.js).

- `generateImages()` appelle désormais `autoFitCardTitles(node)` sur chaque `<card>`, **après le préchargement des polices et avant la capture `domtoimage`**.
- Pour chaque `.title`, `autoFitTitle()` fait une **recherche dichotomique** de la plus grande taille de police qui tient horizontalement (plancher 8px, 12 itérations).
- `titleContentFits()` détecte le débordement via `scrollWidth > clientWidth` sur le titre **et ses descendants** (le mot long déborde le `div` interne en `width:100%`).
- **No‑op si le titre tient déjà** → les titres latins courants ne sont pas touchés (taille préservée).

## Validation visuelle (Playwright — ai‑01)

Harnais reproduisant le **gabarit Fallacies Face réel** (CSS + markup `<div class="title"><div>…</div></div>`), titre rendu ~84.5px sur carte 709px :

| Titre | Avant | Après | Débordait ? |
|---|---|---|---|
| `AD HOMINEM` (latin, contrôle) | 84.5px | **84.5px (inchangé)** | non → no‑op ✓ |
| `НЕЙРОЛИНГВИСТИЧЕСКОЕ ПРОГРАММИРОВАНИЕ` | 84.5px | 39.1px | oui (1236>570) → tient (571≈570) ✓ |
| `ПСЕВДОНАУЧНОСТЬ` | 84.5px | 51.7px | oui (934>570) → tient (571≈570) ✓ |

Captures avant/après confirmées à la vision : RU rogné → RU entièrement lisible ; latin intact.

## ⚠ Dépendance déploiement (régénération)

Le pipeline **Release** charge CardPen depuis **GitHub Pages** (pas l'IIS local). Pour que la régénération multilingue prenne ce correctif :
1. merger ce PR sur `master`,
2. laisser le workflow GitHub Pages **déployer CardPen** mis à jour,
3. **puis** lancer la régénération Release (po‑2023).

En Debug/IIS local, redéployer le site IIS depuis le repo si besoin.

## Suite

- Ce PR **remplace** la PR #353 (Option A / CSS), à fermer comme *superseded*.
- Le débordement éventuel de l'entête `.famille` (autre élément) est hors‑scope #316 ; à traiter séparément si confirmé en QA.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>