### PR TITLE
fix(rules): add missing i18n columns to P&P CSV + Rule entity

### DIFF
--- a/Cards/Rules/Argumentum Rules - Cards Print and Play.csv
+++ b/Cards/Rules/Argumentum Rules - Cards Print and Play.csv
@@ -1,9 +1,9 @@
-Text,Text_en,Text_ru,Text_pt,print_and_play
+Text,Text_en,Text_ru,Text_pt,print_and_play,Text_ar,Text_es,Text_zh,Text_fa
 "# Argumentum
 ## L'école des menteurs","# Argumentum
 ## The school of liars","# Armeryum
 ## школа лжецов","# Argumentum
-## Liars' School","1"
+## Liars' School",1,,,,
 "*Règles du jeu : de 4 à 8 joueurs*
 
 ## Matériel
@@ -56,7 +56,7 @@ Argiryum основан на классификации этих ошибочн�
 
 Os jogadores, por sua vez, tentarão adivinhar um cartão de argumento falacioso com a maioria dos outros jogadores, durante um SayNet de improvisação de um cenário aleatório. Enquanto se divertem, os jogadores aprendem a reconhecer, decodificar e, portanto, desconstruir os argumentos falaciosos.
 
-Argumentum é baseado na classificação desses argumentos falaciosos, organizados em ordens e famílias que são indicadas no topo do mapa. Por exemplo, a Flatterie é uma sub -categoria da chamada para emoções. Os cartões de memorando resumem essa classificação.","1"
+Argumentum é baseado na classificação desses argumentos falaciosos, organizados em ordens e famílias que são indicadas no topo do mapa. Por exemplo, a Flatterie é uma sub -categoria da chamada para emoções. Os cartões de memorando resumem essa classificação.",1,,,,
 "## Installation
 
 Selon le nombre de joueurs et le niveau de difficulté voulu, on constitue la pioche des cartes d’argument fallacieux en ajoutant les niveaux indiqués en bas à droite des cartes par ordre croissant. Il en faut au minimum 7  x  le nombre de joueurs.
@@ -89,7 +89,7 @@ Escolhemos a duração do jogo. Isso inclui uma sucessão de rodadas de 7 minuto
 
 Os argumentos falaciosos são misturados, bem como os cartões de cenário. Constituímos 2 desenhos de cartões de cartão de cenário colocados no meio da mesa. Cada jogador é distribuído para 5 cartões de argumento falaciosos que ele mantém para ele. O restante dos cartões constitui a reserva.
 
-O primeiro picador é desenhado. Cada jogador tem um pequeno objeto único (moeda, feijão, etc.) para a votação.","1"
+O primeiro picador é desenhado. Cada jogador tem um pequeno objeto único (moeda, feijão, etc.) para a votação.",1,,,,
 "## Déroulé de la manche
 
 ### 1.       Le piocheur
@@ -146,7 +146,7 @@ O papel de Baratineur é designado para o primeiro jogador que posa, em frente a
 
 ### 3. SayNet
 
-O picador inicia o debate como ele deseja. Ele pode retomar a sugestão de primeira réplica em itálico na parte inferior do cartão de cenário. O baratiner e o picador têm um minuto máximo para improvisar uma discussão durante a qual o baratineur tentará usar o tipo de argumento indicado pelo cartão que ele escolheu."
+O picador inicia o debate como ele deseja. Ele pode retomar a sugestão de primeira réplica em itálico na parte inferior do cartão de cenário. O baratiner e o picador têm um minuto máximo para improvisar uma discussão durante a qual o baratineur tentará usar o tipo de argumento indicado pelo cartão que ele escolheu.",,,,
 "Le baratineur expose ses arguments et le piocheur lui donne la réplique sans chercher à dominer la scène. Le baratineur peut choisir d’écourter la saynète quand il le souhaite.
 
 ### 4.       Le jury
@@ -195,7 +195,7 @@ Os membros do júri tomam nota das cartas reveladas, um jogador pode lê -lo em 
 
 Se o cartão Baratineur for designado por todo o júri, cada um desenha uma carta na reserva, exceto o baratineur.
 
-Caso contrário, o vencedor do canal é aquele cujo cartão obteve o maior número de votos, baratineur ou membro do júri."
+Caso contrário, o vencedor do canal é aquele cujo cartão obteve o maior número de votos, baratineur ou membro do júri.",,,,
 "Il garde alors sa carte qui vaut 1 point et la pose, face visible devant lui. Il ne pioche pas de nouvelle carte.
 
 En cas d’égalité, les joueurs concernés qui ont trouvé la carte du baratineur sont tous déclarés vainqueurs. Si aucun des joueurs concernés ne l'a trouvé, c'est le baratineur qui l’emporte.
@@ -242,4 +242,4 @@ O vizinho esquerdo do vizinho se torna o próximo cabo da próxima rodada.
 
 * No Tribunal do Saynet, qualquer membro do júri pode usar uma carta de seu jogo para intervir no papel de pickaxe. Se sua intervenção ilustrar bem o cartão, ele reipoca um e será nomeado a próxima picareta, se não, ele perde o cartão e o jogo assume sua quadra.
 * A picareta tem o direito de designar diretamente o baratineur do Canal da Mancha.
-* O vencedor do jogo deve incorporar o baratinener de um cenário final, onde ele deve colocar em jogo todas as cartas que ganhou durante o jogo."
+* O vencedor do jogo deve incorporar o baratinener de um cenário final, onde ele deve colocar em jogo todas as cartas que ganhou durante o jogo.",,,,

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Rule.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Rule.cs
@@ -19,6 +19,9 @@ namespace Argumentum.AssetConverter.Entities
         public string Text_ru { get; set; }
         public string Text_pt { get; set; }
         public string Text_es { get; set; }
+        public string Text_ar { get; set; }
+        public string Text_fa { get; set; }
+        public string Text_zh { get; set; }
         public string PrintAndPlay { get; set; }
     }
 
@@ -31,7 +34,10 @@ namespace Argumentum.AssetConverter.Entities
             Map(m => m.Text_en).Name("Text_en");
             Map(m => m.Text_ru).Name("Text_ru");
             Map(m => m.Text_pt).Name("Text_pt");
-            Map(m => m.Text_es).Name("Text_es");
+            Map(m => m.Text_es).Name("Text_es").Optional();
+            Map(m => m.Text_ar).Name("Text_ar").Optional();
+            Map(m => m.Text_fa).Name("Text_fa").Optional();
+            Map(m => m.Text_zh).Name("Text_zh").Optional();
             Map(m => m.PrintAndPlay).Name("print_and_play").Optional();
         }
     }


### PR DESCRIPTION
## Problem
Pipeline crashed during 8-language generation with `CsvHelper.HeaderValidationException: Header with name 'Text_es' was not found`.

The Rules Print and Play CSV (`Argumentum Rules - Cards Print and Play.csv`) only had 5 columns (Text, Text_en, Text_ru, Text_pt, print_and_play) but `RuleClassMap` expected `Text_es` without `.Optional()`.

## Fix
- **Rule.cs**: Add `Text_ar`, `Text_fa`, `Text_zh` properties + `.Optional()` on all 4 new mappings
- **Rule.cs**: Make existing `Text_es` mapping `.Optional()` (was missing)
- **P&P CSV**: Add 4 empty columns (Text_ar, Text_es, Text_zh, Text_fa) — 6 data rows updated

## Verification
- `dotnet test`: 125 total, 120 pass, 0 fail, 5 skip ✅
- Pipeline 8-language regeneration launched successfully with this fix (no more HeaderValidationException)
- FR/EN/RU/PT PDFs generated (32 total, cached from prior run)
- ES/AR/FA/ZH harvest in progress

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>