### PR TITLE
test(ontology): #204 OwlAdapter regression — 🔴 BUG FOUND: all readers return empty (RDFResource.Equals(Uri) type-mismatch)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlAdapterRegressionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlAdapterRegressionTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.IO;
+using System.Linq;
+using Argumentum.AssetConverter.Ontology;
+using FluentAssertions;
+using RDFSharp.Model;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Ontology
+{
+    /// <summary>
+    /// Regression / characterization tests for <see cref="OwlAdapter"/> — dispatch #204 (primaire, cont.).
+    ///
+    /// NEW additive file. The Ontology subsystem had zero xUnit coverage prior to this (the
+    /// production-side <c>Tests/OwlOntologyValidationTests.cs</c> module is NOT an xUnit suite).
+    /// CLAUDE.md flags the SKOS/OWL layer as fragile: <c>OwlAdapter</c> bypasses the broken
+    /// <c>SKOSHelper</c> extension methods in OWLSharp and self-retrieves concepts via fallback
+    /// annotation scanners (<c>GetAnnotationSubjects</c> / <c>GetResourceAnnotations</c> /
+    /// <c>GetLiteralAnnotations</c>).
+    ///
+    /// ⚠️ These tests surfaced a REAL BUG (not greenwashed). Every fallback reader compares
+    /// <c>a.ValueIRI.Equals(value.URI)</c> / <c>a.SubjectIRI.Equals(subject.URI)</c> where
+    /// <c>.URI</c> is a <b>string</b> and <c>ValueIRI</c>/<c>SubjectIRI</c> are
+    /// <c>RDFResource</c>. <c>RDFResource.Equals(string)</c> returns <b>false by type-mismatch</b>,
+    /// so every read returns empty. See <see cref="Diag_RDFResource_Equals_String_Is_False_By_Type_Mismatch"/>.
+    /// This is the root cause behind the production validation module silently reporting
+    /// "no concepts → skip → PASS" on annotation/AIF checks. Reported as [BUG] on the dashboard.
+    ///
+    /// Tests are split into: (A) characterization of the bug (pinned, documents current behavior),
+    /// (B) the correct comparison semantics (documents the fix), (C) write-path + serialization
+    /// (these DO work). No fix is applied — the file only pins observed behavior so a future fix
+    /// flips the [BUG] tests red→green and the fix author has a regression suite ready.
+    ///
+    /// Deterministic, key-free, release-independent. No existing file modified. Baseline additive.
+    /// </summary>
+    public class OwlAdapterRegressionTests
+    {
+        private const string Ns = "http://argumentum.test/onto#";
+
+        private static OwlAdapter NewAdapter() => new OwlAdapter(Ns);
+
+        private static RDFResource Res(string local) => new RDFResource(Ns + local);
+
+        private static RDFPlainLiteral Lit(string value) => new RDFPlainLiteral(value);
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (B) Root-cause probe — the comparison semantics the readers depend on.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Diag_RDFResource_Equals_String_Is_False_By_Type_Mismatch()
+        {
+            // ROOT CAUSE of the [BUG]: RDFResource.Equals(object) requires the argument to BE an
+            // RDFResource with the same URI. Passing a string (which is what `.URI` yields) returns
+            // false on every comparison. The OwlAdapter fallback readers all do
+            // `a.ValueIRI.Equals(value.URI)` and `a.SubjectIRI.Equals(subject.URI)` — so they never
+            // match. This test pins the RDFSharp semantics so the root cause is undeniable.
+            var r = new RDFResource(Ns + "X");
+            var sameUriString = Ns + "X";
+
+            r.Equals(sameUriString).Should().BeFalse(
+                "RDFResource.Equals(string) is false by type-mismatch — the read-path bug");
+            r.Equals(new RDFResource(sameUriString)).Should().BeTrue(
+                "RDFResource.Equals(RDFResource) is true when URIs match — what the readers SHOULD compare against");
+            (r.ToString() == sameUriString).Should().BeTrue(
+                "ToString() yields the plain URI string — the correct string basis for comparison");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (A) [BUG] characterization — readers return empty despite writes succeeding.
+        //     These pin the BROKEN behavior. When OwlAdapter is fixed, these flip to red and
+        //     become proper round-trip assertions (remove the .Be(0) and assert the populated set).
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void BUG_GetConcepts_Returns_Empty_Despite_Declared_Concepts()
+        {
+            // Write 3 concepts; the reader should return 3 but returns 0 (comparison bug).
+            var adapter = NewAdapter();
+            var scheme = Res("Scheme");
+            adapter.DeclareConceptScheme(scheme);
+            adapter.DeclareConcept(Res("C1"), scheme);
+            adapter.DeclareConcept(Res("C2"), scheme);
+            adapter.DeclareConcept(Res("C3"), scheme);
+
+            var concepts = adapter.GetConcepts();
+            concepts.Should().BeEmpty(
+                "[BUG] GetConcepts returns empty because the fallback scanner compares RDFResource.Equals(string)");
+        }
+
+        [Fact]
+        public void BUG_GetResourcesByType_Concept_Returns_Empty()
+        {
+            // Same root cause, different reader. ValidateOwlOntologyStructure relies on this.
+            var adapter = NewAdapter();
+            var scheme = Res("Scheme");
+            adapter.DeclareConceptScheme(scheme);
+            adapter.DeclareConcept(Res("C1"), scheme);
+
+            adapter.GetResourcesByType(SKOSVocabulary.Concept).Should().BeEmpty("[BUG] RDFResource.Equals(string)");
+            adapter.GetResourcesByType(SKOSVocabulary.ConceptScheme).Should().BeEmpty("[BUG] RDFResource.Equals(string)");
+        }
+
+        [Fact]
+        public void BUG_GetTopConcepts_Returns_Empty_Despite_Declared()
+        {
+            var adapter = NewAdapter();
+            adapter.DeclareTopConcept(Res("Top1"), Res("Scheme"));
+            adapter.DeclareTopConcept(Res("Top2"), Res("Scheme"));
+
+            adapter.GetTopConcepts().Should().BeEmpty("[BUG] GetAnnotationObjects compares RDFResource.Equals(string)");
+        }
+
+        [Fact]
+        public void BUG_HasAnnotation_Returns_False_Despite_Annotation_Present()
+        {
+            var adapter = NewAdapter();
+            var scheme = Res("Scheme");
+            adapter.DeclareConceptScheme(scheme);
+
+            // The annotation IS written (see write-path test below), but HasAnnotation can't find it.
+            adapter.HasAnnotation(scheme, RDFVocabulary.RDF.TYPE, SKOSVocabulary.ConceptScheme)
+                .Should().BeFalse("[BUG] HasAnnotation compares ValueIRI.Equals(value.URI string) → false");
+        }
+
+        [Fact]
+        public void BUG_CheckIsNarrowerConcept_Returns_False_Despite_Declared()
+        {
+            var adapter = NewAdapter();
+            var parent = Res("Fallacies");
+            var child = Res("AdHominem");
+            adapter.DeclareNarrowerConcepts(parent, child);
+
+            // CheckIsNarrowerConcept has a try/except fallback that ALSO uses .Equals(string.URI),
+            // so even the fallback fails.
+            adapter.CheckIsNarrowerConcept(child, parent)
+                .Should().BeFalse("[BUG] fallback compares RDFResource.Equals(string) → false");
+        }
+
+        [Fact]
+        public void BUG_GetConceptPreferredLabels_Returns_Empty_Despite_Label_Set()
+        {
+            var adapter = NewAdapter();
+            var concept = Res("C");
+            adapter.DeclareConcept(concept, Res("Scheme"));
+            adapter.AnnotateConceptPreferredLabel(concept, Lit("Ad Hominem"));
+
+            adapter.GetConceptPreferredLabels(concept).Should().BeEmpty(
+                "[BUG] GetLiteralAnnotations compares AnnotationProperty.GetIRI().Equals(property.URI string)");
+        }
+
+        [Fact]
+        public void BUG_GetConceptDocumentation_Returns_Empty_Despite_Documented()
+        {
+            var adapter = NewAdapter();
+            var concept = Res("C");
+            adapter.DeclareConcept(concept, Res("Scheme"));
+            adapter.DocumentConcept(concept, SKOSDocumentationTypes.Definition, Lit("A fallacy..."));
+
+            adapter.GetConceptDocumentation(concept, SKOSDocumentationTypes.Definition)
+                .Should().BeEmpty("[BUG] same RDFResource.Equals(string) root cause");
+        }
+
+        [Fact]
+        public void BUG_GetExactMatchConcepts_Returns_Empty_Despite_Declared()
+        {
+            var adapter = NewAdapter();
+            var c1 = Res("EN");
+            var c2 = Res("FR");
+            adapter.DeclareExactMatchConcepts(c1, c2);
+
+            adapter.GetExactMatchConcepts(c1).Should().BeEmpty("[BUG] RDFResource.Equals(string)");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (C) Write-path + serialization — these WORK (the ontology is correctly built in
+        //     memory; only the self-retrieval readers are broken). Pinned so a fix doesn't
+        //     regress the write side.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Constructor_Produces_An_Adapter_With_The_Declared_Namespace_Uri()
+        {
+            var adapter = NewAdapter();
+            adapter.Uri.ToString().Should().Be(Ns);
+            adapter.GetOntology().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void DeclareConcept_Appends_AnnotationAxioms_To_The_Ontology()
+        {
+            // The WRITE side is correct: DeclareConcept adds real annotation axioms to the
+            // ontology (verifiable by inspecting the underlying graph directly, bypassing the
+            // broken reader). This is why ToFileAsync produces a valid ontology despite the
+            // readers being broken.
+            var adapter = NewAdapter();
+            var scheme = Res("Scheme");
+            var concept = Res("C1");
+
+            adapter.DeclareConceptScheme(scheme);
+            adapter.DeclareConcept(concept, scheme);
+
+            var onto = adapter.GetOntology();
+            onto.AnnotationAxioms.Should().NotBeEmpty("DeclareConcept writes annotation axioms");
+
+            // Verify by ToString() comparison (the correct basis), not the broken reader.
+            var hasConceptType = onto.AnnotationAxioms.OfType<OWLSharp.Ontology.OWLAnnotationAssertion>()
+                .Any(a => a.AnnotationProperty.GetIRI().ToString() == RDFVocabulary.RDF.TYPE.URI.ToString()
+                       && a.SubjectIRI.ToString() == concept.URI.ToString()
+                       && a.ValueIRI?.ToString() == SKOSVocabulary.Concept.URI.ToString());
+            hasConceptType.Should().BeTrue(
+                "the concept's rdf:type=skos:Concept axiom IS present in the graph (write works; reader is broken)");
+        }
+
+        [Fact]
+        public void DeclareNarrowerConcepts_Appends_Both_Directional_Axioms()
+        {
+            var adapter = NewAdapter();
+            var parent = Res("P");
+            var child = Res("C");
+            adapter.DeclareNarrowerConcepts(parent, child);
+
+            var onto = adapter.GetOntology();
+            var hasNarrower = onto.AnnotationAxioms.OfType<OWLSharp.Ontology.OWLAnnotationAssertion>()
+                .Any(a => a.AnnotationProperty.GetIRI().ToString() == SKOSVocabulary.Narrower.URI.ToString()
+                       && a.SubjectIRI.ToString() == parent.URI.ToString()
+                       && a.ValueIRI?.ToString() == child.URI.ToString());
+            var hasBroader = onto.AnnotationAxioms.OfType<OWLSharp.Ontology.OWLAnnotationAssertion>()
+                .Any(a => a.AnnotationProperty.GetIRI().ToString() == SKOSVocabulary.Broader.URI.ToString()
+                       && a.SubjectIRI.ToString() == child.URI.ToString()
+                       && a.ValueIRI?.ToString() == parent.URI.ToString());
+
+            hasNarrower.Should().BeTrue("skos:narrower parent→child written");
+            hasBroader.Should().BeTrue("skos:broader child→parent written (reciprocal)");
+        }
+
+        [Fact]
+        public void AnnotateConceptPreferredLabel_Appends_The_PrefLabel_Axiom()
+        {
+            // Write-path verification via direct graph inspection (bypassing the broken reader).
+            // Assert the prefLabel axiom exists for the concept — the literal value rendering
+            // format is OWLSharp-internal, so we only assert the property+subject binding.
+            var adapter = NewAdapter();
+            var concept = Res("C");
+            adapter.DeclareConcept(concept, Res("Scheme"));
+            adapter.AnnotateConceptPreferredLabel(concept, Lit("Ad Hominem"));
+
+            var onto = adapter.GetOntology();
+            var hasLabel = onto.AnnotationAxioms.OfType<OWLSharp.Ontology.OWLAnnotationAssertion>()
+                .Any(a => a.AnnotationProperty.GetIRI().ToString() == SKOSVocabulary.PrefLabel.URI.ToString()
+                       && a.SubjectIRI.ToString() == concept.URI.ToString()
+                       && a.ValueLiteral != null);
+            hasLabel.Should().BeTrue("skos:prefLabel axiom written to the graph (write works; reader broken)");
+        }
+
+        [Fact]
+        public void BUG_CheckHasClass_Returns_False_Despite_Class_Declared()
+        {
+            // CheckHasClass uses DeclarationAxioms and compares cls.GetIRI().Equals(resource.URI)
+            // where .URI is a System.Uri. RDFResource.Equals(Uri) is false by type-mismatch — the
+            // SAME root cause as the annotation readers. So CheckHasClass is also broken.
+            var adapter = NewAdapter();
+            var declared = Res("DeclaredClass");
+            adapter.DeclareClass(declared);
+
+            // The class IS declared in DeclarationAxioms:
+            var onto = adapter.GetOntology();
+            onto.DeclarationAxioms.Should().NotBeEmpty("DeclareClass wrote the declaration axiom");
+
+            // ...but CheckHasClass can't find it:
+            adapter.CheckHasClass(declared).Should().BeFalse(
+                "[BUG] cls.GetIRI().Equals(resource.URI) compares RDFResource.Equals(Uri) → false by type-mismatch");
+        }
+
+        [Fact]
+        public void DocumentConcept_Unknown_Type_Throws()
+        {
+            var adapter = NewAdapter();
+            var concept = Res("C");
+            var invalid = (SKOSDocumentationTypes)999;
+
+            Action act = () => adapter.DocumentConcept(concept, invalid, Lit("x"));
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void ToFileAsync_Writes_A_Non_Empty_OWL2XML_File()
+        {
+            // Serialization works end-to-end (this is why #133 ships a non-empty ontology despite
+            // the readers being broken — the graph is correctly built, only self-retrieval fails).
+            var adapter = NewAdapter();
+            var scheme = Res("Scheme");
+            adapter.DeclareConceptScheme(scheme);
+            adapter.DeclareConcept(Res("C1"), scheme);
+            adapter.AnnotateConceptPreferredLabel(Res("C1"), Lit("Test Concept"));
+
+            var tempPath = Path.Combine(Path.GetTempPath(), $"arg_onto_test_{Guid.NewGuid():N}.owl");
+            try
+            {
+                adapter.ToFileAsync(OWLSharp.OWLEnums.OWLFormats.OWL2XML, tempPath).Wait();
+                File.Exists(tempPath).Should().BeTrue();
+                var content = File.ReadAllText(tempPath);
+                content.Should().NotBeNullOrEmpty("the serialized ontology must be non-empty");
+                content.Should().Match(s => s.Contains("<rdf:RDF") || s.Contains("xmlns"),
+                    "the OWL2XML output must be RDF/XML");
+            }
+            finally
+            {
+                if (File.Exists(tempPath)) File.Delete(tempPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **This PR is also a [BUG] report.** ai-01 — please read the BUG section before merging. The fix is a ~6-line change in `OwlAdapter.cs` (out of my scope); I've delivered the ready-to-go regression suite so the fix author flips the 8 `[BUG]_*` tests red→green.

## What

NEW additive file `Ontology/OwlAdapterRegressionTests.cs` (+16 tests, 313 lines). **Baseline 202 → 218 / 0 fail / 5 skip.** The Ontology subsystem had zero xUnit coverage before this (the production-side `Tests/OwlOntologyValidationTests.cs` is a post-gen module, not a test suite).

## 🔴 BUG FOUND (not greenwashed)

**Every self-retrieval reader in `OwlAdapter` is broken — they all silently return empty/false.** Root cause: the comparison `RDFResource.Equals(someUri)` where `someUri` is a `System.Uri` (or string). `RDFResource.Equals(object)` requires the argument to **be** an `RDFResource` — so it returns **false by type-mismatch** on every call.

Confirmed empirically in `Diag_RDFResource_Equals_String_Is_False_By_Type_Mismatch`:
- `RDFResource.Equals(string)` → **false** (type mismatch) ← what the readers do
- `RDFResource.Equals(RDFResource with same URI)` → true ← what they *should* do
- `RDFResource.ToString() == uriString` → true ← the correct string basis

**Affected readers (all return empty/false):**
| Reader | Line | Broken comparison |
|---|---|---|
| `GetAnnotationSubjects` | 333-334 | `a.ValueIRI.Equals(typeResource.URI)` |
| `GetAnnotationObjects` (GetTopConcepts) | 342 | — (returns ValueIRI but filter `property.URI`) |
| `GetResourceAnnotations` | 351-352 | `a.SubjectIRI.Equals(subject.URI)` |
| `GetLiteralAnnotations` | 361-362 | `a.SubjectIRI.Equals(subject.URI)` |
| `HasAnnotation` | 389-391 | `a.ValueIRI.Equals(value.URI)` + `a.SubjectIRI.Equals(subject.URI)` |
| `CheckIsNarrowerConcept` fallback | 290-292 | `.Equals(...URI)` |
| `CheckHasClass` | 373 | `cls.GetIRI().Equals(resource.URI)` |

**Production impact:** `Generation/Converters/Argumentum.AssetConverter/Tests/OwlOntologyValidationTests.cs` is the post-generation OWL validation module and it calls these readers heavily:
- `ValidateMultilingualAnnotations` → `GetResourcesByType(Concept)` returns empty → early-returns **"no concepts → skip → PASS"** (silent false-pass)
- `ValidateAIFMappings` → same silent false-pass
- `ValidateOwlOntologyStructure` → logs all 4 errors (no ConceptScheme, no Concept, no topConcepts, no narrower) → **FAILs**

So OWL validation is currently unreliable. #133 (OWL publication) ships a non-empty ontology because the **write** path + serialization work (verified in section C), but the validators can't actually inspect it.

## Why no fix in this PR

`OwlAdapter.cs` is out of scope for this test-only dispatch (may intersect #444/#457 reserved files; fix is ai-01's call). Instead, this PR delivers the **ready-to-go regression suite**: the fix author changes the comparisons to `a.ValueIRI.Equals(new RDFResource(value.URI.ToString()))` (or `.ToString()`-based), and the 8 `[BUG]_*` tests flip red→green into proper round-trip assertions.

## Test structure (16 tests)

**Section A — [BUG] characterization (8 tests):** pin the BROKEN behavior. Each `.Should().BeEmpty()` / `.BeFalse()` with a `[BUG]` reason. When fixed, these become `.Should().HaveCount(...)` / `.BeTrue()`.

**Section B — root-cause probe (1 test):** pins the exact RDFSharp `Equals` semantics so the cause is undeniable and the fix is obvious.

**Section C — write-path + serialization (7 tests):** verify the WRITE side works (the graph IS correctly built in memory; `ToFileAsync` produces valid RDF/XML — that's why #133 ships non-empty despite broken readers). Verified by **direct graph inspection** (`.ToString()` comparison), NOT via the broken readers. So a fix can't accidentally regress the write side.

## DoD

- ✅ 202 → **218** pass / 0 fail / 5 skip
- ✅ Additive only (1 new file, 0 existing file modified)
- ✅ Build green
- ✅ Real bug surfaced honestly (no greenwashing — the 8 `[BUG]` tests assert the broken behavior, not a flipped assertion)

## Recommendation to ai-01

1. This PR can merge as-is (pure additive test coverage + bug characterization).
2. Open a separate `[BUG]` issue / fix PR for `OwlAdapter.cs` read methods — the fix is mechanical (6 comparison sites), and this PR's section-A tests become its regression suite.

🤖 Worker po-2024 on dispatch `j1jfoi` (primaire). Verdict QA visuelle = ai-01.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
