### PR TITLE
feat(pipeline): dissociate front/back target folders + halt before PDF (#28)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/ImageGeneration/Issue28TargetDissociationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/ImageGeneration/Issue28TargetDissociationTests.cs
@@ -1,0 +1,156 @@
+using Xunit;
+using FluentAssertions;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ImageMagick;
+using Xunit.Abstractions;
+
+namespace Argumentum.AssetConverter.Tests.ImageGeneration
+{
+    /// <summary>
+    /// Issue #28: (a) dissociate front/back target folders, (b) halt the pipeline
+    /// before PDF assembly. Both opt-in via config, default behaviour unchanged.
+    /// </summary>
+    public class Issue28TargetDissociationTests : IDisposable
+    {
+        private readonly string _testOutputDir;
+        private readonly ITestOutputHelper _output;
+
+        public Issue28TargetDissociationTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _testOutputDir = Path.Combine(AppContext.BaseDirectory, "TestRuns", Guid.NewGuid().ToString());
+            if (Directory.Exists(_testOutputDir))
+            {
+                Directory.Delete(_testOutputDir, true);
+            }
+            Directory.CreateDirectory(_testOutputDir);
+        }
+
+        private AssetConverterConfig BuildConfig(bool separateFrontBack, bool stopBeforePdf, List<CardSetDocumentConfig> docConfigs)
+        {
+            var imageOutputDir = Path.Combine(_testOutputDir, "GeneratedImages");
+            Directory.CreateDirectory(imageOutputDir);
+
+            return new AssetConverterConfig
+            {
+                BaseTargetDirectoryName = imageOutputDir,
+                SeparateFrontBackFolders = separateFrontBack,
+                StopBeforePdfGeneration = stopBeforePdf,
+                LocalizationConfig = new LocalizationConfig { Enabled = false, DefaultLanguage = "en" },
+                WebBasedGeneratorConfig = new WebBasedGeneratorConfig
+                {
+                    EnableParallelism = false,
+                    CardSetDocuments = docConfigs
+                }
+            };
+        }
+
+        // ---- (a) Front/back folder dissociation ----
+
+        [Fact]
+        public void GetImageFolder_WhenSeparateDisabled_KeepsFlatLayoutForFrontAndBack()
+        {
+            var docConfig = new CardSetDocumentConfig { DocumentName = "TestDoc", ImageFormat = MagickFormat.Png };
+            var config = BuildConfig(separateFrontBack: false, stopBeforePdf: false, new List<CardSetDocumentConfig> { docConfig });
+
+            var frontFolder = ImageHelper.GetImageFolder(config, docConfig, "en", "TestSet", isBack: false);
+            var backFolder = ImageHelper.GetImageFolder(config, docConfig, "en", "TestSet", isBack: true);
+
+            // Backward-compatible: front and back share the same card-set folder.
+            frontFolder.Should().Be(backFolder);
+            frontFolder.Should().NotContain(@"front" + Path.DirectorySeparatorChar);
+            backFolder.Should().NotContain(@"back" + Path.DirectorySeparatorChar);
+        }
+
+        [Fact]
+        public void GetImageFolder_WhenSeparateEnabled_RoutesFrontAndBackToDistinctSubFolders()
+        {
+            var docConfig = new CardSetDocumentConfig { DocumentName = "TestDoc", ImageFormat = MagickFormat.Png };
+            var config = BuildConfig(separateFrontBack: true, stopBeforePdf: false, new List<CardSetDocumentConfig> { docConfig });
+
+            var frontFolder = ImageHelper.GetImageFolder(config, docConfig, "en", "TestSet", isBack: false);
+            var backFolder = ImageHelper.GetImageFolder(config, docConfig, "en", "TestSet", isBack: true);
+
+            frontFolder.Should().NotBe(backFolder);
+            frontFolder.TrimEnd(Path.DirectorySeparatorChar).Should().EndWith("front");
+            backFolder.TrimEnd(Path.DirectorySeparatorChar).Should().EndWith("back");
+            Directory.Exists(frontFolder).Should().BeTrue();
+            Directory.Exists(backFolder).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GetImageFileName_WhenSeparateEnabled_PlacesBackImageUnderBackSubFolder()
+        {
+            var docConfig = new CardSetDocumentConfig { DocumentName = "TestDoc", ImageFormat = MagickFormat.Png };
+            var config = BuildConfig(separateFrontBack: true, stopBeforePdf: false, new List<CardSetDocumentConfig> { docConfig });
+
+            var facePath = ImageHelper.GetImageFileName(config, docConfig, "en", "TestSet", "card1_face", isBack: false);
+            var backPath = ImageHelper.GetImageFileName(config, docConfig, "en", "TestSet", "default", isBack: true);
+
+            facePath.Should().Contain(@"front" + Path.DirectorySeparatorChar);
+            facePath.Should().EndWith("card1_face.png");
+            backPath.Should().Contain(@"back" + Path.DirectorySeparatorChar);
+            backPath.Should().EndWith("default.png");
+        }
+
+        // ---- (b) Halt before PDF generation ----
+
+        [Fact]
+        public void GenerateCardSetDocuments_WhenStopBeforePdf_ProducesNoPdf()
+        {
+            var docConfig = new CardSetDocumentConfig
+            {
+                DocumentName = "TestDoc",
+                Enabled = true,
+                NoBack = true,
+                DocumentFormat = CardDocumentFormat.FacesOnly,
+                ImageFormat = MagickFormat.Png,
+                CardSets = new List<DocumentCardSet> { new DocumentCardSet { CardSetName = "TestSet" } }
+            };
+            // QuestPdfGeneration IS enabled, but StopBeforePdfGeneration must short-circuit assembly.
+            var config = BuildConfig(separateFrontBack: false, stopBeforePdf: true, new List<CardSetDocumentConfig> { docConfig });
+            config.Mode = ConverterMode.WebBasedImageGeneration | ConverterMode.QuestPdfGeneration;
+
+            var generator = new global::Argumentum.AssetConverter.WebBasedGenerator
+            {
+                AssetConverterConfig = config,
+                Config = config.WebBasedGeneratorConfig
+            };
+
+            // Build a fake on-disk face image and a docImages dictionary as if image generation had run.
+            var facePath = ImageHelper.GetImageFileName(config, docConfig, "en", "TestSet", "card1");
+            Directory.CreateDirectory(Path.GetDirectoryName(facePath)!);
+            using (var img = new MagickImage(MagickColors.Transparent, 1, 1))
+            {
+                img.Format = MagickFormat.Png;
+                img.Write(facePath);
+            }
+
+            var docImages = new ConcurrentDictionary<(CardSetDocumentConfig document, string language), List<CardImages>>();
+            docImages.TryAdd((docConfig, "en"), new List<CardImages> { new CardImages { Front = facePath } });
+
+            var documentDir = config.GetDocumentDirectory("en");
+
+            // Act
+            generator.GenerateCardSetDocuments(docImages);
+
+            // Assert: no PDF produced because the pipeline halted before assembly.
+            var pdfs = Directory.Exists(documentDir)
+                ? Directory.GetFiles(documentDir, "*.pdf", SearchOption.AllDirectories)
+                : Array.Empty<string>();
+            pdfs.Should().BeEmpty("StopBeforePdfGeneration must prevent any PDF assembly even when QuestPdfGeneration is set");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_testOutputDir))
+            {
+                try { Directory.Delete(_testOutputDir, true); } catch { /* best effort */ }
+            }
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -330,6 +330,23 @@ public string DocumentsDirectoryName { get; set; } = @"Documents\";
 
 		public bool OverwriteExistingDocs { get; set; } = true;
 
+		/// <summary>
+		/// Issue #28 (a): when true, harvested card images are written to distinct
+		/// <c>front\</c> and <c>back\</c> sub-folders under each card-set image folder
+		/// instead of sharing the same directory. Default <c>false</c> keeps the
+		/// historical flat layout (faces suffixed <c>_face</c>, backs by their own name)
+		/// for backward compatibility.
+		/// </summary>
+		public bool SeparateFrontBackFolders { get; set; } = false;
+
+		/// <summary>
+		/// Issue #28 (b): when true, the pipeline stops right after harvesting and
+		/// image generation, before any PDF document is assembled. Lets callers
+		/// produce the card images without paying the cost of PDF assembly, even when
+		/// <see cref="ConverterMode.QuestPdfGeneration"/> is set. Default <c>false</c>.
+		/// </summary>
+		public bool StopBeforePdfGeneration { get; set; } = false;
+
 		public bool OverwriteExistingHtmlMaps { get; set; }
 
 		public bool EnableSVGPrompt { get; set; } = true;

--- a/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
@@ -57,16 +57,16 @@ namespace Argumentum.AssetConverter
             throw new NotSupportedException($"The provided image URL is not a valid data URL (base64) or an embedded SVG: {srcUrl}");
         }
 
-        public static string GetImageFileName(AssetConverterConfig config, DocumentConfig docConfig, string language, string cardSetName, string imageName)
+        public static string GetImageFileName(AssetConverterConfig config, DocumentConfig docConfig, string language, string cardSetName, string imageName, bool isBack = false)
         {
-	      
-	        var cardSetFolderName = GetImageFolder(config, docConfig, language, cardSetName);
+
+	        var cardSetFolderName = GetImageFolder(config, docConfig, language, cardSetName, isBack);
 
 	        var imageFileName = $"{imageName.RemoveInvalidFileNameChars().Replace(" ", "_")}.{docConfig.ImageFormat.ToString().ToLowerInvariant()}";
 	        return Path.Combine(cardSetFolderName, imageFileName);
         }
 
-		public static string GetImageFolder(AssetConverterConfig config, DocumentConfig docConfig, string language, string cardSetName)
+		public static string GetImageFolder(AssetConverterConfig config, DocumentConfig docConfig, string language, string cardSetName, bool isBack = false)
 		{
 			var imagesFolderName = config.GetImagesDirectory(language);
 
@@ -74,10 +74,16 @@ namespace Argumentum.AssetConverter
 			var densityFolderName = docConfig.GetDensityDirectory(imagesFolderName);
 			var cardSetFolderName = Path.Combine(densityFolderName, $@"{cardSetName}\");
 
+			// Issue #28 (a): optionally split front/back images into distinct sub-folders.
+			if (config.SeparateFrontBackFolders)
+			{
+				cardSetFolderName = Path.Combine(cardSetFolderName, isBack ? @"back\" : @"front\");
+			}
+
 			Directory.CreateDirectory(cardSetFolderName);
 
 			return cardSetFolderName;
-			
+
 		}
 
 		public static string LoadAndProcessImageUrl(this DocumentCardSet documentCardSet, string language, bool isBack, AssetConverterConfig config, CardSetDocumentConfig docConfig,
@@ -87,7 +93,7 @@ namespace Argumentum.AssetConverter
 
 			var imagesFolderName = config.GetImagesDirectory(language);
 
-			var imageFileName = GetImageFileName(config, docConfig, language, documentCardSet.CardSetName, imageName);
+			var imageFileName = GetImageFileName(config, docConfig, language, documentCardSet.CardSetName, imageName, isBack);
 
 			         if (File.Exists(imageFileName))
             {

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGenerator.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGenerator.cs
@@ -75,6 +75,13 @@ namespace Argumentum.AssetConverter
 				Logger.Log("QuestPdfGeneration mode is disabled. Skipping PDF generation.");
 				return;
 			}
+
+			// Issue #28 (b): explicit halt before PDF assembly, even when QuestPdfGeneration is set.
+			if (AssetConverterConfig.StopBeforePdfGeneration)
+			{
+				Logger.Log("StopBeforePdfGeneration is enabled. Images generated; skipping PDF generation.");
+				return;
+			}
 			Logger.Log("QuestPdfGeneration mode is enabled. Entering PDF generation logic.");
 
 			Logger.LogTitle("Generating pdf documents");


### PR DESCRIPTION
Closes #28.

Issue #28 (2021) asked for two pipeline ergonomics improvements. The 2026 triage confirmed (b) was *functionally* reachable by clearing the `QuestPdfGeneration` Mode flag and (a) was a real, low-prio gap (front/back images shared one folder). This PR delivers both as **explicit, opt-in, default-off** config toggles — backward compatible, code-only, disk-light.

## (a) Dissociate front/back target folders — `SeparateFrontBackFolders`
- New `AssetConverterConfig.SeparateFrontBackFolders` (default `false`).
- When `true`, `ImageHelper` routes face images into a `front\` sub-folder and back images into a `back\` sub-folder under each card-set image directory.
- When `false` (default), the historical flat layout is preserved exactly (faces suffixed `_face`, backs by name) — **zero behaviour change**.
- Implementation: threaded the *already-existing* `isBack` flag from `LoadAndProcessImageUrl` through `GetImageFileName` / `GetImageFolder` via a new optional param (default `false`), so all other callers (mind-map thumbnails) are unaffected.

## (b) Halt before PDF generation — `StopBeforePdfGeneration`
- New `AssetConverterConfig.StopBeforePdfGeneration` (default `false`).
- When `true`, `GenerateCardSetDocuments` returns right after image generation — before any PDF assembly — **even when `ConverterMode.QuestPdfGeneration` is set**. This is the explicit, intention-revealing halt the issue asked for, without having to flip Mode flags.

## Diff
| File | Lines |
|------|-------|
| `AssetConverterConfig.cs` | +17 (two bool props + XML docs) |
| `WebBasedGenerator.cs` | +7 (halt guard after the QuestPdf guard) |
| `ImageHelper.cs` | +18/-6 (optional `isBack` param + front/back sub-folder) |
| `Issue28TargetDissociationTests.cs` | +156 (new, 4 xUnit tests) |

## Tests
4 new tests in `Issue28TargetDissociationTests`:
- flat layout when `SeparateFrontBackFolders=false` (backward compat),
- distinct `front\`/`back\` folders when enabled,
- back image lands under `back\`,
- `GenerateCardSetDocuments` produces **no PDF** when `StopBeforePdfGeneration=true` even with `QuestPdfGeneration` set.

Full suite: **159 pass / 0 fail / 5 skip**. `dotnet build` clean (0 errors).

## Notes / follow-up
- Toggles are plain behavioural booleans (like `OverwriteExistingDocs`), not output-quality params, so the `XxxDebug`/`XxxRelease` pairing convention does not apply here.
- Config is C#-only (single source of truth); the generated JSON is regenerated from defaults.
- No CSV / template / workflow / `.claude` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)