### PR TITLE
docs(release): v0.9.0 readiness table + disk root-cause (Docker 488 GB)

### DIFF
--- a/docs/v0.9.0-readiness-and-disk-recovery.md
+++ b/docs/v0.9.0-readiness-and-disk-recovery.md
@@ -1,0 +1,105 @@
+# v0.9.0 — Readiness & Disk Recovery Brief
+
+**Author**: po-2023 (worker) · **Date**: 2026-06-13 · **For**: jsboige (Sunday validation) + ai-01 (coordinator)
+
+This brief consolidates two things in one place: (1) what is ready for the Sunday
+sur-pièce validation, and (2) the root-cause disk diagnosis from the 2026-06-13 cluster
+crash (disk full → wsl/docker/claudish down ~2h), which is **outside the worker scope**
+and requires a human decision.
+
+---
+
+## Part 1 — Sunday Validation Readiness
+
+### What is verified-solid (ground-truthed against master `6f591619`)
+
+| Claim | Verified reality | How verified |
+|-------|------------------|--------------|
+| 8 languages generated | ✅ `ar/en/es/fa/fr/pt/ru/zh` | Release Target subdir inventory |
+| 64 PDFs | ✅ 8 doc types × 8 langs | `find ... -name '*.pdf' \| wc -l` = 64 |
+| PDF types | TarotCards, TarotCards_Virtues, TarotCards_Print&Play_A4, PokerCards, PokerCards_Print&Play_A4, Fallacies_Web_A0, Fallacies_Web_A4, Fallacies_Web_Thumbnails_A4 | per-basename count, each ×8 |
+| MindMap SVGs | ⚠️ **4 langs only** (FR/EN/RU/PT = 21 SVGs) | `Cards/Fallacies/Mindmaps/`: fr=6, en/ru/pt=5 |
+| Tests | 155 pass / 0 fail / 5 skip | dotnet test (pre-crash; not re-run this tick to save disk) |
+| Multi-script rendering | ✅ Latin / Cyrillic / Arabic-RTL / CJK | previously validated inline (Memo Backs FR/RU/AR/ZH + fronts "Généralisation hâtive" FR/AR/ZH) |
+
+### Docs state (merged on master)
+
+All three release docs are now **truthful as of master HEAD** (post #460):
+
+- `CHANGELOG.md` — MindMap line corrected to "FR/EN/RU/PT (21 SVGs)"
+- `RELEASE-NOTES-v0.9.0.md` — asset table reconciles to 64; MindMap row shows 4 langs/21; Known-Limitation #5 names ES (was omitting it)
+- `docs/release-v0.9.0-validation-brief.md` — structured sur-pièce checklist for Sunday
+
+### Open decision for Sunday (jsboige)
+
+- **Option A**: run Track 1a MindMap regen (ES/AR/FA/ZH) → SVGs become 8-lang → trivial docs bump to "8 ✅". This is **ai-01's lane** (foreground FreePlane GUI, deferred to Sunday).
+- **Option B**: docs stay at 4-lang SVGs (already aligned, honest).
+
+Either way, the 🟡 count-table fix is correct and already merged.
+
+### Still frozen (release-gated)
+
+- tag v0.9.0 / GitHub Release #134
+- Release 8-lang full regen (Track 1b)
+- DNN PRs #442 / #444 (go-live coupled)
+
+---
+
+## Part 2 — Disk Root-Cause (cluster crash 2026-06-13)
+
+### The actual culprit: Docker, not Argumentum
+
+```
+C: drive       929.5 GB total, 898 GB used, 31.5 GB free (97% full)
+docker_data.vhdx           487.6 GB   ← 54% of the drive
+  C:\Users\jsboi\AppData\Local\Docker\wsl\disk\docker_data.vhdx
+```
+
+The disk-full crash was caused by **Docker's WSL2 virtual disk ballooning to 488 GB**,
+not by Argumentum build artifacts. This matches jsboige's crash report ("chute de wsl,
+docker, de claudish").
+
+### What a worker CAN clean (Argumentum scope, done this tick)
+
+| Artifact | Size | Status |
+|----------|------|--------|
+| `bin/Debug/**` | 11 GB | ✅ Deleted (regenerable, gitignored) |
+| `bin/Release/.../Target/**` | 12 GB | ⛔ **Intentionally KEPT** — 64 PDFs = Sunday validation proof; regen would cost 5+ GB and erase the evidence |
+| `tmp/` | 196 MB | ✅ Deleted prior tick (stale logs) |
+
+Net worker-side cleanup: ~11 GB. **Disk barely moved (33→31.5 GB free)** — confirming
+the argumentum artifacts are not the fill source.
+
+### What is OUTSIDE worker scope (needs jsboige decision)
+
+These are the real disk consumers and require human/system action:
+
+| Consumer | Size | Action needed |
+|----------|------|---------------|
+| **`docker_data.vhdx`** | **488 GB** | `docker system prune -a --volumes` (if daemon up) + **compact the vhdx** (`wsl --shutdown` then `Optimize-VHD` or `diskpart`). vhdx never auto-shrinks. **jsboige decision** — affects other workloads on this machine, not just Argumentum. |
+| `.git` | 6.1 GB | `git-filter-repo` cleanup = **#415**, a coordinated 3-person operation. HELD. Do not touch. |
+| `.conda` | 10 GB | unrelated to Argumentum |
+| OneDrive / Dropbox | 27 GB | unrelated |
+
+### Recommendation to jsboige
+
+1. **Before any heavy regen** (Track 1a / Release 1b): prune + compact Docker vhdx. At
+   488 GB it will re-fill the drive and crash the cluster again the moment a worker
+   runs `dotnet build` + FreePlane. This is the single highest-impact disk action.
+2. **`.git` 6.1 GB**: keep gated under #415. Not urgent for disk (Docker dominates),
+   but real bloat — good filter-repo candidate when the 3-person window opens.
+3. Argumentum workers should resume normal regen capacity once Docker is under control.
+   At 31.5 GB free with Docker still at 488 GB, a single Release regen is risky.
+
+---
+
+## Handoff
+
+- **po-2023 worker**: cron `cd4109a0` (2h) armed. Queue non-gated safe is empty until
+  Docker is pruned (Track 1a disk-risky) or gate lifts (#136/#135 are #131/#132/#134-gated).
+  Standing by for re-dispatch.
+- **ai-01**: Track 1a is your foreground lane (deferred Sunday). Apply/PR any further
+  worker patches.
+- **jsboige**: (1) prune+compact Docker vhdx to restore cluster stability;
+  (2) Sunday sur-pièce validation per `release-v0.9.0-validation-brief.md`;
+  (3) A/B MindMap decision.


### PR DESCRIPTION
Consolidates Sunday-validation readiness (ground-truthed: 64 PDFs 8×8, 21 SVGs 4-lang, 155/0/5, multi-script) + decision A/B, and documents the cluster crash root-cause diagnostic: **Docker `docker_data.vhdx` = 487.6 GB (54% of C:)** — outside Argumentum scope, blocks heavy regen until jsboige prunes WSL/Docker.

Docs-only (new file). No gate conflict. Patch handoff from po-2023 (commit `1cfae446` → applied `1d02ab42`).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>