### PR TITLE
feat(dataset-updater): align translation tasks to gpt-5.5 mandate (#192, #299 follow-up)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -243,7 +243,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → EN translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.PKHierarchicalChar,
 			PKHierarchyLevel = 3,
@@ -306,7 +306,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → RU translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			PKHierarchyLevel = 3,
@@ -370,7 +370,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → PT translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			PKHierarchyLevel = 3,
@@ -576,7 +576,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → RU translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 8,
@@ -640,7 +640,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → PT translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 8,
@@ -689,7 +689,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// Wikipedia link lookup - eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 8,
@@ -930,7 +930,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → RU translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 8,
@@ -998,7 +998,7 @@ public class DatasetUpdaterRootConfig
 				}
 			},
 			// FR → PT translation empty-only — eco tier. Fallback: gpt-4.1-mini
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 8,
@@ -1299,7 +1299,7 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateEsAssistant.txt"
 				}
 			},
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 3,
@@ -1342,7 +1342,7 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateArAssistant.txt"
 				}
 			},
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 3,
@@ -1385,7 +1385,7 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateFaAssistant.txt"
 				}
 			},
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 3,
@@ -1428,7 +1428,7 @@ public class DatasetUpdaterRootConfig
 					AssistantAnswerPath = PromptsRootPath + "PromptRulesTranslateZhAssistant.txt"
 				}
 			},
-			Model = "gpt-5.4-mini",
+			Model = "gpt-5.5",
 			MaxTokensPerMinute = 70000,
 			DivisionMode = DivisionMode.SequentialChunks,
 			ChunkSize = 3,


### PR DESCRIPTION
## What

Enforces the standing **gpt-5.5-only translation mandate**. The eco-tier `gpt-5.4-mini` is banned for translations ("plus de fenêtre eco-tier ; pushback si un worker propose 5.4-mini"). This PR flips **every** `gpt-5.4-mini` occurrence in `DatasetUpdaterRootConfig.cs` to `gpt-5.5`.

Code-only, single file. References the #466 DOC-ONLY investigation [`docs/investigations/2026-06-14-llm-model-quality-datasetupdater.md`](../blob/master/docs/investigations/2026-06-14-llm-model-quality-datasetupdater.md), which identified the `gpt-5.4-mini` residue as drift from the mandate.

> **Count note:** the investigation's pre-edit table stated 10× `gpt-5.4-mini`. The working-tree file actually carries **12** such occurrences (the doc undercounted — it tabbed the 4 Rules ES/AR/FA/ZH tasks but its "10" summary did not fully reconcile, and Fallacies→EN was still on the eco tier despite the doc's synthesis text). All 12 are translation tasks → all move up, per the "every occurrence" directive.

## Exactly which tasks changed (line, name, old → new)

| # | Line | Task name | Old → New |
|---|------|-----------|-----------|
| 1 | 246 | Translate Fallacies to English by branch empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 2 | 309 | Translate Fallacies to Russian by chunk empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 3 | 373 | Translate Fallacies to Portuguese by chunk empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 4 | 579 | Translate Virtues to Russian by chunk empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 5 | 643 | Translate Virtues to Portuguese by chunk empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 6 | 692 | Generate Virtues Portuguese Wikipedia links empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 7 | 933 | Translate Scenarii to Russian by chunk empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 8 | 1001 | Translate Scenarii to Portuguese by chunk empty-only 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 9 | 1302 | Translate Rules to Spanish by chunk 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 10 | 1345 | Translate Rules to Arabic by chunk 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 11 | 1388 | Translate Rules to Farsi by chunk 0-shot | `gpt-5.4-mini` → `gpt-5.5` |
| 12 | 1431 | Translate Rules to Chinese Simplified by chunk 0-shot | `gpt-5.4-mini` → `gpt-5.5` |

**Count: 12 changed lines** (`git diff --stat` = 12 insertions / 12 deletions; file otherwise byte-identical).

## Intentionally left untouched (separate decision for @jsboige)

The 4 `gpt-5.4` (**non-mini**) tasks are FR-native generation / refinement, **not** translation. The mandate is about translation, so these are left as-is and flagged here as a distinct decision:

| Line | Task name | Model (unchanged) | Why kept |
|------|-----------|-------------------|----------|
| 61 | Update Virtues Taxonomy by chunks 1-shot | `gpt-5.4` | FR taxonomy creation/refinement |
| 117 | Update Fallacies French Description by branch 0-shot | `gpt-5.4` | FR `desc_fr` refinement |
| 182 | Update Fallacies French example by branch 0-shot | `gpt-5.4` | FR `example_fr` creative generation |
| 446 | Cleanup Fallacies translations by chunk empty-only 0-shot | `gpt-5.4` | multi-lang cleanup review (quality tier) |

If you want these aligned to `gpt-5.5` too (or the cleanup-review one in particular), that's a separate call — happy to follow up.

## No runtime / cost effect

All 47 tasks remain `Enabled = false`. There is no execution or API cost until a deliberate run is enabled.

## Validation

- **Build + tests:** `dotnet test Argumentum.AssetConverter.Tests` → **159 pass / 0 fail / 5 skip** (skips = GSheet/GDrive + Freeplane GUI, expected).
- **EOL integrity:** `git ls-files --eol` → `i/lf w/crlf` preserved (no line-ending flip).
- **Diff scope:** `git diff` shows exactly the 12 `Model =` lines; no other byte changed.

Model distribution after: `gpt-5.5` 31 → **43**, `gpt-5.4-mini` 12 → **0**, `gpt-5.4` **4** (unchanged), total 47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
