### PR TITLE
feat(dataset-updater): #457 DNN UI strings localization infra (Enabled=false)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/DnnUiStringClassMapRegressionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/DnnUiStringClassMapRegressionTests.cs
@@ -1,0 +1,136 @@
+using System.Linq;
+using Argumentum.AssetConverter.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Parsing
+{
+    /// <summary>
+    /// Regression tests for DnnUiStringClassMap (issue #457 — DNN UI strings localization).
+    /// These exercise the REAL load path — <see cref="CsvBase{T,TMap}.LoadFromContent"/> —
+    /// which registers the ClassMap and applies PrepareHeaderForMatch (diacritics/underscore/
+    /// hyphen/space stripping + lowercasing), so the "source_file" header resolves and
+    /// MissingFieldFound only logs.
+    ///
+    /// DUAL PATH NOTE: the DatasetUpdater engine reads raw CSV headers via a PLAIN
+    /// CsvConfiguration (DataSetInfo.GetDictionaryFromCsv — no ClassMap), so FieldsToInclude/
+    /// FieldsToUpdate in the task config use the literal header names. This test guards the
+    /// harvest/validation entity path. Inline CSV keeps each test self-contained; rows are
+    /// built via string.Join to avoid header/column miscounts.
+    /// </summary>
+    public class DnnUiStringClassMapRegressionTests
+    {
+        private static readonly string[] Columns =
+        {
+            "key", "context", "source_file", "fr", "en", "ru", "pt", "es", "ar", "fa", "zh", "notes"
+        };
+
+        private static string Row(params string[] values)
+        {
+            // Pads/truncates to the full 12-column width so callers only specify the leading cells.
+            var full = new string[Columns.Length];
+            for (var i = 0; i < full.Length && i < values.Length; i++)
+            {
+                full[i] = values[i] ?? "";
+            }
+
+            return string.Join(",", full);
+        }
+
+        private static string Csv(params string[] rows) =>
+            string.Join(",", Columns) + "\n" + string.Join("\n", rows) + "\n";
+
+        /// <summary>
+        /// Full header set: Key maps the "key" PK, FR is the source, the 7 localized columns
+        /// map to their language properties. "source_file" resolves via PrepareHeaderForMatch
+        /// (underscore stripped before matching). Placeholders {0}/{1} round-trip untouched.
+        /// </summary>
+        [Fact]
+        public void DnnUiString_LoadFromContent_MapsKeyFrAndLocalizedColumns()
+        {
+            var csv = Csv(Row(
+                "ui.rules.players_range",
+                "Rules player-count line",
+                "_RulesExplorer_RuleList.cshtml:15",
+                "de {0} à {1} joueurs",
+                "from {0} to {1} players",
+                "от {0} до {1} игроков",
+                "de {0} a {1} jogadores",
+                "de {0} a {1} jugadores",
+                "من {0} إلى {1} لاعب",
+                "از {0} تا {1} بازیکن",
+                "{0} 到 {1} 名玩家",
+                "keep {0}/{1}"));
+
+            var strings = DnnUiString.LoadFromContent(csv);
+
+            strings.Should().ContainSingle();
+            var s = strings[0];
+            s.Key.Should().Be("ui.rules.players_range");
+            s.Context.Should().Be("Rules player-count line");
+            s.SourceFile.Should().Be("_RulesExplorer_RuleList.cshtml:15");
+            s.Fr.Should().Be("de {0} à {1} joueurs");
+            s.En.Should().Be("from {0} to {1} players");
+            s.Ru.Should().Be("от {0} до {1} игроков");
+            s.Pt.Should().Be("de {0} a {1} jogadores");
+            s.Es.Should().Be("de {0} a {1} jugadores");
+            s.Ar.Should().Be("من {0} إلى {1} لاعب");
+            s.Fa.Should().Be("از {0} تا {1} بازیکن");
+            s.Zh.Should().Be("{0} 到 {1} 名玩家");
+            s.Notes.Should().Be("keep {0}/{1}");
+        }
+
+        /// <summary>
+        /// GetId() returns Key when present.
+        /// </summary>
+        [Fact]
+        public void DnnUiString_GetId_ReturnsKey()
+        {
+            var csv = Csv(Row("res.RuleSummary", "section heading", "_Detail.cshtml:37", "Résumé"));
+
+            var strings = DnnUiString.LoadFromContent(csv);
+
+            strings[0].Key.Should().Be("res.RuleSummary");
+            strings[0].GetId().Should().Be("res.RuleSummary");
+        }
+
+        /// <summary>
+        /// Only "key" is required; every other column is Optional. A header set reduced to
+        /// key + fr must parse without throwing and leave the other properties null.
+        /// </summary>
+        [Fact]
+        public void DnnUiString_OptionalColumns_AbsentDoesNotThrow()
+        {
+            var csv = "key,fr\nres.RuleSummary,Résumé\n";
+
+            var act = () => DnnUiString.LoadFromContent(csv);
+
+            act.Should().NotThrow();
+            var s = act().Should().Subject.First();
+            s.Key.Should().Be("res.RuleSummary");
+            s.Fr.Should().Be("Résumé");
+            s.En.Should().BeNull();
+            s.Ru.Should().BeNull();
+            s.Pt.Should().BeNull();
+            s.SourceFile.Should().BeNull();
+            s.Notes.Should().BeNull();
+        }
+
+        /// <summary>
+        /// An empty FR source (res.RuleMemoInstructions — DB-only, "export required before
+        /// translation") must still load with a null Fr, so the DatasetUpdater prompt can skip
+        /// it. Guards the documented "pas de source → pas de traduction" rule.
+        /// </summary>
+        [Fact]
+        public void DnnUiString_EmptyFrSource_LoadsWithNullFr()
+        {
+            var csv = Csv(Row("res.RuleMemoInstructions", "memo instructions", "_Detail.cshtml:59", ""));
+
+            var strings = DnnUiString.LoadFromContent(csv);
+
+            strings.Should().ContainSingle();
+            strings[0].Key.Should().Be("res.RuleMemoInstructions");
+            strings[0].Fr.Should().BeNullOrEmpty();
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -79,6 +79,13 @@ namespace Argumentum.AssetConverter
 				CsvType = typeof(Virtue),
 				ReleaseFilePath = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Fallacies/Argumentum%20Virtues%20-%20Taxonomy.csv",
 				DebugFilePath = @"..\..\..\..\..\..\Cards\Fallacies\Argumentum Virtues - Taxonomy.csv"
+			},
+			new DataSetInfo()
+			{
+				Name = KnownDataSets.DnnUiStrings,
+				CsvType = typeof(Argumentum.AssetConverter.Entities.DnnUiString),
+				ReleaseFilePath = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/docs/dnn-localization/dnn-ui-strings.csv",
+				DebugFilePath = @"..\..\..\..\..\..\docs\dnn-localization\dnn-ui-strings.csv"
 			}
 		});
 

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterRootConfig.cs
@@ -2632,6 +2632,67 @@ public class DatasetUpdaterRootConfig
 				MaxGroupItemNb = 12,
 				WriteOneTargetFileByField = false,
 				MaxChildren = 8
+			},
+			new DatasetUpdaterConfig()
+			{
+				Enabled = false,
+				Name = "Translate DNN UI strings FR to all languages (en/ru/pt/es/ar/fa/zh) empty-only multi",
+				SourceDataset = KnownDataSets.DnnUiStrings,
+				FieldsToInclude = new List<string>()
+				{
+					"key",
+					"context",
+					"source_file",
+					"fr",
+					"notes",
+					"en",
+					"ru",
+					"pt",
+					"es",
+					"ar",
+					"fa",
+					"zh"
+				},
+				FieldsToUpdate = new List<string>()
+				{
+					"en",
+					"ru",
+					"pt",
+					"es",
+					"ar",
+					"fa",
+					"zh"
+				},
+				PrimaryField = "key",
+				TargetPath = @".\Target\Datasets\dnn-ui-strings.csv",
+				SystemPromptPath = PromptsRootPath + "PromptGeneralSystem.txt",
+				DialogPrompts = new List<PromptExample>()
+				{
+					new PromptExample()
+					{
+						UserPromptPath = PromptsRootPath + "PromptDnnUiStringsTranslateMultiUser.txt",
+						AssistantAnswerPath = PromptsRootPath + "PromptDnnUiStringsTranslateMultiAssistant.txt"
+					}
+				},
+				// FR -> all 7 languages via OpenAI gpt-5.5 (issue #457). OpenRouter key (.keys\openai-key.txt).
+				Model = "gpt-5.5",
+				OpenAIKeyPath = @".keys\openai-key.txt",
+				MaxOutputTokens = 4096,
+				MaxTokensPerMinute = 70000,
+				DivisionMode = DivisionMode.SequentialChunks,
+				ChunkSize = 4,
+				UseFunctionCalling = true,
+				NbMessageCalls = 1,
+				SkipChunkNb = 0,
+				TakeChunkNb = -1,
+				SelectEmptyTargets = true,
+				RandomizeChunks = false,
+				MaxDegreeOfParallelismWebService = 4,
+				CompareMode = false,
+				AutoCompare = false,
+				MaxGroupItemNb = 12,
+				WriteOneTargetFileByField = false,
+				MaxChildren = 8
 			}
 		};
 }

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptDnnUiStringsTranslateMultiAssistant.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptDnnUiStringsTranslateMultiAssistant.txt
@@ -1,0 +1,8 @@
+Instructions bien reçues. Je vais traduire les chaînes UI DNN d'Argumentum du français vers les 7 langues cibles (en, ru, pt, es, ar, fa, zh) en respectant :
+- La conservation EXACTE des placeholders `{0}`/`{1}` à la position équivalente
+- Le saut des entrées dont `fr` est vide (aucun UpdateRecord émis)
+- Le style concis naturel de l'UI dans chaque langue
+- "Argumentum" invariant ; familles de cartes en français
+- ar/fa en lecture RTL naturelle ; résolution des entités HTML (`&agrave;` → "à")
+- Un appel `UpdateRecord` (primaryKey = `key`, fieldName = langue cible, newValue = traduction) par champ, tous en parallel tool calls, sans texte libre.
+Prêt à recevoir les données.

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptDnnUiStringsTranslateMultiUser.txt
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Resources/PromptDnnUiStringsTranslateMultiUser.txt
@@ -1,0 +1,27 @@
+**Instructions de Traduction multi-langue (DNN UI strings — issue #457) :**
+
+Dans le prochain message utilisateur, tu trouveras au format json un ensemble de chaînes d'interface utilisateur du site web DNN d'Argumentum. Chaque entrée comporte les champs :
+- `key` : identifiant de la ressource (ex. "ui.fallacy.find_out_more", "res.RuleSummary") — ne JAMAIS le traduire ni le modifier
+- `context` : description du contexte d'affichage (libellé de lien, titre de section <h2>, bouton, plage de joueurs…)
+- `source_file` : fichier template .cshtml d'origine (pour référence)
+- `fr` : texte source canonique en français
+- `notes` : notes éditoriales (ex. "INFERRED FR", "keep placeholders")
+- Les champs cibles vides : `en` (anglais), `ru` (russe), `pt` (portugais), `es` (espagnol), `ar` (arabe standard moderne / فصحى), `fa` (persan), `zh` (chinois simplifié)
+
+Ta tâche consiste à traduire le champ `fr` vers ces 7 langues, uniquement pour les entrées dont les champs cibles sont vides.
+
+1. **Utilisation du Function calling :** Pour chaque champ cible de chaque entrée, utilise un appel à la fonction `UpdateRecord` avec `primaryKey` = la valeur de `key`, `fieldName` = le nom du champ cible (`en`/`ru`/`pt`/`es`/`ar`/`fa`/`zh`), `newValue` = la traduction. Émets TOUS les appels en parallel tool calls. N'écris JAMAIS de texte libre. Pour 10 entrées × 7 langues, émets jusqu'à 70 appels parallèles.
+
+2. **Placeholders OBLIGATOIRES :** Certaines chaînes contiennent des marqueurs de format `{0}`, `{1}` (ex. "de {0} à {1} joueurs"). Tu DOIS conserver EXACTEMENT ces marqueurs `{0}`/`{1}` à la position équivalente dans chaque traduction. Ne pas les échapper, ne pas les réordonner, ne pas les traduire.
+
+3. **Pas de source → pas de traduction :** Si le champ `fr` d'une entrée est vide (cas `res.RuleMemoInstructions`), n'émet AUCUN appel UpdateRecord pour cette entrée. Laisse les champs cibles vides.
+
+4. **Style UI :** Ce sont des chaînes d'interface — concision, clarté, convention naturelle de l'UI dans chaque langue (libellés de boutons courts, titres de section sans verbe quand pertinent). Pas de traduction mot à mot.
+
+5. **Termes du jeu :** "Argumentum" (nom du jeu) reste "Argumentum" dans toutes les langues. Les noms des familles de cartes restent en français.
+
+6. **RTL :** L'arabe (`ar`) et le persan (`fa`) seront affichés RTL — produis le texte dans le sens de lecture naturel de chaque langue.
+
+7. **Entités HTML :** Les chaînes sources peuvent contenir des entités HTML (ex. `&agrave;` pour "à"). Traduis le caractère signifié (ici "à"), pas l'entité littérale.
+
+Es-tu prêt à recevoir les données ?

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/DnnUiString.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/DnnUiString.cs
@@ -1,0 +1,67 @@
+using CsvHelper.Configuration;
+
+namespace Argumentum.AssetConverter.Entities
+{
+    /// <summary>
+    /// DNN web-platform UI strings (issue #457). Source CSV lives at
+    /// docs/dnn-localization/dnn-ui-strings.csv with columns:
+    /// key, context, source_file, fr, en, ru, pt, es, ar, fa, zh, notes.
+    /// "key" is the primary key (e.g. "ui.fallacy.find_out_more", "res.RuleSummary").
+    /// "fr" is the canonical source; the 7 target languages (en/ru/pt/es/ar/fa/zh) are
+    /// populated by the DatasetUpdater (gpt-5.5).
+    ///
+    /// DUAL PATH NOTE: the DatasetUpdater engine reads raw CSV headers via a PLAIN
+    /// CsvConfiguration (DataSetInfo.GetDictionaryFromCsv — no ClassMap, no
+    /// PrepareHeaderForMatch), so FieldsToInclude/FieldsToUpdate/PrimaryField in the task
+    /// config use the literal header names (key, fr, en, source_file...). This ClassMap is
+    /// exercised by the harvest/validation entity path (CsvBase.LoadFromContent) and by the
+    /// DnnUiStringClassMapRegressionTests.
+    /// </summary>
+    public class DnnUiString : CsvBase<DnnUiString, DnnUiStringClassMap>, ICsvBase
+    {
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Returns Key when present, otherwise a sequential id derived from RowIndex
+        /// (mirrors Rule.GetId). The base Id is intentionally left unmapped.
+        /// </summary>
+        public new string GetId()
+        {
+            return !string.IsNullOrEmpty(Key) ? Key : $"DnnUi_{RowIndex + 1:D2}";
+        }
+
+        public string Context { get; set; }
+        public string SourceFile { get; set; }
+        public string Fr { get; set; }
+        public string En { get; set; }
+        public string Ru { get; set; }
+        public string Pt { get; set; }
+        public string Es { get; set; }
+        public string Ar { get; set; }
+        public string Fa { get; set; }
+        public string Zh { get; set; }
+        public string Notes { get; set; }
+    }
+
+    public sealed class DnnUiStringClassMap : ClassMap<DnnUiString>
+    {
+        public DnnUiStringClassMap()
+        {
+            // Only "key" is required so the CSV loads even before any translation exists;
+            // every other column is Optional (MissingFieldFound only logs). "source_file"
+            // resolves via PrepareHeaderForMatch (underscore stripped before matching).
+            Map(m => m.Key).Name("key");
+            Map(m => m.Context).Name("context").Optional();
+            Map(m => m.SourceFile).Name("source_file").Optional();
+            Map(m => m.Fr).Name("fr").Optional();
+            Map(m => m.En).Name("en").Optional();
+            Map(m => m.Ru).Name("ru").Optional();
+            Map(m => m.Pt).Name("pt").Optional();
+            Map(m => m.Es).Name("es").Optional();
+            Map(m => m.Ar).Name("ar").Optional();
+            Map(m => m.Fa).Name("fa").Optional();
+            Map(m => m.Zh).Name("zh").Optional();
+            Map(m => m.Notes).Name("notes").Optional();
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/KnownDataSets.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/KnownDataSets.cs
@@ -11,4 +11,5 @@ public static class KnownDataSets
 	public static string RulesPrintAndPlay = "Rules - Print & Play";
 	public static string FallaciesTaxonomy = "Fallacies - Taxonomy";
 	public static string VirtuesTaxonomy = "Fallacies - Virtues";
+	public static string DnnUiStrings = "DNN UI Strings";
 }


### PR DESCRIPTION
## What

DatasetUpdater **config infrastructure** for issue **#457** — translate the DNN web-platform UI strings (`docs/dnn-localization/dnn-ui-strings.csv`) FR → all 7 languages (en/ru/pt/es/ar/fa/zh) via **gpt-5.5**. The task ships **`Enabled = false`** so the mechanics can be reviewed before the smoke/full run.

This is the **config-infra PR** (my ACK to ai-01, `rqb5pm`). The smoke test + full run → **data PR** is the next step.

## Files (7, +320/-13)

| File | Change |
|------|--------|
| `Entities/DnnUiString.cs` | NEW — entity + `DnnUiStringClassMap` (`key`=PK, only required col) |
| `WebBasedGenerator/KnownDataSets.cs` | + `DnnUiStrings` constant |
| `AssetConverterConfig.cs` | + `DataSetInfo` (DebugFilePath → `docs/dnn-localization/dnn-ui-strings.csv`, CsvType=`DnnUiString`) |
| `DatasetUpdater/DatasetUpdaterRootConfig.cs` | + task block (Enabled=false, gpt-5.5, OpenRouter key, ChunkSize=4, multi-lang single task) |
| `Resources/PromptDnnUiStringsTranslateMultiUser.txt` | NEW prompt |
| `Resources/PromptDnnUiStringsTranslateMultiAssistant.txt` | NEW prompt |
| `Tests/Parsing/DnnUiStringClassMapRegressionTests.cs` | NEW +4 tests |

## Mechanics note for ai-01 (review)

- **DUAL CSV PATH.** The engine reads the source via `DataSetInfo.GetDictionaryFromCsv`, which uses a **plain** `CsvConfiguration` (no `PrepareHeaderForMatch`, **no ClassMap**) → dictionary keys are the **raw CSV header names**. Therefore `FieldsToInclude`/`FieldsToUpdate`/`PrimaryField` use the literal headers (`key`, `fr`, `en`, `source_file`…), **not** property names. The `DnnUiStringClassMap` is only on the harvest/validation path (`CsvBase.LoadFromContent`) and is exercised by the 4 new tests. Verified by reading `DataSetInfo.cs:396-410` + `DatasetUpdaterConfig.cs:125-157`.
- **Single multi-language task** (mirrors `PromptRulesPPTranslateMulti`): `FieldsToUpdate = [en,ru,pt,es,ar,fa,zh]`, model emits up to 70 parallel `UpdateRecord` calls (10 rows × 7 langs). `UpdateRecord(primaryKey, fieldName, newValue)` is one-field-per-call (`RecordsUpdater.cs:18`).
- **`SelectEmptyTargets = true`** selects all 10 rows (all targets empty). The prompt instructs skipping rows whose `fr` is empty.
- **`SkipConfigFile = true`** convention respected — C# defaults are the single source of truth.

## Content-integrity flags for @jsboige (signalled, NOT declared PASS)

1. **`res.RuleMemoInstructions`** has **no FR source** (CSV note: *"DB-only — NOT inferred; export required before translation"*). Its 7 cells will stay **empty by design** — the prompt instructs the model to skip empty-`fr` rows. A DB export is needed before this string can be translated.
2. **6 rows are "INFERRED FR"** (`res.RuleSummary/Material/Installation/Variants/MemoCard/MemoCardFileNamePrefix/MemoCardDownload`) — source FR values are guesses. Translations will be of inferred source and **need export verification** before final acceptance.

## DoD (from dispatch `uy6g62`)

- [x] Config infra built, compiles (0 errors)
- [x] gpt-5.5 confirmed in task config (no 5.4-mini)
- [ ] Smoke test (1-2 records) — **next**, pending this PR / key check
- [ ] Full run → translated strings → **data PR** (separate)
- [ ] jsboige content validation (ai-01 validates mechanics)

The full-run **data PR stays in pending content validation by jsboige** — I deliver + signal, I do not declare PASS.

## Verification

- `dotnet build` → **0 errors** (16 pre-existing warnings, none from new code).
- `dotnet test` → **252 pass / 0 fail / 5 skip**, incl. +4 `DnnUiStringClassMapRegressionTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
