### PR TITLE
fix(harvest): raise #zipButton timeout to 300s for large CardSets

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
@@ -529,8 +529,9 @@ public class HarvestManager : IAsyncDisposable
 	              Log("generateImages() called, waiting for completion...");
 
 	              // Attendre que le bouton ZIP devienne visible (signal que la génération est terminée)
+	              // NOTE: 300s (5 min) nécessaire pour les gros CardSets (Fallacies 1408 cartes × plusieurs langues)
 	              var zipButtonLocator = iframe.Locator("#zipButton");
-	              await zipButtonLocator.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 120000 });
+	              await zipButtonLocator.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 300000 });
 	              Log("Image generation process completed successfully.");
 
 	              // ✅ FIX: Capturer le DPI depuis CardPen après la génération


### PR DESCRIPTION
## Problem

The Release pipeline crashed at ~30 min with a `TimeoutException` while waiting for `#zipButton` to become visible in CardPen. The 120s timeout was insufficient for large CardSets (Fallacies 1408 cards × 8 languages = heavy JS rendering).

## Fix

Increase `#zipButton` `WaitForAsync` timeout from 120s to 300s (5 min) in `HarvestManager.cs:533`.

## Validation

Full Release 8 langs pipeline completed successfully:
- **64 PDFs** (8 types × 8 languages)
- **9,904 PNGs** (~1,238/lang)
- **~11.4 GB** total
- **69 min** runtime, 0 errors
- All 8 languages: FR/EN/RU/PT/ES/AR/FA/ZH ✅

## Related

- Follow-up to #406 (which raised `SetDefaultTimeout` + `#generateButton` to 120s)
- That fix was necessary but not sufficient — `#zipButton` also needed a higher timeout