### PR TITLE
docs(release): fix Magick.NET version (13.5.0→14.13.1) + OWL size (664KB→5.3MB) drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Complete restoration of the generation pipeline from the April 2024 Golden Maste
 ### Changed
 
 - **DNN platform**: Upgraded 2sxc 15→21.07 with Razor14 migration + IRenderService fix (#418)
-- **Dependencies**: System.Linq.Dynamic.Core 1.3.12→1.7.2 (security), Spectre.Console→0.50.0, QuestPDF pinned to 2022.12.12 (MIT free license), Magick.NET 13.5.0, SkiaSharp.NativeAssets.Win32 2.88.6
+- **Dependencies**: System.Linq.Dynamic.Core 1.3.12→1.7.2 (security), Spectre.Console→0.50.0, QuestPDF pinned to 2022.12.12 (MIT free license), Magick.NET-Q16-AnyCPU 14.13.1 (dependabot-tracked), SkiaSharp.NativeAssets.Win32 2.88.6
 - **Build artifacts**: Stopped tracking 968 MB of regenerable build outputs (#415 Phase 1)
 - **Mémo Back taxonomy**: Grouping selector now language-invariant (CSS class-based, not text-based)
 

--- a/RELEASE-NOTES-v0.9.0.md
+++ b/RELEASE-NOTES-v0.9.0.md
@@ -34,7 +34,7 @@ All CSV data (Fallacies, Virtues, Scenarii, Rules) is 100% translated across all
 | **Total PDFs** | 8 | **64** |
 | MindMap SVGs | 4 (FR/EN/RU/PT) | 21 |
 | Card Images (PNG) | 8 | ~9,834 |
-| OWL Ontology | 1 (FR) | 1 (664 KB) |
+| OWL Ontology | 1 (FR) | 1 (~5.3 MB) |
 
 ### 🛠 Pipeline Recovery
 
@@ -106,7 +106,7 @@ Automated visual regression testing for generated assets:
 | Package | Version | Change |
 |---------|---------|--------|
 | QuestPDF | 2022.12.12 | Pinned (MIT free license, thread-safety boundary) |
-| Magick.NET | 13.5.0 | Stable for SVG conversion |
+| Magick.NET-Q16-AnyCPU | 14.13.1 | Stable for SVG conversion (dependabot-tracked) |
 | Microsoft.Playwright | 1.43.0 | Browser automation |
 | OpenAI .NET SDK | 2.10.0 | New — translation pipeline |
 | System.Linq.Dynamic.Core | 1.7.2 | Security upgrade (GHSA-4cv2-4hjh-77rx) |


### PR DESCRIPTION
## Summary
Two doc-vs-master drifts found by po-2023 scanning release docs against the actual `.csproj` and committed OWL file (same flow as #469). **Docs-only, +3/-3, gate release unchanged.**

## Drift 1 — Magick.NET version (material: Dependencies table credibility)
- CHANGELOG L64 + RELEASE-NOTES L109 said **13.5.0**.
- `AssetConverter.csproj:23` = **Magick.NET-Q16-AnyCPU 14.13.1**. Git blame confirms merged dependabot bump `25ebfb3b` (`Bump Magick.NET-Q16-AnyCPU from 14.12.0 to 14.13.1`). Release reality = 14.13.1; the Release regen (64 PDFs, exit 0) ran on it.
- Fixed both docs to `Magick.NET-Q16-AnyCPU 14.13.1 (dependabot-tracked)` (full package id).

## Drift 2 — OWL ontology size (cosmetic, 8× factor)
- RELEASE-NOTES L37 said `1 (664 KB)`.
- `docs/ontology/argumentum.owl` = 5,378,765 bytes (~5.3 MB), committed once at that size (`d206e59c` SKOS-enabled). 664 KB was never the post-SKOS size.
- Fixed to `~5.3 MB`.

## Provenance
po-2023 work (push-blocked 403 → patch handoff, SHA256 `c584e2c5…` verified), applied via `git am` by ai-01. Verdict/CI = ai-01.

🤖 Coordinator ai-01 (integrating po-2023)