### PR TITLE
fix(security): harden web.config — CSP, HSTS, cookies, crypto (#131)

### DIFF
--- a/DNNPlatform/web.config
+++ b/DNNPlatform/web.config
@@ -133,13 +133,22 @@
         <remove name="X-Powered-By" />
         <remove name="X-XSS-Protection" />
         <remove name="X-Frame-Options" />
+        <remove name="X-Content-Type-Options" />
+        <remove name="Strict-Transport-Security" />
         <add name="X-XSS-Protection" value="1; mode=block" />
         <add name="X-Frame-Options" value="SAMEORIGIN" />
+        <add name="X-Content-Type-Options" value="nosniff" />
+        <!-- #131 Security hardening: HSTS — activate ONLY when site is fully HTTPS in production -->
+        <!-- <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" /> -->
+        <!-- #131 Security hardening: CSP — restrictive default; relax per-site as needed -->
+        <add name="Content-Security-Policy" value="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src 'self'; connect-src 'self' https://api.stripe.com;" />
+        <add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
+        <add name="Permissions-Policy" value="camera=(), microphone=(), geolocation=()" />
       </customHeaders>
     </httpProtocol>
   </system.webServer>
   <system.web>
-    <machineKey validationKey="REPLACE" decryptionKey="REPLACE" decryption="3DES" validation="SHA1" />
+    <machineKey validationKey="REPLACE" decryptionKey="REPLACE" decryption="AES" validation="HMACSHA256" />
     <!-- set code access security trust level - this is generally set in the machine.config
     <trust level="Full" originUrl=".*" />
     -->
@@ -174,7 +183,7 @@
     -->
     <!-- allow large file uploads -->
     <httpRuntime targetFramework="4.8" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="28672" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false" requestValidationMode="2.0" fcnMode="Single" />
-    <httpCookies httpOnlyCookies="true" requireSSL="false" domain="" />
+    <httpCookies httpOnlyCookies="true" requireSSL="true" domain="" />
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.
     Utf-8 is not supported on Netscape 4.x
@@ -220,7 +229,7 @@
           cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered
           domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
-    <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain="" />
+    <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="true" cookieSlidingExpiration="true" cookieProtection="All" domain="" />
     <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
       <providers>
         <clear />
@@ -238,7 +247,7 @@
                 passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES)
                 description="string"                        Description of what the provider does
                 -->
-        <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="SiteSqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="0" requiresUniqueEmail="false" passwordFormat="Hashed" applicationName="DotNetNuke" description="Stores and retrieves membership data from the local Microsoft SQL Server database" />
+        <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="SiteSqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" minRequiredPasswordLength="12" minRequiredNonalphanumericCharacters="1" requiresUniqueEmail="false" passwordFormat="Hashed" applicationName="DotNetNuke" description="Stores and retrieves membership data from the local Microsoft SQL Server database" />
       </providers>
     </membership>
   </system.web>
@@ -752,8 +761,8 @@
     <authServices>
       <messageHandlers>
         <clear />
-        <add name="BasicAuth" type="DotNetNuke.Web.Api.Auth.BasicAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="false" />
-        <add name="DigestAuth" type="DotNetNuke.Web.Api.Auth.DigestAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="false" />
+        <add name="BasicAuth" type="DotNetNuke.Web.Api.Auth.BasicAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="true" />
+        <add name="DigestAuth" type="DotNetNuke.Web.Api.Auth.DigestAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="true" />
       </messageHandlers>
     </authServices>
     <cryptography defaultProvider="FipsCompilanceCryptographyProvider">


### PR DESCRIPTION
@
## Security hardening — DNNPlatform/web.config (#131)

Prep work for #131 Phase D. Harden the web.config snapshot (keys-excluded, safe to commit). The real production web.config (with machineKey/connection strings) is on the VPS — jsboige applies changes manually.

### Changes (+15/-6, 1 file)

**HTTP response headers** (`system.webServer/httpProtocol`):
- Add `X-Content-Type-Options: nosniff` — prevent MIME sniffing
- Add `Content-Security-Policy` — restrictive default (self + needed CDN exceptions for Stripe/JS/fonts)
- Add `Referrer-Policy: strict-origin-when-cross-origin`
- Add `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- `Strict-Transport-Security` — **commented out** (activate only when prod is fully HTTPS)

**Cryptography** (`machineKey`):
- `decryption`: 3DES → **AES**
- `validation`: SHA1 → **HMACSHA256**

**Cookies**:
- `httpCookies requireSSL`: false → **true** — cookies only over HTTPS
- `anonymousIdentification cookieRequireSSL`: false → **true**
- `anonymousIdentification cookieProtection`: None → **All** (encryption + validation)

**Password policy** (`AspNetSqlMembershipProvider`):
- `minRequiredPasswordLength`: 7 → **12**
- `minRequiredNonalphanumericCharacters`: 0 → **1**

**Auth services**:
- `BasicAuth/DigestAuth forceSSL`: false → **true**

### PR Status
**HOLD** — merge timing:
- This PR is independent of the pipeline release (#140 sign-off)
- Can be merged at any point before or after the DNN platform upgrade
- jsboige will need to apply equivalent changes to the production web.config on VPS

### Testing
- Static config change only — no automated tests applicable
- Verify in staging: check response headers via `curl -I`, confirm cookies set with `Secure` flag
- CSP may need relaxation if third-party resources are added (analytics, fonts, etc.)

### Related
- #131 (DNN platform update + security)
- Security audit comment: https://github.com/ArgumentumGames/Argumentum/issues/131#issuecomment-4630922563
- Dependabot #120 (368 alerts, mostly npm transitive)
@