### PR TITLE
docs(release): align v0.9.0 notes with master HEAD reality (#456 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The entire pipeline now generates assets in **8 languages**: French, English, Ru
 
 - **CSV data**: 100% translation coverage for Fallacies, Virtues, Scenarii, and Rules across all 8 languages (title, description, example, family hierarchy, links)
 - **PDF generation**: CardSets (Tarot, Poker, A0 posters, Print&Play) produce localized PDFs for all 8 languages via `CardSetLocalizations` field mapping
-- **MindMap SVGs**: FreeMind mind maps generated for all 8 languages with localized node text, family hierarchy, and descriptions
+- **MindMap SVGs**: FreeMind mind maps committed for FR/EN/RU/PT (21 SVGs) with localized node text, family hierarchy, and descriptions; the pipeline is extended (`StaticConversions` + `MindMapLocalization`) for ES/AR/FA/ZH with SVG regeneration pending (#458 Track 1a)
 - **Mémo cards**: Front/back cards with language-invariant grouping selectors and localized taxonomy labels
 - **Rules cards**: Translated rule content for all 8 languages including AR/ES/FA/ZH additions
 - **Entity layer**: Added AR/FA/ZH properties to `Fallacy.cs` (21 properties + 21 CsvHelper mappings) and `Rule.cs` (4 properties)
@@ -44,7 +44,7 @@ Complete restoration of the generation pipeline from the April 2024 Golden Maste
 - **CardPen templates**: Restored `argumentsVertueux` CSS class, fixed Scenarii asset paths to GitHub URLs, auto-shrink overflowing card titles (#316), auto-shrink Virtues body text overflow (#420)
 - **CSV injection**: Restored Golden Master CSV injection (no `Replace("\n", "\\n")` — PapaParse handles newlines correctly)
 - **Configuration**: Removed erroneous `RowsetNb=14` for Scenarii CardSet, restored Virtues CardSet (critical for Print&Play Tarot)
-- **SVG generation**: Replaced XSLT-based SVGs with FreeMind Batik SVGs (20 SVGs, 4 languages × 5 types), automated FreePlane GUI via `SendKeys.SendWait`
+- **SVG generation**: Replaced XSLT-based SVGs with FreeMind Batik SVGs (21 SVGs across FR/EN/RU/PT), automated FreePlane GUI via `SendKeys.SendWait`
 - **Mémo Back cards**: Language-invariant control-break grouping (#449), localized taxonomy labels for all 8 languages (#446), cyrillic font fallbacks + vertical grid auto-fit for RU (#452)
 
 ### Fixed — Data Quality

--- a/RELEASE-NOTES-v0.9.0.md
+++ b/RELEASE-NOTES-v0.9.0.md
@@ -22,17 +22,17 @@ Argumentum now generates its entire educational card game in **8 languages**:
 | فارسی | `fa` | Persian (RTL) | ✅ Complete |
 | 中文 | `zh` | CJK | ✅ Complete |
 
-All CSV data (Fallacies, Virtues, Scenarii, Rules) is 100% translated across all 8 languages. The generation pipeline produces localized PDFs, MindMap SVGs, and card images for each language.
+All CSV data (Fallacies, Virtues, Scenarii, Rules) is 100% translated across all 8 languages. The generation pipeline produces localized PDFs and card images for all 8 languages. MindMap SVGs are currently committed for FR/EN/RU/PT; the pipeline is configured for ES/AR/FA/ZH with SVG regeneration pending (see Known Limitations).
 
 ### 🃏 Generated Assets
 
 | Asset Type | Languages | Count |
 |------------|-----------|-------|
-| Tarot Card PDFs | 8 | ~64 |
-| Poker Card PDFs | 8 | ~8 |
-| A0 Poster PDFs | 8 | ~16 |
-| Print&Play PDFs | 8 | ~16 |
-| MindMap SVGs | 8 | ~40 |
+| Tarot PDFs (cards + Virtues + Print&Play A4) | 8 | 24 |
+| Poker PDFs (cards + Print&Play A4) | 8 | 16 |
+| Fallacies Web PDFs (A0 poster + A4 + Thumbnails) | 8 | 24 |
+| **Total PDFs** | 8 | **64** |
+| MindMap SVGs | 4 (FR/EN/RU/PT) | 21 |
 | Card Images (PNG) | 8 | ~9,834 |
 | OWL Ontology | 1 (FR) | 1 (664 KB) |
 
@@ -89,7 +89,7 @@ Automated visual regression testing for generated assets:
 2. **CJK fonts (ZH)**: Requires system-installed CJK fonts for correct rendering in PDFs and card images
 3. **DNN site**: Deployment pending (#131/#132) — release coupled with site update (Decision 2)
 4. **OWLOntology**: Published in French only — multilingual ontology planned for future release
-5. **MindMap SVGs for AR/FA/ZH**: Pipeline configured but SVG regeneration pending (post-merge #454)
+5. **MindMap SVGs for ES/AR/FA/ZH**: Only FR/EN/RU/PT SVGs are committed (21 files). The pipeline is configured for ES/AR/FA/ZH (`StaticConversions` + `MindMapLocalization` in `AssetConverterConfig.cs`), but SVG regeneration is pending — it requires an attended FreePlane GUI run (`SendKeys.SendWait` desktop automation, skipped by the test suite as "requires interactive session"). Tracked as #458 Track 1a.
 
 ---
 


### PR DESCRIPTION
Corrects 3 discrepancies in merged CHANGELOG.md + RELEASE-NOTES-v0.9.0.md so docs are truthful as of master HEAD `7b57251e`.

**Changes (ground-truth verified):**
- 🔴 MindMap SVGs: claimed 8 langs / ~40 SVGs → actual FR/EN/RU/PT only (21 SVGs). ES/AR/FA/ZH pending Track 1a regen.
- 🟡 Asset table: per-type PDF counts reconciled to 64 = Tarot 24 + Poker 16 + FallaciesWeb 24 (8 types × 8 langs).
- Prose overstatement removed.

Prep for jsboige Sunday validation. Option B (docs align to current reality). If Option A (Track 1a regen) chosen, trivial bump post-regen.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>