### PR TITLE
perf(#29): 3 output-neutral cleanups (held — do not merge during gate)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/UtilityExtensions.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/UtilityExtensions.cs
@@ -19,6 +19,9 @@ namespace Argumentum.AssetConverter
 	public static class UtilityExtensions
 	{
 
+		// Shared HttpClient (was `new HttpClient()` per call — #29 H6). Thread-safe for concurrent calls;
+		// avoids socket exhaustion / GC pressure on long runs with repeated downloads. Output-neutral.
+		private static readonly HttpClient _sharedHttpClient = new HttpClient();
 
 
 		public static void ExportDataTable(this CsvWriter writer, DataTable dt)
@@ -214,7 +217,7 @@ namespace Argumentum.AssetConverter
 				try
 				{
 					// Download the file from the specified URL
-					using var client = new HttpClient();
+					var client = _sharedHttpClient;
 
 					var response = await client.GetAsync(urlFile);
 					if (response.IsSuccessStatusCode)

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
@@ -356,7 +356,6 @@ public class HarvestManager : IAsyncDisposable
 		Log("Entering GenerateHarvestImages.");
 		var currentHarvest = new CardSetHarvest();
 		var page = await GetFreePage(browser);
-		var consoleMessages = new List<string>();
 
 		void Page_Console(object sender, IConsoleMessage msg)
 		{
@@ -408,7 +407,7 @@ public class HarvestManager : IAsyncDisposable
 
 			Log("Diagnostic check passed: #cpOutput iframe is ready.");
 
-			var faces = await GenerateImages(page, cardSetDocuments.front, configCardSet.Config.FaceCardSetInfo, consoleMessages);
+			var faces = await GenerateImages(page, cardSetDocuments.front, configCardSet.Config.FaceCardSetInfo);
 			currentHarvest.Faces = faces;
 
 			// Issue #190 phase 1: opportunistic overflow detection on Virtues face cards.
@@ -434,7 +433,7 @@ public class HarvestManager : IAsyncDisposable
 
 			if (cardSetDocuments.back != null)
 			{
-				var backs = await GenerateImages(page, cardSetDocuments.back, configCardSet.Config.BackCardSetInfo, consoleMessages);
+				var backs = await GenerateImages(page, cardSetDocuments.back, configCardSet.Config.BackCardSetInfo);
 				currentHarvest.Backs = backs;
 			}
 		}
@@ -448,7 +447,7 @@ public class HarvestManager : IAsyncDisposable
 	}
 
 
-	      public async Task<CardPenHarvest> GenerateImages(IPage page, CardSetPayload cardSetDocument, CardSetInfo cardSetInfo, List<string> consoleMessages)
+	      public async Task<CardPenHarvest> GenerateImages(IPage page, CardSetPayload cardSetDocument, CardSetInfo cardSetInfo)
 	      {
 	          var toReturn = new CardPenHarvest();
 	          if (cardSetDocument?.CardSetDocument == null)

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PrintAndPlayDocument.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PrintAndPlayDocument.cs
@@ -16,6 +16,10 @@ namespace Argumentum.AssetConverter
         private readonly List<byte[]> _frontImagesData;
         private readonly List<byte[]> _backImagesData;
 
+        // Header bytes read once and cached (was File.ReadAllBytes per page in ComposePage — #29 H5).
+        // Identical bytes, just no re-read; output-neutral.
+        private readonly Lazy<byte[]> _headerImageData;
+
         private const float InchToCentimetre = 2.54f;
         private const float InchToPoints = 72;
         private float MmToPointsFactor = 0.1f / InchToCentimetre * InchToPoints;
@@ -25,6 +29,15 @@ namespace Argumentum.AssetConverter
             _docConfig = docConfig;
             _frontImagesData = frontImagesData;
             _backImagesData = backImagesData;
+            _headerImageData = new Lazy<byte[]>(LoadHeaderImageData);
+        }
+
+        private byte[] LoadHeaderImageData()
+        {
+            if (string.IsNullOrEmpty(_docConfig.Header))
+                return null;
+            var imagePath = Path.Combine(Environment.CurrentDirectory, _docConfig.Header);
+            return File.Exists(imagePath) ? File.ReadAllBytes(imagePath) : null;
         }
 
         public DocumentMetadata GetMetadata() => new DocumentMetadata()
@@ -93,14 +106,9 @@ namespace Argumentum.AssetConverter
             page.PageColor(Colors.White);
             page.DefaultTextStyle(x => x.FontSize(20));
 
-            if (!string.IsNullOrEmpty(_docConfig.Header))
+            if (_headerImageData.Value != null)
             {
-                var imagePath = Path.Combine(Environment.CurrentDirectory, _docConfig.Header);
-                if(File.Exists(imagePath))
-                {
-                    var imageData = File.ReadAllBytes(imagePath);
-                    page.Header().AlignCenter().Height(pageSize.Height / 10).Padding(pageSize.Width / 150).Image(imageData, ImageScaling.FitHeight);
-                }
+                page.Header().AlignCenter().Height(pageSize.Height / 10).Padding(pageSize.Width / 150).Image(_headerImageData.Value, ImageScaling.FitHeight);
             }
 
             page.Content()


### PR DESCRIPTION
## Summary

3 **LOW-risk, output-neutral** perf cleanups from the [#29 memory/perf audit](../blob/master/docs/investigations/2026-06-14-29-memory-perf-hotspots.md) §3 shortlist. Dispatched by ai-01 (`ou00g3` v2) as the primary key-free task.

## Changes
| # | File | Fix | Output impact |
|---|------|-----|---------------|
| **H6** | `UtilityExtensions.cs` | `new HttpClient()` per call → `static readonly _sharedHttpClient` | none (same payloads) |
| **H5** | `PrintAndPlayDocument.cs` | `File.ReadAllBytes(header)` per page → `Lazy<byte[]>` cached once | none (same bytes) |
| **H7** | `HarvestManager.cs` | remove dead `consoleMessages` param (never written — confirmed by grep in both call sites + GenerateImages body) | none |

## Proof of output-neutrality
- Build **green** (0 errors; 18 warnings all in untouched files).
- Tests **159 passed / 0 failed / 5 skipped** — matches baseline exactly (zero regression).
- No render/CSV/PDF logic touched; no MED/HIGH hotspots (H1-H4/H8 need profiling/design — out of scope).

## ⚠️ HELD — do NOT merge during gate
Per dispatch rule: this PR is open but **not self-merged**. ai-01/jsboige decide timing post-validation (master untouched while jsboige validates the 64 Release PDFs on po-2023). The branch does not affect validation (jsboige validates already-regenerated artefacts).

🤖 Worker po-2024 (dispatch `ou00g3` primary)