### PR TITLE
fix(#29): deterministic Magick.NET dispose — P0 memory fix

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -84,7 +84,6 @@ namespace Argumentum.AssetConverter
              string imageName, string imageUrl, double sourceDpi)
         {
 	        string toReturn;
-            MagickImage imageFromEmbeddedUrl;
 
 			var imagesFolderName = config.GetImagesDirectory(language);
 
@@ -92,27 +91,18 @@ namespace Argumentum.AssetConverter
 
 			         if (File.Exists(imageFileName))
             {
-				//imageFromEmbeddedUrl = new MagickImage(imageFileName);
-
 				Logger.Log($"Skip existing image: {imageFileName}");
 				toReturn = imageFileName;
 			}
             else
             {
-                if (imageUrl.StartsWith("data:image"))
+                // #29 fix: deterministic dispose of MagickImage after processing
+                using var imageFromEmbeddedUrl = imageUrl switch
                 {
-                    imageFromEmbeddedUrl = ImageHelper.LoadImageFromEmbeddedUrl(imageUrl);
-                }
-                else if (imageUrl.PathIsUrl())
-                {
-                    // This case might be for other URL types in the future,
-                    // but for now, we assume it's also an embedded URL.
-                    imageFromEmbeddedUrl = ImageHelper.LoadImageFromEmbeddedUrl(imageUrl);
-                }
-                else
-                {
-                    imageFromEmbeddedUrl = ImageHelper.LoadImageFromPath(imageUrl);
-                }
+                    _ when imageUrl.StartsWith("data:image") => ImageHelper.LoadImageFromEmbeddedUrl(imageUrl),
+                    _ when imageUrl.PathIsUrl() => ImageHelper.LoadImageFromEmbeddedUrl(imageUrl),
+                    _ => ImageHelper.LoadImageFromPath(imageUrl)
+                };
                 imageFromEmbeddedUrl.Density = new Density(sourceDpi);
                 if (documentCardSet.SaveOriginalImage)
                 {

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
@@ -201,7 +201,10 @@ namespace Argumentum.AssetConverter
                 }
                 else
                 {
-                    targetFile.documentImages().Write(targetFile.fileName);
+                    // #29 fix: deterministic dispose of MagickImageCollection after write
+                    // prevents ~1.2 GB peak held until GC finalizer (especially Fallacies Tarot ~277 images)
+                    using var collection = targetFile.documentImages();
+                    collection.Write(targetFile.fileName);
                     Logger.LogSuccess($"Generated pdf document {targetFile.fileName}");
                 }
             }


### PR DESCRIPTION
## P0 Memory Fix — Held PR (merge post-release)

### Problem
`PdfManager.cs` and `ImageHelper.cs` create `MagickImage`/`MagickImageCollection` objects without deterministic disposal. The GC finalizer eventually reclaims them, but during a Release run (Fallacies Tarot ~277 images × 4.5 MB each), **~1.2 GB of unmanaged memory** remains resident until the finalizer runs.

This is the likely root cause of the timeout crash band-aided by commit `f2d2c55e` (#406: timeout 120→300s): GC pressure from undisposed Magick objects causes prolonged GC pauses, which makes Playwright rendering exceed timeouts.

### Changes

**PdfManager.cs — `GeneratePdfsFromImages` (line 204)**
- Wrap `MagickImageCollection` in `using var` → deterministic `Dispose()` after `.Write()`
- The collection owns its child `MagickImage` objects → `Dispose()` cascades
- Covers all 4 code paths (`GenerateFacesOnly`, `GenerateAlternateFaceAndBack`, `GenerateBackFirstOneDocPerBack`, faces-only partition)

**ImageHelper.cs — `LoadAndProcessImageUrl` (lines 99-105)**
- Replace `if/else if/else` + separate variable declaration with `using var` + switch expression
- Remove dead commented-out code and unused `MagickImage imageFromEmbeddedUrl` declaration
- Deterministic disposal after `.Write()` at end of processing block

### Testing
- **148 pass / 0 fail / 5 skip** (identical to master)
- Build: 0 errors (existing warnings unchanged)

### Impact
- **~1.2 GB** freed deterministically per PDF generation (instead of waiting for GC finalizer)
- Zero behavioral change — disposal happens after PDF is fully materialized on disk
- Merge timing: **held until post-release batch** (PdfManager is release-critical; dossier #140 must stay frozen until jsboige Thursday sign-off)

### Connection to #406
The timeout 120→300s band-aid (`f2d2c55e`) masks GC pressure symptoms. This fix addresses the root cause. If after merge the Release run completes within 120s, the timeout can be reverted to its original value.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>