### PR TITLE
feat(dataset-updater): Fallacies PT register polish task (#411)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -2583,6 +2583,55 @@ public class DatasetUpdaterRootConfig
 				MaxGroupItemNb = 12,
 				WriteOneTargetFileByField = false,
 				MaxChildren = 8
+			},
+			new DatasetUpdaterConfig()
+			{
+				Enabled = false,
+				Name = "Fallacies cosmetic polish PT register gpt-5.5",
+				SourceDataset = KnownDataSets.FallaciesTaxonomy,
+				FieldsToInclude = new List<string>()
+				{
+					"path",
+					"text_fr",
+					"text_en",
+					"text_pt",
+					"desc_pt",
+					"example_pt",
+				},
+				FieldsToUpdate = new List<string>()
+				{
+					"text_pt",
+					"desc_pt",
+					"example_pt",
+				},
+				PrimaryField = "path",
+				TargetPath = @".\Target\Datasets\Argumentum Fallacies - Taxonomy.csv",
+				SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+				DialogPrompts = new List<PromptExample>()
+				{
+					new PromptExample()
+					{
+						UserPromptPath = PromptsRootPath + "PromptCosmeticPolishPtRegisterUser.txt",
+						AssistantAnswerPath = PromptsRootPath + "PromptCosmeticPolishPtRegisterAssistant.txt"
+					}
+				},
+				Model = "gpt-5.5",
+				MaxOutputTokens = 8192,
+				MaxTokensPerMinute = 300000,
+				DivisionMode = DivisionMode.SequentialChunks,
+				ChunkSize = 6,
+				UseFunctionCalling = true,
+				NbMessageCalls = 1,
+				SkipChunkNb = 0,
+				TakeChunkNb = -1,
+				SelectEmptyTargets = false,
+				RandomizeChunks = false,
+				MaxDegreeOfParallelismWebService = 1,
+				CompareMode = false,
+				AutoCompare = true,
+				MaxGroupItemNb = 12,
+				WriteOneTargetFileByField = false,
+				MaxChildren = 8
 			}
 		};
 }


### PR DESCRIPTION
## Summary

Add `DatasetUpdaterConfig` entry for **Fallacies taxonomy PT register harmonization** — the last of the 3 datasets (Virtues ✅, Scenarii ✅, Fallacies 🔜).

## Changes

- New task `"Fallacies cosmetic polish PT register gpt-5.5"` in `DatasetUpdaterRootConfig.cs` (lines 2587-2635)
- Fields: `text_pt`, `desc_pt`, `example_pt` (3 PT text columns to polish)
- Context fields: `path`, `text_fr`, `text_en` (for LLM reference)
- `Enabled = false` — requires manual activation + OpenAI API key

## Pattern

Exact same config as existing Virtues/Scenarii PT register tasks:
- Model: `gpt-5.5`
- `SequentialChunks` with `ChunkSize = 6`
- Function calling enabled (`UpdateRecord` tool)
- `AutoCompare = true`
- Reuses existing prompt files: `PromptCosmeticPolishPtRegisterUser.txt` / `Assistant.txt`

## Validation

- ✅ `dotnet build` — 0 errors
- ✅ `dotnet test` — 151 pass, 0 fail, 5 skip
- ✅ Follows existing Virtues/Scenarii pattern exactly

## Related

- Part of #411 Cat B (i18n cosmetic polish)
- Depends on existing PT register prompts (already committed)
- ai-01 deep queue dispatch: #411 Cat B → po-2024

## Post-merge

jsboige needs to:
1. Set `Enabled = true`
2. Ensure API key path resolves
3. Run smoke test on small sample (e.g., `SkipChunkNb = 0, TakeChunkNb = 2`)
4. Review `AutoCompare` output before full run