### PR TITLE
chore(deps): upgrade System.Linq.Dynamic.Core 1.3.12 → 1.7.2 (GHSA-4cv2-4hjh-77rx)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
+++ b/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.12" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />

--- a/Generation/Converters/Argumentum.AssetConverter/CustomTypeProvider.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/CustomTypeProvider.cs
@@ -7,10 +7,10 @@ using Argumentum.AssetConverter.Mindmapper;
 
 namespace Argumentum.AssetConverter
 {
-    public class CustomTypeProvider : IDynamicLinkCustomTypeProvider
+    public class CustomTypeProvider : IDynamicLinqCustomTypeProvider
     {
 
-        public IDynamicLinkCustomTypeProvider DefaultProvider { get; set; }
+        public IDynamicLinqCustomTypeProvider DefaultProvider { get; set; }
 
 
         public HashSet<Type> GetCustomTypes()


### PR DESCRIPTION
## Security Fix — High Severity

Fixes [GHSA-4cv2-4hjh-77rx](https://github.com/advisories/GHSA-4cv2-4hjh-77rx): **remote access to properties on reflection types and static properties/fields** in System.Linq.Dynamic.Core.

### Changes
- `System.Linq.Dynamic.Core` 1.3.12 → 1.7.2 (minimal safe version = 1.6.0, upgraded to latest)
- `CustomTypeProvider.cs`: interface renamed upstream `IDynamicLinkCustomTypeProvider` → `IDynamicLinqCustomTypeProvider` (typo fix, breaking change)

### Verification
- **Build**: 0 errors, 17 warnings (was 20 — eliminated 2 NU1903 for this package)
- **Tests**: 131 pass / 0 fail / 5 skip (unchanged)
- **Scope**: 2 files changed (+3/−3) — only .csproj version bump + interface name

### Remaining NU1903
AutoMapper 14.0.0 (GHSA-rvv3-g6hj-g44x) still flagged — upgrade would be 14→16 (major version jump, requires separate assessment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)