### PR TITLE
fix(i18n): localize Mémo Back taxonomy labels EN/RU/PT (#443 follow-up)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Localization/FallaciesLocalizationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Localization/FallaciesLocalizationTests.cs
@@ -58,6 +58,21 @@ namespace Argumentum.AssetConverter.Tests.Localization
 			return template;
 		}
 
+		// Mirrors the Back branch of CardSetLocalization.TranslateCardSetInfo (front:false) — at runtime
+		// the Memo Back card is localized through BackFieldConversions, NOT FrontFieldConversions.
+		private static string ApplyBackSubstitution(CardSetLocalization loc, string template, string destLang)
+		{
+			foreach (var fieldConversion in loc.BackFieldConversions)
+			{
+				var sourcePattern = loc.FormatField(fieldConversion.sourceFieldName);
+				var conv = fieldConversion.fieldConversions.FirstOrDefault(c => c.Language == destLang);
+				if (string.IsNullOrEmpty(conv.destFieldName)) continue;
+				var destPattern = loc.FormatField(conv.destFieldName);
+				template = template.Replace(sourcePattern, destPattern);
+			}
+			return template;
+		}
+
 		[Theory]
 		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "en")]
 		[InlineData("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "ru")]
@@ -148,6 +163,69 @@ namespace Argumentum.AssetConverter.Tests.Localization
 			//     so that Famille(FR)==text_fr(FR) still groups all 8 families correctly.
 			translated.Should().Contain("text_fr ",
 				$"{destLang} Memo Back ifCond must keep text_fr (FR-invariant selector for family grouping)");
+		}
+
+		[Theory]
+		[InlineData("en", "Family", "Subfamily", "Subsubfamily")]
+		[InlineData("ru", "Family_ru", "Subfamily_ru", "Subsubfamily_ru")]
+		[InlineData("pt", "Family_pt", "Subfamily_pt", "Subsubfamily_pt")]
+		public void Memo_Back_Taxonomy_Display_Tokens_Are_Localized_While_Grouping_Selector_Stays_FR(
+			string destLang, string family, string subfamily, string subsubfamily)
+		{
+			// Regression test for the #358/#435/#443 follow-up — the Memo Back card kept its taxonomy
+			// labels in French (Famille / Sous-Famille / Soussousfamille) in EN/RU/PT because the Memo
+			// BackFieldConversions only carried tagline_fr. At runtime the Back is rendered through
+			// BackFieldConversions (TranslateCardSetInfo, front:false), so the taxonomy DISPLAY tokens
+			// must be localized there — while the FR-invariant ifCond family selector (Famille == text_fr)
+			// must stay untouched so the 8 families still group correctly.
+			var original = ReadTemplate("Cards/Memo/Argumentum_Memo_Back_fr.json");
+			var loc = GetFallaciesLocalization();
+
+			var translated = ApplyBackSubstitution(loc, original, destLang);
+			translated = loc.DoStaticConversions(translated, destLang);
+
+			// (a) Display tokens localized to the real CSV columns (casing matters — CsvHelper is case-sensitive).
+			translated.Should().Contain("{{" + family + "}}", $"{destLang} Back must bind family label to CSV column '{family}'");
+			translated.Should().Contain("{{" + subfamily + "}}", $"{destLang} Back must bind subfamily label to CSV column '{subfamily}'");
+			translated.Should().Contain("{{" + subsubfamily + "}}", $"{destLang} Back must bind subsubfamily label to CSV column '{subsubfamily}'");
+
+			// (b) French display tokens must be gone.
+			translated.Should().NotContain("{{Famille}}", $"{destLang} Back family label must no longer be the FR token");
+			translated.Should().NotContain("{{Sous-Famille}}", $"{destLang} Back subfamily label must no longer be the FR token");
+			translated.Should().NotContain("{{Soussousfamille}}", $"{destLang} Back subsubfamily label must no longer be the FR token");
+
+			// (c) The FR-invariant grouping selector must survive: ifCond keeps Famille == text_fr.
+			//     NB: this template is read raw from the .json (no JSON-unescape), so the operator quotes
+			//     appear escaped on disk as \"==\" — assert against that on-disk form.
+			translated.Should().Contain("Famille \\\"==\\\"", $"{destLang} Back ifCond family operand must stay FR (data-driven grouping)");
+			translated.Should().Contain("text_fr ", $"{destLang} Back ifCond must keep text_fr (FR-invariant selector)");
+
+			// (d) The CSS colour class binding ({{Famille_camelCase}}) must stay intact.
+			translated.Should().Contain("Famille_camelCase", $"{destLang} Back CSS colour class binding must be preserved");
+
+			// (e) Subtitle still localized via StaticConversions.
+			translated.Should().NotContain("L'art de jamais avoir tort", $"{destLang} Back subtitle must be translated (#358)");
+		}
+
+		[Fact]
+		public void Memo_Back_Conversions_Include_Taxonomy_Ordered_MostSpecificFirst()
+		{
+			var loc = GetFallaciesLocalization();
+			var names = loc.BackFieldConversions.Select(c => c.sourceFieldName).ToList();
+
+			names.Should().Contain("Soussousfamille", "Memo Back must localize the subsubfamily label (#443 follow-up)");
+			names.Should().Contain("Sous-Famille", "Memo Back must localize the subfamily label (#443 follow-up)");
+			names.Should().Contain("Famille", "Memo Back must localize the family label (#443 follow-up)");
+			names.Should().Contain("tagline_fr", "the original tagline mapping must be preserved");
+
+			var soussousIndex = names.IndexOf("Soussousfamille");
+			var sousIndex = names.IndexOf("Sous-Famille");
+			var familleIndex = names.IndexOf("Famille");
+
+			soussousIndex.Should().BeLessThan(sousIndex,
+				"Soussousfamille must precede Sous-Famille so 'Famille}}' does not clobber 'Sous-Famille}}'");
+			sousIndex.Should().BeLessThan(familleIndex,
+				"Sous-Famille must precede Famille to prevent partial overlap");
 		}
 
 		[Fact]

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -116,6 +116,14 @@ namespace Argumentum.AssetConverter
 						("example_fr", new List<(string Language, string destFieldName)>(new []{("en", "example_en"), ("ru", "example_ru"), ("pt", "example_pt"), ("es", "example_es"), ("ar", "example_ar"), ("fa", "example_fa"), ("zh", "example_zh") }) ),
 					}),
 					BackFieldConversions = new List<(string sourceFieldName, List<(string Language, string destFieldName)> fieldConversions)>(new []{
+						// Memo Back renders the SAME taxonomy display tokens as the Face ({{Famille}}/{{Sous-Famille}}/{{Soussousfamille}}) — #358/#435/#443 follow-up.
+						// Without these the Back stayed FR in EN/RU/PT (only the subtitle localized via StaticConversions). Order: most specific first
+						// (Soussousfamille > Sous-Famille > Famille) so "Famille}}" does not clobber the longer "Sous-Famille}}".
+						// SAFE for the FR-invariant family selector: FormatField appends "}}" with NO space, so it matches {{Famille}} but NOT the
+						// ifCond operand `Famille "=="` (space before "==") nor {{Famille_camelCase}} (CSS colour class). Grouping stays data-driven (8/8).
+						("Soussousfamille", new List<(string Language, string destFieldName)>(new []{("en", "Subsubfamily"), ("ru", "Subsubfamily_ru"), ("pt", "Subsubfamily_pt"), ("es", "Subsubfamily_es"), ("ar", "Subsubfamily_ar"), ("fa", "Subsubfamily_fa"), ("zh", "Subsubfamily_zh") }) ),
+						("Sous-Famille", new List<(string Language, string destFieldName)>(new []{("en", "Subfamily"), ("ru", "Subfamily_ru"), ("pt", "Subfamily_pt"), ("es", "Subfamily_es"), ("ar", "Subfamily_ar"), ("fa", "Subfamily_fa"), ("zh", "Subfamily_zh") }) ),
+						("Famille", new List<(string Language, string destFieldName)>(new []{("en", "Family"), ("ru", "Family_ru"), ("pt", "Family_pt"), ("es", "Family_es"), ("ar", "Family_ar"), ("fa", "Family_fa"), ("zh", "Family_zh") }) ),
 						("tagline_fr", new List<(string Language, string destFieldName)>(new []{("en", "tagline_en"), ("ru", "tagline_ru"), ("pt", "tagline_pt"), ("es", "tagline_es"), ("ar", "tagline_ar"), ("fa", "tagline_fa"), ("zh", "tagline_zh") }) ),
 					}),
 					// StaticConversions: handle hardcoded FR text in Memo templates that FrontFieldConversions


### PR DESCRIPTION
## Problème

La carte **Mémo Back** affichait encore sa taxonomie (`Famille` / `Sous-Famille` / `Soussousfamille`) **en français** dans les langues EN/RU/PT, alors que la Face était bien localisée.

Cause : au runtime, le dos est rendu via `BackFieldConversions` (`CardSetLocalization.TranslateCardSetInfo`, `front:false`), or les `BackFieldConversions` du Mémo ne contenaient **que `tagline_fr`**. Seuls le sous-titre (via `StaticConversions`, #358) et la Face (via `FrontFieldConversions`) étaient traduits. Résidu non couvert par #443 (`81af2279`).

## Correctif

Ajout de `Soussousfamille` / `Sous-Famille` / `Famille` → colonnes `Family*` aux `BackFieldConversions` du Mémo, **du plus spécifique au moins spécifique** pour que `Famille}}` ne vienne pas écraser `Sous-Famille}}`.

**Sûr pour le sélecteur de famille FR-invariant** : `FormatField` ajoute `}}` **sans espace**, donc il matche les tokens d'affichage `{{Famille}}` mais **pas** l'opérande `ifCond` `Famille "=="` (espace avant `==`) ni `{{Famille_camelCase}}` (classe CSS couleur). Le regroupement 8/8 familles, piloté par les données (`Famille` FR == `text_fr` FR), reste intact.

## Tests

`FallaciesLocalizationTests` — nouvelle couverture appliquant `BackFieldConversions` (pas Front) au vrai template `Argumentum_Memo_Back_fr.json` pour EN/RU/PT :
- les tokens taxonomie se localisent (`{{Family}}`, `{{Subfamily}}`, `{{Subsubfamily}}` + variantes `_ru`/`_pt`) ;
- les tokens FR d'affichage disparaissent ;
- le sélecteur de regroupement reste FR (`Famille "=="`, `text_fr`) ;
- la classe CSS `{{Famille_camelCase}}` est préservée ;
- le sous-titre reste localisé via `StaticConversions`.
- + test de forme/ordre de la config.

**Suite complète : 155 pass / 0 fail / 5 skip.**

## Validation visuelle

⚠️ Régénération Mémo Back EN/RU/PT requise après merge (po-2023) → re-validation visuelle ai-01 (Playwright + vision) avant présentation #140/#134 à jsboige. **#435 reste OUVERTE** jusqu'à cette re-validation.

Refs #358 #435 #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
