### PR TITLE
fix(harvest): raise Playwright timeouts to 120s (Release crash on heavy AR/FA/ZH cards)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
@@ -336,6 +336,11 @@ public class HarvestManager : IAsyncDisposable
 		{
 			var b = await browser();
 			var newPage = await b.NewPageAsync();
+			// CardPen renders heavy datasets (AR/FA/ZH cards) slowly; the Playwright default
+			// operation timeout is only 30s, which causes uncaught TimeoutExceptions that kill
+			// the whole Release run. Raise the default for every await on this page to 120s
+			// (matches the explicit 120s waits elsewhere; lesson "CardPen needs 90-120s").
+			newPage.SetDefaultTimeout(120000);
 			LastPageUsed = newPage;
 			return newPage;
 		}
@@ -515,7 +520,7 @@ public class HarvestManager : IAsyncDisposable
 	              
 	              // Attendre que le bouton Generate Images soit présent (signal que l'iframe est chargé)
 	              var generateButtonLocator = iframe.Locator("#generateButton");
-	              await generateButtonLocator.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 30000 });
+	              await generateButtonLocator.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 120000 });
 	              Log("Generate button found, iframe is ready.");
 	              
 	              // Appeler generateImages() dans le contexte de l'iframe pour démarrer la génération


### PR DESCRIPTION
## Problème
La régénération **Release** crashait (~81 %, datasets lourds **AR/FA/ZH**) avec un `Microsoft.Playwright.TimeoutException` **non catché** : *"Timeout 30000ms exceeded"*.

## Diagnostic (code = vérité, master `943dc6ea`)
- Le SEUL timeout explicite < 120s était l'attente `#generateButton` (ex-ligne 518, `30000`).
- Les autres `await` de `GenerateImages` **sans try/catch interne** (ex. `TextContentAsync` dans `ExtractCardNames`) utilisaient le **défaut Playwright de 30s**.
- `DownloadImages` est **résilient par carte** (`catch (PlaywrightException)`), donc le throw fatal venait de ces awaits 30s (explicite + défaut), **pas** du fetch d'image.

## Correctif
- `GetFreePage` : **`page.SetDefaultTimeout(120000)`** juste après `NewPageAsync()` → tous les awaits sans timeout explicite passent à 120s (CardPen a besoin de 90-120s).
- Bump de l'attente explicite `#generateButton` **`30000 → 120000`** (un timeout explicite n'est PAS surchargé par `SetDefaultTimeout`).

Pur ajustement de timeout : **aucune** modification de logique, ne peut pas régresser le comportement correct ; n'allonge que la latence pire-cas sur un vrai blocage.

## Validation
- `dotnet build` : **0 Erreur(s)** (18 warnings préexistants).
- Débloque la régénération **8 langues** en attente côté po-2023.

Refs : #134 (release gate), #140 (QA multilingue), #403 (i18n 100 %).

🤖 ai-01 (Claude Opus 4.8)