### PR TITLE
feat(gsheet-sync): cell-level diff uploader with formula protection (#237)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/GSheetSync/CellLevelUploadTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/GSheetSync/CellLevelUploadTests.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Argumentum.AssetConverter.GSheetSync;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.GSheetSync
+{
+	/// <summary>
+	/// Tests for the cell-level upload configuration, DryRun report persistence,
+	/// and GSheetSyncRunner routing logic (cell-level vs full-sheet).
+	/// </summary>
+	public class CellLevelUploadTests : IDisposable
+	{
+		private readonly string _tempDir;
+
+		public CellLevelUploadTests()
+		{
+			_tempDir = Path.Combine(Path.GetTempPath(), $"gsheet-test-{Guid.NewGuid():N}");
+			Directory.CreateDirectory(_tempDir);
+		}
+
+		public void Dispose()
+		{
+			if (Directory.Exists(_tempDir))
+			{
+				Directory.Delete(_tempDir, true);
+			}
+		}
+
+		// --- Config tests ---
+
+		[Fact]
+		public void GSheetSyncConfig_UseCellLevelUpload_DefaultsTrue()
+		{
+			var config = new GSheetSyncConfig();
+			Assert.True(config.UseCellLevelUpload);
+		}
+
+		[Fact]
+		public void GSheetSyncConfig_SyncReportsPath_DefaultsToTargetSyncReports()
+		{
+			var config = new GSheetSyncConfig();
+			Assert.Equal("Target/SyncReports", config.SyncReportsPath);
+		}
+
+		[Fact]
+		public void GSheetSyncConfig_UseCellLevelUpload_CanBeSetFalse()
+		{
+			var config = new GSheetSyncConfig { UseCellLevelUpload = false };
+			Assert.False(config.UseCellLevelUpload);
+		}
+
+		// --- DryRun report file tests ---
+
+		[Fact]
+		public void CellLevelDiffResult_ToReport_ContainsAllSections()
+		{
+			var result = new CellLevelDiffResult
+			{
+				TotalGDriveRows = 100,
+				TotalLocalRows = 105,
+				PkMatched = 98,
+				PkUnmatched = 5,
+				CellsCompared = 490,
+			};
+			result.PatchesToApply.Add(new CellPatch
+			{
+				A1Notation = "D5",
+				ColumnName = "title_en",
+				PrimaryKey = "42",
+				OldValue = "Ad Hominem",
+				NewValue = "Ad Hominem Circumstantial",
+			});
+			result.ProtectedSkips.Add(new CellPatch
+			{
+				A1Notation = "E5",
+				ColumnName = "path_padded",
+				PrimaryKey = "42",
+				OldValue = "=TEXT(A5,\"000.000\")",
+				NewValue = "042",
+				SkipReason = PatchSkipReason.FormulaProtected,
+			});
+			result.PkUnmatchedRows.Add(new CellPatch
+			{
+				PrimaryKey = "NEW1",
+				SkipReason = PatchSkipReason.PkUnmatched,
+			});
+
+			var report = result.ToReport();
+
+			Assert.Contains("# Cell-Level Diff Report", report);
+			Assert.Contains("GDrive rows: 100", report);
+			Assert.Contains("Local CSV rows: 105", report);
+			Assert.Contains("PK matched: 98", report);
+			Assert.Contains("PK unmatched: 5", report);
+			Assert.Contains("Cells compared: 490", report);
+			Assert.Contains("Cells to patch: 1", report);
+			Assert.Contains("Protected (formula, NOT patched): 1", report);
+			Assert.Contains("D5", report);
+			Assert.Contains("title_en", report);
+			Assert.Contains("path_padded", report);
+		}
+
+		[Fact]
+		public void DryRunReport_WrittenToFile()
+		{
+			var result = new CellLevelDiffResult
+			{
+				TotalGDriveRows = 10,
+				TotalLocalRows = 10,
+				PkMatched = 10,
+				CellsCompared = 50,
+			};
+
+			var reportPath = Path.Combine(_tempDir, "fallacies-2026-06-03_01-00-00.md");
+			File.WriteAllText(reportPath, result.ToReport());
+
+			Assert.True(File.Exists(reportPath));
+			var content = File.ReadAllText(reportPath);
+			Assert.Contains("Cell-Level Diff Report", content);
+			Assert.Contains("Cells to patch: 0", content);
+		}
+
+		[Fact]
+		public void DryRunReport_CreatedInSubdirectory()
+		{
+			var reportDir = Path.Combine(_tempDir, "Target", "SyncReports");
+			Directory.CreateDirectory(reportDir);
+			var reportPath = Path.Combine(reportDir, "virtues-2026-06-03_02-00-00.md");
+
+			var result = new CellLevelDiffResult
+			{
+				TotalGDriveRows = 5,
+				TotalLocalRows = 5,
+				PkMatched = 5,
+				CellsCompared = 25,
+			};
+			result.PatchesToApply.Add(new CellPatch
+			{
+				A1Notation = "A2",
+				ColumnName = "pk",
+				PrimaryKey = "1",
+				OldValue = "old",
+				NewValue = "new",
+			});
+
+			File.WriteAllText(reportPath, result.ToReport());
+
+			Assert.True(File.Exists(reportPath));
+			var content = File.ReadAllText(reportPath);
+			Assert.Contains("Cells to patch: 1", content);
+		}
+
+		// --- Runner routing logic (config-based) ---
+
+		[Fact]
+		public void GSheetSyncConfig_CellLevelUpload_EnabledByDefault()
+		{
+			// Verify that a fresh config routes to cell-level path
+			var config = new GSheetSyncConfig();
+			Assert.True(config.UseCellLevelUpload,
+				"Default should be cell-level (formula-aware) upload");
+		}
+
+		[Fact]
+		public void GSheetSyncConfig_DirectionDefaultsToDownload()
+		{
+			var config = new GSheetSyncConfig();
+			Assert.Equal(SyncDirection.Download, config.Direction);
+		}
+
+		// --- Cell-level edge case tests ---
+
+		[Fact]
+		public void CellLevelDiffEngine_EmptyGDrive_ProducesNoPatches()
+		{
+			var gdrive = new SheetSnapshot
+			{
+				Values = new List<IList<object>>(),
+				Formulas = new List<IList<object>>(),
+				ProtectedCells = new HashSet<(int, int)>(),
+			};
+
+			var csv = "pk,title\n1,A\n2,B";
+			var engine = new CellLevelDiffEngine("pk");
+			var result = engine.Compare(gdrive, csv);
+
+			Assert.Empty(result.PatchesToApply);
+			Assert.Equal(0, result.TotalGDriveRows);
+			Assert.Equal(2, result.TotalLocalRows);
+		}
+
+		[Fact]
+		public void CellLevelDiffEngine_MultipleFormulaCells_AllSkipped()
+		{
+			var gdrive = new SheetSnapshot
+			{
+				Values = new List<IList<object>>
+				{
+					new List<object> { "pk", "col_a", "col_b" },
+					new List<object> { "1", "100", "200" },
+				},
+				Formulas = new List<IList<object>>
+				{
+					new List<object> { "pk", "col_a", "col_b" },
+					new List<object> { "1", "=A2*2", "=B2*3" },
+				},
+				ProtectedCells = new HashSet<(int, int)> { (1, 1), (1, 2) },
+			};
+
+			var csv = "pk,col_a,col_b\n1,999,888";
+			var engine = new CellLevelDiffEngine("pk");
+			var result = engine.Compare(gdrive, csv);
+
+			Assert.Empty(result.PatchesToApply);
+			Assert.Equal(2, result.ProtectedSkips.Count);
+		}
+
+		[Fact]
+		public void CellLevelDiffEngine_MixedFormulaAndValue_FormulaSkippedValuePatched()
+		{
+			var gdrive = new SheetSnapshot
+			{
+				Values = new List<IList<object>>
+				{
+					new List<object> { "pk", "title", "computed" },
+					new List<object> { "1", "Old Title", "42" },
+				},
+				Formulas = new List<IList<object>>
+				{
+					new List<object> { "pk", "title", "computed" },
+					new List<object> { "1", "Old Title", "=A2+B2" },
+				},
+				ProtectedCells = new HashSet<(int, int)> { (1, 2) },
+			};
+
+			var csv = "pk,title,computed\n1,New Title,99";
+			var engine = new CellLevelDiffEngine("pk");
+			var result = engine.Compare(gdrive, csv);
+
+			Assert.Single(result.PatchesToApply);
+			Assert.Equal("title", result.PatchesToApply[0].ColumnName);
+			Assert.Equal("New Title", result.PatchesToApply[0].NewValue);
+
+			Assert.Single(result.ProtectedSkips);
+			Assert.Equal("computed", result.ProtectedSkips[0].ColumnName);
+		}
+
+		[Fact]
+		public void CellLevelDiffEngine_IdenticalData_NoPatches()
+		{
+			var gdrive = new SheetSnapshot
+			{
+				Values = new List<IList<object>>
+				{
+					new List<object> { "pk", "title" },
+					new List<object> { "1", "Ad Hominem" },
+					new List<object> { "2", "Straw Man" },
+				},
+				Formulas = new List<IList<object>>
+				{
+					new List<object> { "pk", "title" },
+					new List<object> { "1", "Ad Hominem" },
+					new List<object> { "2", "Straw Man" },
+				},
+				ProtectedCells = new HashSet<(int, int)>(),
+			};
+
+			var csv = "pk,title\n1,Ad Hominem\n2,Straw Man";
+			var engine = new CellLevelDiffEngine("pk");
+			var result = engine.Compare(gdrive, csv);
+
+			Assert.Empty(result.PatchesToApply);
+			Assert.Empty(result.ProtectedSkips);
+			Assert.Equal(2, result.PkMatched);
+		}
+
+		[Fact]
+		public void CellLevelDiffEngine_WhitespaceNormalization_IgnoresTrailingSpaces()
+		{
+			var gdrive = new SheetSnapshot
+			{
+				Values = new List<IList<object>>
+				{
+					new List<object> { "pk", "title" },
+					new List<object> { "1", "Ad Hominem " }, // trailing space
+				},
+				Formulas = new List<IList<object>>
+				{
+					new List<object> { "pk", "title" },
+					new List<object> { "1", "Ad Hominem " },
+				},
+				ProtectedCells = new HashSet<(int, int)>(),
+			};
+
+			var csv = "pk,title\n1, Ad Hominem"; // leading space
+			var engine = new CellLevelDiffEngine("pk");
+			var result = engine.Compare(gdrive, csv);
+
+			Assert.Empty(result.PatchesToApply); // Both normalize to "Ad Hominem"
+		}
+
+		// --- ToReport edge cases ---
+
+		[Fact]
+		public void CellLevelDiffResult_ToReport_TruncatesLongPatches()
+		{
+			var result = new CellLevelDiffResult();
+			var longValue = new string('X', 100);
+			result.PatchesToApply.Add(new CellPatch
+			{
+				A1Notation = "A1",
+				ColumnName = "desc",
+				PrimaryKey = "1",
+				OldValue = longValue,
+				NewValue = longValue,
+			});
+
+			var report = result.ToReport();
+			Assert.Contains("...", report); // Should truncate
+		}
+
+		[Fact]
+		public void CellLevelDiffResult_ToReport_LimitsPatchesTo100()
+		{
+			var result = new CellLevelDiffResult();
+			for (int i = 0; i < 150; i++)
+			{
+				result.PatchesToApply.Add(new CellPatch
+				{
+					A1Notation = $"A{i + 1}",
+					ColumnName = "title",
+					PrimaryKey = $"{i}",
+					OldValue = "old",
+					NewValue = "new",
+				});
+			}
+
+			var report = result.ToReport();
+			Assert.Contains("+50 more", report);
+		}
+
+		[Fact]
+		public void CellLevelDiffResult_ToReport_LimitsProtectedTo50()
+		{
+			var result = new CellLevelDiffResult();
+			for (int i = 0; i < 75; i++)
+			{
+				result.ProtectedSkips.Add(new CellPatch
+				{
+					A1Notation = $"B{i + 1}",
+					ColumnName = "computed",
+					PrimaryKey = $"{i}",
+					OldValue = "=FORMULA",
+					NewValue = "value",
+					SkipReason = PatchSkipReason.FormulaProtected,
+				});
+			}
+
+			var report = result.ToReport();
+			Assert.Contains("+25 more", report);
+		}
+
+		// --- Obsolete attribute test ---
+
+		[Fact]
+		public void GSheetService_UpdateSheetDataAsync_IsObsolete()
+		{
+			var method = typeof(GSheetService).GetMethod("UpdateSheetDataAsync");
+			Assert.NotNull(method);
+			var attr = method.GetCustomAttributes(typeof(ObsoleteAttribute), false)
+				.Cast<ObsoleteAttribute>().FirstOrDefault();
+			Assert.NotNull(attr);
+			Assert.Contains("BatchUpdateCellsAsync", attr.Message);
+		}
+	}
+}

--- a/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetService.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetService.cs
@@ -186,7 +186,11 @@ namespace Argumentum.AssetConverter.GSheetSync
 
 		/// <summary>
 		/// Writes a 2D grid to a sheet tab (clears existing data first, then writes).
+		/// Obsolete: prefer cell-level upload via <see cref="BatchUpdateCellsAsync"/>
+		/// which preserves formulas and avoids destructive full-sheet overwrite.
 		/// </summary>
+		[Obsolete("Use BatchUpdateCellsAsync for formula-aware cell-level updates. " +
+		          "Full-sheet clear+write destroys formulas.")]
 		public async Task UpdateSheetDataAsync(string spreadsheetId, string sheetTitle, IList<IList<object>> grid)
 		{
 			var range = $"'{sheetTitle}'";

--- a/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncConfig.cs
@@ -47,5 +47,19 @@ namespace Argumentum.AssetConverter.GSheetSync
 		public bool AbortOnColumnStructureChange { get; set; } = true;
 
 		public int MaxOverwriteExamplesToShow { get; set; } = 5;
+
+		/// <summary>
+		/// When true (default), upload uses cell-level patching via
+		/// <see cref="CellLevelDiffEngine"/> which skips formula-protected
+		/// cells. When false, falls back to full-sheet clear+write via
+		/// the obsolete <see cref="GSheetService.UpdateSheetDataAsync"/>.
+		/// </summary>
+		public bool UseCellLevelUpload { get; set; } = true;
+
+		/// <summary>
+		/// Directory where DryRun markdown reports are written.
+		/// Relative paths resolve from the project output directory.
+		/// </summary>
+		public string SyncReportsPath { get; set; } = "Target/SyncReports";
 	}
 }

--- a/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncRunner.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/GSheetSync/GSheetSyncRunner.cs
@@ -101,7 +101,165 @@ namespace Argumentum.AssetConverter.GSheetSync
 
 		private async Task RunUploadAsync()
 		{
-			Console.WriteLine("--- Upload: Local CSV → GSheet ---");
+			if (_config.UseCellLevelUpload)
+			{
+				await RunCellLevelUploadAsync();
+			}
+			else
+			{
+				await RunFullSheetUploadAsync();
+			}
+		}
+
+		/// <summary>
+		/// Cell-level upload: downloads GDrive with formulas, diffs against local CSV,
+		/// patches only changed non-formula cells. Preserves formulas on GDrive.
+		/// </summary>
+		private async Task RunCellLevelUploadAsync()
+		{
+			Console.WriteLine("--- Upload: Local CSV → GSheet (cell-level, formula-aware) ---");
+
+			// Step 1: Load local CSV
+			string localPath = ResolveLocalPath(_config.LocalCsvPath);
+
+			if (!File.Exists(localPath))
+			{
+				Console.WriteLine($"  ✗ Local CSV not found: {localPath}");
+				return;
+			}
+
+			var localCsv = await File.ReadAllTextAsync(localPath);
+			Console.WriteLine($"  Local CSV: {localCsv.Split('\n').Length} lines");
+
+			// Step 2: Initialize service and download formula-aware snapshot
+			var (service, sheetTitle) = await InitializeServiceAsync();
+
+			Console.WriteLine("  Downloading formula-aware snapshot...");
+			var snapshot = await service.GetSheetWithFormulasAsync(_config.SpreadsheetId, _config.Gid);
+			Console.WriteLine($"  Downloaded {snapshot.Values.Count} rows ({snapshot.ProtectedCells.Count} formula-protected cells)");
+
+			// Step 3: Compute cell-level diff
+			var cellDiffEngine = new CellLevelDiffEngine(_config.PrimaryKeyColumn);
+			var cellDiff = cellDiffEngine.Compare(snapshot, localCsv);
+
+			Console.WriteLine($"  Cell diff: {cellDiff.PatchesToApply.Count} patches, " +
+			                  $"{cellDiff.ProtectedSkips.Count} formula-protected, " +
+			                  $"{cellDiff.PkUnmatched} PK unmatched");
+
+			// Step 3b: Also run row-level diff for safety checks
+			var currentSheetCsv = service.GridToCsv(snapshot.Values);
+			var rowDiffEngine = new CsvDiffEngine(
+				_config.PrimaryKeyColumn,
+				_config.MaxOverwriteExamplesToShow,
+				_config.CsvDelimiter);
+			var rowDiff = rowDiffEngine.Compare(currentSheetCsv, localCsv);
+
+			// Step 4: Safety check (row-level thresholds)
+			var safetyChecker = new SyncSafetyChecker();
+			var safetyResult = safetyChecker.Evaluate(rowDiff, _config);
+
+			if (safetyResult.Warnings.Count > 0)
+			{
+				Console.ForegroundColor = ConsoleColor.Yellow;
+				foreach (var warning in safetyResult.Warnings)
+				{
+					Console.WriteLine($"  ⚠ {warning}");
+				}
+				Console.ResetColor();
+			}
+
+			if (!safetyResult.IsSafe)
+			{
+				Console.ForegroundColor = ConsoleColor.Red;
+				Console.WriteLine("  ✗ Safety check FAILED — upload aborted:");
+				foreach (var error in safetyResult.Errors)
+				{
+					Console.WriteLine($"    ✗ {error}");
+				}
+				Console.ResetColor();
+				return;
+			}
+
+			// Step 5: Write DryRun report to file
+			var reportDir = ResolveLocalPath(_config.SyncReportsPath);
+			Directory.CreateDirectory(reportDir);
+			var reportPath = Path.Combine(reportDir,
+				$"{_config.Name}-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.md");
+			var reportContent = cellDiff.ToReport();
+			await File.WriteAllTextAsync(reportPath, reportContent);
+			Console.WriteLine($"  DryRun report written: {reportPath}");
+
+			if (cellDiff.PatchesToApply.Count == 0)
+			{
+				Console.WriteLine("  ✓ No patches to apply — local and GDrive are in sync.");
+				return;
+			}
+
+			// Step 6: Dry-run check
+			if (_config.DryRun)
+			{
+				Console.WriteLine("  [DRY RUN] No remote changes made. Set DryRun=false to apply changes.");
+				Console.WriteLine($"  Report: {reportPath}");
+				return;
+			}
+
+			// Step 7: User confirmation
+			if (_config.RequireConfirmation)
+			{
+				Console.Write("  Upload cell-level patches to Google Sheets? (y/N): ");
+				var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+				if (response != "y" && response != "yes")
+				{
+					Console.WriteLine("  Cancelled by user.");
+					return;
+				}
+			}
+
+			// Step 8: Create backup
+			if (_config.CreateBackupBeforeUpload)
+			{
+				Console.WriteLine("  Creating backup tab...");
+				var backupTitle = await service.CreateBackupSheetAsync(
+					_config.SpreadsheetId, sheetTitle);
+				Console.WriteLine($"  ✓ Backup created: '{backupTitle}'");
+			}
+
+			// Step 9: Apply patches
+			Console.WriteLine($"  Applying {cellDiff.PatchesToApply.Count} cell patches...");
+			await service.BatchUpdateCellsAsync(
+				_config.SpreadsheetId, sheetTitle, cellDiff.PatchesToApply);
+			Console.WriteLine($"  ✓ {cellDiff.PatchesToApply.Count} cells patched");
+
+			// Step 10: Verification
+			Console.WriteLine("  Verifying patches...");
+			var mismatches = await service.VerifyCellPatchesAsync(
+				_config.SpreadsheetId, sheetTitle, cellDiff.PatchesToApply);
+
+			if (mismatches.Count > 0)
+			{
+				Console.ForegroundColor = ConsoleColor.Yellow;
+				Console.WriteLine($"  ⚠ {mismatches.Count} verification mismatches:");
+				foreach (var mm in mismatches.Take(10))
+				{
+					Console.WriteLine($"    ⚠ {mm}");
+				}
+				if (mismatches.Count > 10)
+					Console.WriteLine($"    ... (+{mismatches.Count - 10} more)");
+				Console.ResetColor();
+			}
+			else
+			{
+				Console.WriteLine("  ✓ All patches verified — upload successful.");
+			}
+		}
+
+		/// <summary>
+		/// Full-sheet upload (legacy): clears entire sheet and writes local CSV.
+		/// Destroys formulas. Kept for backward compatibility.
+		/// </summary>
+		private async Task RunFullSheetUploadAsync()
+		{
+			Console.WriteLine("--- Upload: Local CSV → GSheet (full-sheet, legacy) ---");
 
 			// Step 1: Load local CSV
 			string localPath = ResolveLocalPath(_config.LocalCsvPath);
@@ -185,11 +343,13 @@ namespace Argumentum.AssetConverter.GSheetSync
 				Console.WriteLine($"  ✓ Backup created: '{backupTitle}'");
 			}
 
-			// Step 8: Upload
-			Console.WriteLine("  Uploading data...");
+			// Step 8: Upload (legacy full-sheet overwrite)
+#pragma warning disable CS0618 // Suppress obsolete warning for backward compat
+			Console.WriteLine("  Uploading data (full-sheet overwrite)...");
 			var uploadGrid = GSheetService.CsvToGrid(localCsv);
 			await service.UpdateSheetDataAsync(
 				_config.SpreadsheetId, sheetTitle, uploadGrid);
+#pragma warning restore CS0618
 			Console.WriteLine($"  ✓ Uploaded {uploadGrid.Count} rows to '{sheetTitle}'");
 
 			// Step 9: Verification


### PR DESCRIPTION
## Summary

Implements the B2 cell-level diff uploader for GSheet sync, building on the PR #200 infrastructure (CsvDiffEngine, SyncSafetyChecker, 77 tests).

## Changes

### Infrastructure (wired into runner)
- **`GSheetSyncRunner.RunCellLevelUploadAsync()`** — New cell-level upload path:
  1. Downloads formula-aware snapshot (`GetSheetWithFormulasAsync` → FORMULA + UNFORMATTED_VALUE double-get)
  2. Computes cell-level diff (`CellLevelDiffEngine` → `CellPatch` with `SkipReason`)
  3. Runs row-level safety checks (deletion/modification thresholds via `SyncSafetyChecker`)
  4. Writes DryRun markdown report to `Target/SyncReports/<dataset>-<ts>.md`
  5. Applies patches via `BatchUpdateCellsAsync` (RAW mode, no formula injection)
  6. Verifies via `VerifyCellPatchesAsync` (re-read + mismatch detection)
- **`GSheetSyncRunner.RunFullSheetUploadAsync()`** — Legacy path preserved as fallback (`UseCellLevelUpload = false`)
- **`GSheetSyncConfig.UseCellLevelUpload`** — Flag (default: `true`) to select cell-level vs full-sheet
- **`GSheetSyncConfig.SyncReportsPath`** — Configurable DryRun report directory (default: `Target/SyncReports`)

### Obsolete marker
- **`GSheetService.UpdateSheetDataAsync`** — Marked `[Obsolete]` with migration guidance to `BatchUpdateCellsAsync`

### Tests (+17 new, 131→148 pass)
- Config defaults (`UseCellLevelUpload=true`, `SyncReportsPath`, `Direction`)
- DryRun report file persistence (subdirectory creation, content verification)
- Edge cases: empty GDrive, multiple formula cells all skipped, mixed formula+value, identical data, whitespace normalization
- ToReport: long value truncation, patch limit (100), protected limit (50)
- Obsolete attribute verification via reflection

## Test Results
```
148 pass / 0 fail / 5 skip
```

## Guardrails
- **⛔ STOP before GDrive live** — OAuth pending, code + tests are mock-only
- No CSV modification before CardPen injection (C# = source of truth)
- Formula-protected cells are NEVER overwritten
- RAW input mode prevents accidental formula injection from CSV values
- Safety thresholds (deletion %, modification %, column structure change) still enforced

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)