### PR TITLE
docs(dnn): #131/#132 DNN site release-validation dossier skeleton

### DIFF
--- a/docs/dnn-localization/release-validation/2sxc-export-spec.md
+++ b/docs/dnn-localization/release-validation/2sxc-export-spec.md
@@ -1,0 +1,102 @@
+# Spec — Export 2sxc pour vérifier le FR inféré & débloquer #490
+
+**Auteur :** Claude Code @ myia-po-2023 (worker) — 2026-06-16
+**Objet :** Spécification de l'export 2sxc qui (1) vérifie les **7 FR inférés** `res.*` de
+`dnn-ui-strings.csv` vs le dictionnaire Resources live, et (2) extrait le contenu DB-only
+(Rules/Glossary/FAQ/homepage) pour la localisation complète. C'est le **vrai unblocker** de #490 et
+des Phases 2–3 de #457.
+**Accès requis :** jsboige (admin DNN/2sxc). Outil : UI 2sxc **ou** SQL direct sur la base du portail.
+
+---
+
+## 1. Pourquoi cet export
+
+`PHASE1-content-audit.md` §1b établit : les 8 clés `res.*` sont **présentes** dans les templates
+(`@Resources.X`) mais leurs **valeurs vivent en SQL** (dictionnaire Resources de l'app Argumentum) —
+le repo n'a pas d'`App_Data/`. Les 7 valeurs FR de `dnn-ui-strings.csv` sont donc **inférées** du
+contexte `.cshtml`. jsboige a **holdé #490** jusqu'à vérification de ce FR vs le DB live.
+
+Tant que ces 7 FR ne sont pas confirmés, les 7×7 = 49 traductions dépendantes sont **provisoires**.
+
+## 2. Périmètre de l'export
+
+| # | Ce qu'on exporte | Source 2sxc/DNN | But | Priorité |
+|---|------------------|-----------------|-----|----------|
+| 1 | **App Resources** (dictionnaire valeurs FR) | App Argumentum → Content-type `Resources` | Vérifier les 7 FR inférés `res.*` | **P0 — débloque #490** |
+| 2 | **Rules content** (Summary/Material/Installation/Variants/Memo) | Content-items Rules | FR canonique des corps de règles (≈24 règles × 5 champs) | P1 |
+| 3 | **Glossary entries** | App `Glossary3` | ≈50 entrées glossaire | P2 |
+| 4 | **FAQ entries** | App `Faq4` | FAQ | P2 |
+| 5 | **Homepage/About/landing** | App `Content` + modules | ≈10 pages | P2 |
+| 6 | **Nav labels** | DNN tabs | Labels menu | P3 |
+| 7 | **SEO meta** (titres/descriptions) | DNN page settings | ≈40 pages | P3 |
+
+> **Déjà localisé, pas d'export requis :** Fallacies Explorer lit le CSV taxonomy via
+> `App.Query["FallaciesFromCSV"]` → le contenu des fallacies est déjà couvert par les CSV cartes 8
+> langues. (Caveat : le template pin `_en` — bug §4, à corriger en code.)
+
+## 3. Méthode A — UI 2sxc (recommandé, non destructif)
+
+1. Se connecter au portail DNN (local `http://localhost:8090` ou prod) en admin.
+2. **2sxc → App Argumentum → Data** (ou *Content*).
+3. Sélectionner le content-type **`Resources`** → liste des entrées key/value.
+4. Export : bouton **Export** (JSON ou CSV). 2sxc génère un fichier avec toutes les paires key/value
+   (toutes langues présentes en DB).
+5. Répéter pour `Rules`, `Glossary3`, `Faq4`, `Content` selon le périmètre §2.
+
+**Pour les DNN tabs (nav) et page settings (SEO)** : DNN admin → *Pages* → export, ou SQL (§4).
+
+## 4. Méthode B — SQL direct (si l'UI 2sxc est indisponible)
+
+2sxc stocke les entités dans `dbo.[ToSIC_SexyContent_<App>_<ContentType>_Entity]` + valeurs dans des
+tables `*_Value` / attributs EAV. La structure exacte varie ; requête de départ (adapter) :
+
+```sql
+-- Lister les ressources FR de l'app Argumentum (vérifier le schéma EAV réel au préalable)
+SELECT  e.EntityId, e.Guid, a.Name AS [Key], v.Value
+FROM    ToSIC_SexyContent_AttributeValues v
+JOIN    ToSIC_SexyContent_Attributes a       ON a.AttributeId = v.AttributeId
+JOIN    ToSIC_SexyContent_Entities e         ON e.EntityId = v.EntityId
+JOIN    ToSIC_SexyContent_AttributeSets s    ON s.AttributeSetId = a.AttributeSetId
+WHERE   s.Name = 'Resources'                 -- content-type Resources de l'app Argumentum
+  AND   v.Language = 'fr-FR'                 -- (ou NULL si mono-langue)
+ORDER BY a.Name;
+```
+
+⚠️ **Le schéma EAV de 2sxc dépend de la version** (15.02 ici). Vérifier les noms de tables réels
+(`SELECT name FROM sys.tables WHERE name LIKE 'ToSIC_SexyContent%'`) avant la jointure. L'UI (§3) est
+plus sûre si disponible.
+
+## 5. Comparaison & action (comment lever le HOLD #490)
+
+1. **Mapper** les 7 clés `res.*` de `dnn-ui-strings.csv` → valeurs FR de l'export.
+2. Pour chaque clé :
+
+   | Cas | Action |
+   |-----|--------|
+   | FR exporté = FR inféré | ✅ Confirmé — la ligne est fiable |
+   | FR exporté ≠ FR inféré | ⚠️ Corriger la cellule `fr` dans `dnn-ui-strings.csv`, **puis re-run #457** (OpenAI direct, clé rechargée) pour régénérer les 7 traductions de cette ligne |
+   | Clé absente de l'export | La ressource n'existe peut-être plus → à clarifier avec jsboige |
+
+3. **`res.RuleMemoInstructions`** : extraire la **valeur FR multi-phrases** (DB-only, non inférée).
+   La remplir dans `dnn-ui-strings.csv` (colonne `fr`), puis re-run #457 → produit les 7 langues.
+4. Une fois les 7 (8 avec MemoInstructions) FR confirmés → **lever le HOLD #490** et valider les
+   langues (voir `non-latin-verification-guide.md`).
+
+## 6. Format d'export attendu (pour ré-ingestion #457)
+
+Pour que le contenu DB-only (Rules/Glossary/FAQ, périmètre #2-5) soit **traduisible par le
+DatasetUpdater**, l'export doit atterrir dans un CSV au schéma `dnn-ui-strings.csv` :
+`key, context, source_file, fr, en, ru, pt, es, ar, fa, zh, notes` — une ligne par chaîne, `fr`
+rempli, cibles vides. Le DatasetUpdater (OpenAI direct gpt-5.5, clé rechargée) fait ensuite le reste.
+
+## 7. Risques / précautions
+
+- **Non destructif** : export = lecture seule. Aucun write sur le portail.
+- **Ne pas modifier les CSV avant injection CardPen** (règle projet) — N/A ici (pas de CardPen), mais
+  l'export reste une source de vérité ; ne pas éditer à la main les cellules traduites.
+- **Version 2sxc** : 15.02. L'UI d'export peut différer des captures génériques — s'adapter.
+
+---
+
+*Cet export est l'action jsboige qui débloque #490 et ouvre les Phases 2–3. Worker signale ; jsboige
+exécute l'accès admin. Gate release intacte.*

--- a/docs/dnn-localization/release-validation/README.md
+++ b/docs/dnn-localization/release-validation/README.md
@@ -1,0 +1,65 @@
+# DNN Site — Dossier de validation release (Epic #131/#132)
+
+**Auteur :** Claude Code @ myia-po-2023 (worker) — 2026-06-16
+**Objet :** Ossature du dossier que jsboige utilisera pour valider la release du **site web DNN**
+(DNN + 2sxc, 8 langues). C'est l'artefact de validation **site**, distinct du dossier de validation
+**cartes** (`docs/release-v0.9.0-validation-brief.md`).
+**Statut :** **Skeleton** — le site n'est pas encore déployé publiquement (Phase A = boot local IIS
+Express, DNN 9.11.1 + 2sxc 15.02, port 8090). Ce dossier est **préparé à l'avance** ; il est utilisable
+dès maintenant sur le site local et, sans changement, sur un staging/prod futur.
+**Gate release :** ⛔ TOUJOURS ACTIF. Ce dossier **prépare** la validation, il ne la remplace pas et ne
+lève rien. Verdict visuel/contenu = jsboige. Le worker signale, il ne déclare pas PASS.
+
+---
+
+## 1. Pourquoi un dossier séparé « site »
+
+La release v0.9.0 a **deux tracks** validés indépendamment :
+
+| Track | Artefacts | Dossier de validation |
+|-------|-----------|----------------------|
+| **Cartes** (PDF/PNG/mindmaps/OWL) | 64 PDFs × 8 langues, ~9 834 images, 20 SVGs | `docs/release-v0.9.0-validation-brief.md` + `docs/publication/qa-scenario-8langues-release.md` |
+| **Site DNN** (ce dossier) | UI strings 8 langues, Fallacy/Rules Explorers, rendu RTL/CJK | **`docs/dnn-localization/release-validation/`** (ici) |
+
+Le track cartes est couvert. Ce dossier couvre le **track site**, qui n'existait pas.
+
+## 2. Structure du dossier
+
+| Fichier | Rôle | Quand jsboige l'utilise |
+|---------|------|--------------------------|
+| `README.md` (ce fichier) | Index + manifeste + relations | Point d'entrée — lire en premier |
+| `validation-checklist.md` | Checklist par langue + par feature (Explorers, labels, nav) | Pendant la validation site — cocher au fur et à mesure |
+| `non-latin-verification-guide.md` | Guide pour les langues que jsboige ne lit pas (ar/fa/zh, +ru) — chaînes attendues + signatures visuelles | Pour valider ar/fa/zh sans lire la langue |
+| `2sxc-export-spec.md` | Spec d'export 2sxc pour vérifier les 7 FR inférés + extraire le contenu DB-only | **Avant** la validation — débloque #490 |
+
+## 3. Workflow de validation (jsboige)
+
+1. **Préalable — export 2sxc** (voir `2sxc-export-spec.md`) : vérifier les 7 FR inférés `res.*` vs le
+   dictionnaire Resources live. Si un FR inféré diffère, le corriger dans `dnn-ui-strings.csv` puis
+   re-run #457 (OpenAI direct, clé rechargée). Tant que c'est ouvert, la PR #490 reste **HELD**.
+2. **Lever le hold #490** une fois le FR vérifié + les langues validées.
+3. **Validation site** (sur local IIS Express `http://localhost:8090` maintenant, staging/prod plus
+   tard) : parcourir chaque langue avec `validation-checklist.md`.
+4. **Langues non lues** (ar/fa/zh) : s'appuyer sur `non-latin-verification-guide.md` (chaînes
+   attendues + contrôles de direction/police).
+5. **Bugs connus à vérifier** : FallacyExplorer pas culture-aware (pin `_en`) — voir §4 de
+   `../PHASE1-content-audit.md`. À corriger en Phase 2/4.
+
+## 4. Prérequis / dépendances
+
+- **2sxc export** (étape 1 ci-dessus) — gate réel pour la fiabilité du FR source.
+- **Fix FallacyExplorer culture** (audit §4) — sans lui, l'Explorer affiche `text_en` quelle que soit
+  la langue → invalide toute validation ar/fa/zh/ru/pt/es de l'Explorer. À planifier Phase 2/4.
+- **Déploiement staging** — pour une validation représentative du prod (le local IIS suffit pour
+  valider le rendu, pas la perf/SSL).
+
+## 5. Relations avec les autres docs
+
+- `../PHASE1-content-audit.md` — audit de localisation (source des 10 chaînes + bug §4).
+- `../dnn-ui-strings.csv` — données source (#490, HELD).
+- `../../dnn/UPGRADE-ASSESSMENT.md` — assessment migration DNN 9.13→10.x (track déploiement).
+- `../../release-v0.9.0-validation-brief.md` — validation release **cartes** (l'autre track).
+
+---
+
+*Worker signals; visual/content verdict and merge are jsboige's. Release gate untouched.*

--- a/docs/dnn-localization/release-validation/non-latin-verification-guide.md
+++ b/docs/dnn-localization/release-validation/non-latin-verification-guide.md
@@ -1,0 +1,96 @@
+# DNN Site — Guide de vérification des langues non latines (ar/fa/zh, +ru)
+
+**Pourquoi :** jsboige ne lit pas l'arabe (ar), le persan (fa) ni le chinois (zh), et lit peu le
+russe (ru). Ce guide donne les **chaînes attendues** et des **signatures visuelles** pour valider ces
+langues **sans les lire**.
+
+**Source des chaînes :** `../dnn-ui-strings.csv` (PR #490). ⚠️ Les 7 lignes `res.*` (hors
+`MemoInstructions`) ont un **FR inféré** — leurs traductions sont **provisoires** tant que le FR n'est
+pas vérifié vs l'export 2sxc (voir `2sxc-export-spec.md`). #490 est **HELD** pour cette raison.
+
+---
+
+## 1. Comment valider une langue qu'on ne lit pas
+
+Trois contrôles indépendants du sens :
+
+1. **Comparaison de chaîne exacte** — la chaîne rendue à l'écran doit **matcher** (caractère pour
+   caractère) la chaîne attendue ci-dessous. Copier-coller depuis le site vers un diff texte.
+2. **Sens de lecture (RTL)** — pour ar/fa, le conteneur doit être `dir="rtl"` (DevTools → inspecter
+   l'élément, ou `dir="auto"` résolvant à RTL). Le texte commence à droite.
+3. **Glyphe + police** — pas de tofu (□) ni de glyphes latins substitués. La police attendue est
+   chargée (Noto Naskh Arabic / Vazirmatn / Noto Sans SC).
+
+Si les 3 passent, la langue rend correctement (même sans la lire).
+
+## 2. Cheat-sheet — chaînes attendues (#490)
+
+> `res.*` = FR **inféré** (provisoire). `ui.*` = FR solide. `res.RuleMemoInstructions` = absent (non
+> traduit, source FR DB-only).
+
+| key | ar (RTL) | fa (RTL) | zh | ru |
+|-----|----------|----------|----|----|
+| `ui.fallacy.find_out_more` | اعرف المزيد | بیشتر بدانید | 了解更多 | Подробнее |
+| `ui.rules.players_range` | من {0} إلى {1} لاعبين | از {0} تا {1} بازیکن | {0} 至 {1} 名玩家 | от {0} до {1} игроков |
+| `res.RuleSummary` ⚠️ | ملخص | خلاصه | 摘要 | Краткое описание |
+| `res.RuleMaterial` ⚠️ | المواد | محتویات بازی | 材料 | Материалы |
+| `res.RuleInstallation` ⚠️ | الإعداد | آماده‌سازی | 设置 | Подготовка |
+| `res.RuleVariants` ⚠️ | الأنواع | گونه‌ها | 变体 | Варианты |
+| `res.RuleMemoCard` ⚠️ | بطاقة تذكيرية | کارت یادآوری | 备忘卡 | Памятка |
+| `res.RuleMemoCardFileNamePrefix` ⚠️ | مذكرة | یادداشت | 备忘 | Памятка |
+| `res.RuleMemoCardDownload` ⚠️ | تنزيل البطاقة | دانلود کارت | 下载卡牌 | Скачать карту |
+
+**Contrôles spécifiques aux placeholders** (`ui.rules.players_range`) :
+- `{0}` et `{1}` doivent apparaître **tels quels** (accolades incluses) à la position équivalente.
+- En ar : `من {0} إلى {1} لاعبين` — les nombres s'insèrent entre les accolades, lecture RTL.
+- En zh : `{0} 至 {1} 名玩家` — « de {0} à {1} joueurs ».
+
+## 3. Signatures visuelles par langue
+
+### AR (arabe — RTL)
+- **Direction :** RTL. `dir="rtl"` sur le conteneur.
+- **Police :** Noto Naskh Arabic. Glyphes liés (l'arabe est cursif — les lettres se joignent).
+- **Red flags :** lettres détachées (non jointes), sens LTR, tofu, texte latin.
+- **Spot-check :** le libellé du lien FallacyExplorer = `اعرف المزيد` (4 mots arabes joints).
+
+### FA (persan — RTL)
+- **Direction :** RTL. `dir="rtl"`.
+- **Police :** Vazirmatn. Le persan utilise des formes de lettres supplémentaires (گ چ پ ژ) absentes
+  de l'arabe — vérifier qu'elles rendent (ex. `بیشتر` contient `ش`).
+- **Red flags :** identiques à ar, MAIS le persan ne doit PAS utiliser uniquement des glyphes arabes
+  (si Vazirmatn manque, fallback déforme).
+- **Spot-check :** lien FallacyExplorer = `بیشتر بدانید`.
+
+### ZH (chinois simplifié — LTR)
+- **Direction :** LTR (comme le latin).
+- **Police :** Noto Sans SC. Caractères pleins (CJK), pas de tofu.
+- **Red flags :** tofu □, caractères japonais traditionnels (≠ simplifié), texte latin.
+- **Spot-check :** lien FallacyExplorer = `了解更多` (4 caractères CJK).
+
+### RU (russe — Cyrillique, LTR)
+- **Direction :** LTR.
+- **Police :** défaut (le Cyrillique est couvert par la plupart des polices latines).
+- **Red flags :** caractères latins à la place du Cyrillique (ex. « C » au lieu de « С »).
+- **Spot-check :** lien FallacyExplorer = `Подробнее`.
+
+## 4. Contrôle rapide « 30 secondes »
+
+Pour une validation express d'une langue non lue :
+1. Ouvrir la page Rules détail dans la langue cible.
+2. Copier le libellé du bouton de téléchargement (en bas de la carte mémo).
+3. Le coller dans le diff vs la cellule `res.RuleMemoCardDownload` du tableau §2.
+4. Si match exact → la ressource est localisée et la police rend. Sinon → investiguer (fallback FR ?
+   police manquante ? clé non résolue ?).
+
+## 5. Limites
+
+- Ce guide couvre les **10 chaînes** de `dnn-ui-strings.csv`. Les contenus DB-only (Glossary, FAQ,
+  homepage, corps des règles) ne sont **pas encore extraits** (voir `2sxc-export-spec.md`) — ils
+  n'ont donc pas encore de chaînes attendues.
+- Le bug FallacyExplorer (§4 du content-audit) fait que l'Explorer affiche de l'anglais en toute
+  langue → ne pas conclure « traduction manquante » sur l'Explorer avant le fix.
+
+---
+
+*Les chaînes attendues reflètent #490 (HOLD). Toute correction du FR source → re-run #457 →
+mise à jour de ce guide.*

--- a/docs/dnn-localization/release-validation/validation-checklist.md
+++ b/docs/dnn-localization/release-validation/validation-checklist.md
@@ -1,0 +1,99 @@
+# DNN Site — Checklist de validation 8 langues
+
+**Usage :** à parcourir pour **chaque langue** sur le site (local IIS Express `http://localhost:8090`
+maintenant, staging/prod plus tard). Cocher chaque case. Pour ar/fa/zh, s'appuyer sur
+`non-latin-verification-guide.md`.
+
+**Langues :** FR (source) · EN · RU · PT · ES · AR · FA · ZH.
+
+---
+
+## 1. Setup langue
+
+Pour chaque langue, basculer la culture du portail (DNN language selector ou `?language=xx-XX`).
+Vérifier :
+
+- [ ] Le sélecteur de langue existe et liste les 8 langues.
+- [ ] Le changement de langue recharge la page dans la bonne culture (pas de cache FR résiduel).
+
+## 2. Rendu par langue (tableau de signatures)
+
+| Langue | Script | Sens | Police attendue | Red flag (fallback FR) |
+|--------|--------|------|-----------------|------------------------|
+| FR | Latin | LTR | défaut | (source — référence) |
+| EN | Latin | LTR | défaut | texte qui reste en français |
+| RU | Cyrillique | LTR | défaut (Cyrillique) | caractères latin à la place du cyrillique |
+| PT | Latin | LTR | défaut | texte en français |
+| ES | Latin | LTR | défaut | texte en français |
+| AR | Arabe | **RTL** | Noto Naskh Arabic | sens LTR / glyphes manquants (tofu □) |
+| FA | Persan | **RTL** | Vazirmatn | sens LTR / glyphes manquants |
+| ZH | CJK | LTR | Noto Sans SC | glyphes manquants (tofu) / texte latin |
+
+**Pour chaque langue, vérifier :**
+
+- [ ] Aucun **glyphe manquant** (pas de □/tofu).
+- [ ] Aucun **fallback FR** (texte français qui apparaît dans une page non-FR).
+- [ ] Aucun **débordement** (texte coupé ou qui sort de son conteneur).
+- [ ] **Sens de lecture correct** (RTL pour ar/fa — voir contrôle direction §3).
+
+## 3. Features du site (par langue)
+
+### 3.1 Fallacy Explorer (`_FallacyExplorer_Root.cshtml`)
+
+- [ ] La liste des fallacies s'affiche.
+- [ ] **⚠️ BUG CONNU (audit §4)** : le template **pin `text_en`/`desc_en`/`link_en`** quelle que soit
+      la culture + hardcode le label `"find out more"` (EN). → Pour toute langue ≠ EN, l'Explorer
+      affiche actuellement de l'anglais. **C'est un bug à corriger (Phase 2/4), pas un échec de
+      traduction.** Le signaler ; ne pas bloquer la validation des autres features dessus.
+- [ ] Une fois le fix appliqué : le libellé du lien = chaîne localisée (`ui.fallacy.find_out_more`,
+      voir `non-latin-verification-guide.md`).
+
+### 3.2 Rules Explorer — liste (`_RulesExplorer_RuleList.cshtml`)
+
+- [ ] La plage de joueurs s'affiche : `de {0} à {1} joueurs` (FR) → traduit (voir guide).
+- [ ] Les placeholders `{0}`/`{1}` sont **préservés** (nombres de joueurs insérés).
+
+### 3.3 Rules Explorer — détail (`_RulesExplorer_RuleDetail.cshtml`)
+
+Pour chaque règle, vérifier les 8 sections `res.*` (FR → traduit) :
+
+- [ ] `res.RuleSummary` (Résumé)
+- [ ] `res.RuleMaterial` (Matériel)
+- [ ] `res.RuleInstallation` (Installation)
+- [ ] `res.RuleVariants` (Variantes)
+- [ ] `res.RuleMemoCard` (Carte mémo)
+- [ ] `res.RuleMemoInstructions` — **⚠️ PAS DE SOURCE FR** (DB-only multi-sentence). Actuellement
+      **non traduit** (7 cellules vides). Nécessite un export DB FR avant traduction (voir
+      `2sxc-export-spec.md`).
+- [ ] `res.RuleMemoCardFileNamePrefix` (Mémo)
+- [ ] `res.RuleMemoCardDownload` (Télécharger la carte — bouton)
+
+> **Note :** les 7 `res.*` (hors MemoInstructions) ont un **FR inféré** (issu du contexte `.cshtml`,
+> pas du DB live). Leurs traductions dépendent de ce FR. **À vérifier vs export 2sxc avant de s'y
+> fier** (c'est le motif du HOLD #490).
+
+### 3.4 Navigation & meta
+
+- [ ] Labels de navigation localisés (DB-only — nécessite export DNN tabs, voir spec §3).
+- [ ] Titres/meta SEO localisés (DB-only — export page settings).
+
+## 4. Contrôles transverses
+
+- [ ] **Direction RTL** : pour ar/fa, `html[dir="rtl"]` (ou `dir="auto"` résout à RTL). Le layout
+      miroir (sidebar, alignement) suit.
+- [ ] **Polices RTL/CJK chargées** : Noto Naskh Arabic (ar), Vazirmatn (fa), Noto Sans SC (zh) —
+      pas de fallback système qui déformerait les glyphes.
+- [ ] **Encodage UTF-8** : caractères accentués/arabes/CJK intacts (pas de `?` ou mojibake).
+- [ ] **Placeholders** : `{0}`/`{1}` préservés dans toutes les langues (cf. `ui.rules.players_range`).
+
+## 5. Issue tracking
+
+Tout écart → issue GitHub (label `dnn`/`i18n`) ou signalement dashboard. Distinguer :
+- **Bug template** (ex. FallacyExplorer §4) → fix code Phase 2/4.
+- **FR source faux** (inféré ≠ DB) → corriger CSV + re-run #457.
+- **Traduction faible** → ajuster cellule ciblée.
+
+---
+
+*Checklist exhaustive mais non exhaustive des contenus DB-only (Glossary/FAQ/homepage) — ceux-ci
+attendent l'export 2sxc (voir `2sxc-export-spec.md`).*


### PR DESCRIPTION
## What

Adds the missing **"site" validation track** for the DNN release (Epic #131/#132) — distinct from the cards-release brief. Dispatched as **primary** by ai-01's cycle 09:13 deep-queue ("dossier validation release DNN + Epic #131/#132"; dispatch `muf8h5` [idle] "ossature du dossier... guide de vérif des langues que jsboige ne lit pas").

**Pure prep** — 4 new docs, no code/CSV/template/config change, no release artifact, no tag, no DNN write. Release gate untouched. Worker signals; visual/content verdict and merge are jsboige's.

## Files (`docs/dnn-localization/release-validation/`)

| File | Role |
|------|------|
| `README.md` | Index + manifest + validation workflow + relationships (cards-release brief, upgrade assessment) |
| `validation-checklist.md` | Per-language (FR/EN/RU/PT/ES/AR/FA/ZH) + per-feature (Fallacy/Rules Explorers, nav, SEO) checklist |
| `non-latin-verification-guide.md` | Expected ar/fa/zh/ru strings (from #490 data) + visual signatures (RTL, fonts, tofu) so jsboige validates languages he doesn't read |
| `2sxc-export-spec.md` | Actionable 2sxc export (UI + SQL fallback) to verify the 7 inferred FR `res.*` vs the live Resources dictionary — the real unblocker for #490 |

## Why a separate "site" dossier

v0.9.0 has two validation tracks: **cards** (PDF/PNG/mindmaps/OWL — already covered by `docs/release-v0.9.0-validation-brief.md`) and **site** (DNN+2sxc, 8 languages — nothing existed). The site track was the gap. This dossier fills it and is usable now on local IIS Express (`http://localhost:8090`) and unchanged on future staging/prod.

## Grounded in

- `PHASE1-content-audit.md` (the 10 UI strings, the 8 `res.*` keys + confidence, the FallacyExplorer culture bug §4).
- `dnn-ui-strings.csv` (#490 data — the expected strings in the non-latin guide).

## Key flags surfaced (for jsboige)

1. **7 INFERRED FR rows** (`res.*`, #490 HOLD) — their 7×7=49 translations are provisional until FR is verified vs 2sxc export. `2sxc-export-spec.md` operationalizes that export.
2. **`res.RuleMemoInstructions`** — no FR source at all (DB-only multi-sentence); needs export then a re-run.
3. **FallacyExplorer culture bug (audit §4)** — template pins `_en` fields regardless of culture, so the Explorer shows English in every language until fixed (Phase 2/4 code fix). Flagged in the checklist so it isn't mistaken for a missing translation.

## DoD (dispatch primary)

- [x] Dossier ossature (structure + manifest)
- [x] Guide de vérif des langues que jsboige ne lit pas (ar/fa/zh, +ru)
- [x] 2sxc export spec to unblock #490 (secondary, bundled)
- [ ] **Content/merge: jsboige** (worker signals, does not declare PASS)

Refs #131, #132, #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
