### PR TITLE
fix(harvest): wait for cardpen global before use (Release/Pages race)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
@@ -480,6 +480,19 @@ public class HarvestManager : IAsyncDisposable
 	              
 	              // ✅ CORRECTION FINALE: Passer le JSON comme argument de fonction
 	              // Cela évite les problèmes d'échappement multiples des string literals JavaScript
+
+	              // Garde anti-race (Release / GitHub Pages) : le global `cardpen` est défini par
+	              // main.js (main.js:22), qui est le DERNIER script de la page. Le gate amont
+	              // (attente de l'iframe #cpOutput) ne vérifie que la présence d'un élément HTML
+	              // statique, pas l'exécution de main.js. En local IIS (Debug) la latence ~0 masque
+	              // la course ; servi depuis GitHub Pages (Release) elle peut être perdue → l'appel
+	              // ci-dessous lève "ReferenceError: cardpen is not defined". Attendre explicitement
+	              // que l'API cardpen soit prête rend le harvest robuste quelle que soit la source.
+	              await page.WaitForFunctionAsync(
+	                  "() => typeof cardpen !== 'undefined' && cardpen.form && cardpen.write",
+	                  null,
+	                  new PageWaitForFunctionOptions { Timeout = 120000 });
+
 	              await page.EvaluateAsync("(jsonString) => cardpen.form.set(JSON.parse(jsonString))", cardsJson);
 	              await page.EvaluateAsync("cardpen.write.generate(cardpen.form.get(), 'image')");
 


### PR DESCRIPTION
## Problème

Lors d'une régénération **Release** (CardPen servi depuis GitHub Pages), le harvest plante avec `ReferenceError: cardpen is not defined`, ce qui **bloque la régén release-grade (CMYK/PNG)**. En Debug (CardPen servi en local IIS) le pipeline fonctionne.

## Diagnostic (vérifié, ai-01)

- **Le contenu GitHub Pages n'est PAS en cause.** Vérifié en conditions réelles via Playwright sur `https://argumentumgames.github.io/Argumentum/index.html` : après chargement, `cardpen` est un objet complet (`.form` + `.write` présents), `js/main.js` répond **HTTP 200** et s'exécute entièrement ; la seule erreur console est un `favicon.ico` 404 bénin.
- **La cause est une course au chargement dans `HarvestManager`.** Le gate amont (`HarvestManager.cs:374-393`) n'attend que l'existence de l'élément iframe **statique** `#cpOutput` (présent dès le parsing du HTML), **pas** la définition du global `cardpen` — défini par `main.js`, le **dernier** script de la page. Puis `HarvestManager.cs:483` appelle `cardpen.form.set(...)` sans garde d'existence.
- En local IIS (Debug) la latence ~0 masque la course ; servi depuis Pages (Release), la latence CDN peut faire partir l'appel avant l'exécution de `main.js` → `ReferenceError`. Comportement intermittent cohérent avec un échec de course.

## Correctif

Ajout d'un `page.WaitForFunctionAsync("() => typeof cardpen !== 'undefined' && cardpen.form && cardpen.write")` **avant** le premier usage de `cardpen` (HarvestManager.cs:483). Défensif, source-agnostique (IIS local ou Pages distant), timeout 120s aligné sur les autres attentes du fichier. Aucune régression de comportement en Debug (où la garde est satisfaite immédiatement).

## Validation

- `dotnet build` : 0 erreur.
- `dotnet test` : **120 réussis / 0 échec / 5 ignorés**.
- ⏳ **Validation finale = régén Release par po-2023** (seule machine lançant la régén Release ; ai-01 ne lance pas de régén Release localement). La garde élimine la course de façon déterministe ; à confirmer que le crash `cardpen is not defined` a disparu sur un run Release complet.

## Notes

- Le crash de l'iframe (`HarvestManager.cs:522`, `cardpen` dans le contexte iframe où il n'est pas défini) est déjà protégé par try/catch + fallback DPI — hors scope, non touché.
- Pré-requis Pages (Option B #316 / #400) inchangé : toute correction CardPen doit être mergée master pour redéploiement Pages avant régén Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)