### PR TITLE
fix(dnn): make FallacyExplorer culture-aware (cascade loc lang->en->fr)

### DIFF
--- a/DNNPlatform/Portals/1/2sxc/Argumentum/_FallacyExplorer_Root.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Argumentum/_FallacyExplorer_Root.cshtml
@@ -4,6 +4,27 @@
 @{
   var query = App.Query["FallaciesFromCSV"];
   var fallacies = AsList(query);
+
+  // Culture-aware field selection: cascade lang -> en -> fr, mirroring Fallacy.LinkXxxFallback.
+  var lang = (CmsContext.Culture.CurrentCode ?? "fr-fr").Split(new[] { '-' })[0].ToLowerInvariant();
+  var supported = new HashSet<string> { "fr", "en", "ru", "pt", "es", "ar", "fa", "zh" };
+  if (!supported.Contains(lang)) { lang = "fr"; }
+
+  var findOutMore = new Dictionary<string, string> {
+    { "fr", "en savoir plus" }, { "en", "find out more" }, { "ru", "узнать больше" },
+    { "pt", "saber mais" }, { "es", "saber más" }, { "ar", "اعرف المزيد" },
+    { "fa", "بیشتر بدانید" }, { "zh", "了解更多" }
+  };
+
+  string loc(dynamic f, string field)
+  {
+    var primary = ((IDictionary<string, object>)f).ContainsKey(field + "_" + lang) ? f[field + "_" + lang] : null;
+    if (!string.IsNullOrEmpty(primary?.ToString())) { return primary.ToString(); }
+    var en = ((IDictionary<string, object>)f).ContainsKey(field + "_en") ? f[field + "_en"] : null;
+    if (!string.IsNullOrEmpty(en?.ToString())) { return en.ToString(); }
+    var fr = ((IDictionary<string, object>)f).ContainsKey(field + "_fr") ? f[field + "_fr"] : null;
+    return fr?.ToString() ?? "";
+  }
 }
 <div @Edit.TagToolbar(Content)>
    <ul>
@@ -12,12 +33,12 @@
     <li>
       <!-- this creates a link to the current tutorial (data220) and product=id -->
       <a href='@Link.To(parameters: "fallacy/" + fallacy.EntityId)'>
-        @fallacy.text_en (#@fallacy.path)
+        @loc(fallacy, "text") (#@fallacy.path)
       </a>
        <br>
         <em>
-          @fallacy.desc_en 
-          (<a href="@fallacy.link_en" target="_blank">find out more</a>)
+          @loc(fallacy, "desc")
+          (<a href="@loc(fallacy, "link")" target="_blank">@findOutMore[lang]</a>)
         </em>
      </li>
   }
@@ -25,4 +46,3 @@
 
 <!-- unimportant stuff, hidden -->
 </div>
-


### PR DESCRIPTION
## Fix
The Fallacies list `_FallacyExplorer_Root.cshtml` hardcoded `text_en`, `desc_en`, `link_en` and the "find out more" label regardless of the active culture — the page showed English even in FR/AR/ZH/etc.

## Change
- Add culture-aware helper `loc(fallacy, field)` resolving `<field>_<lang>` with **lang → en → fr** fallback, mirroring `Fallacy.LinkXxxFallback` ([Fallacy.cs:22-39](Generation/Converters/Argumentum.AssetConverter/Entities/Fallacy.cs#L22-L39)).
- Culture via `CmsContext.Culture.CurrentCode` ([LocationHelper.cs:13](DNNPlatform/Portals/1/2sxc/Content/bs4/Location/LocationHelper.cs#L13) idiom), clamped to 8 supported languages (default fr).
- "find out more" label translated for all 8 languages.

## Scope
Non-gated prep for **DNN #457 Phase 1**; deployed at go-live. Disk-safe reproduction of po-2023 handoff (commit `21977fe3`) — patch propagation stalled across machines so reproduced byte-for-byte from spec (+24/-4).

## Checklist
- [x] CRLF preserved (Write tool produces LF on this repo; converted via `perl -i -pe`)
- [x] No pipeline code touched (`.cshtml` DNN template only)
- [x] Gate DUR respected — no tag/release

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>