### PR TITLE
docs(dnn): correct stale FallacyExplorer bug flag — FIXED in #464

### DIFF
--- a/docs/dnn-localization/PHASE1-content-audit.md
+++ b/docs/dnn-localization/PHASE1-content-audit.md
@@ -118,6 +118,11 @@ confirmed *by the export itself*:
 
 ## 4. Bug found during audit — FallacyExplorer not culture-aware
 
+> **✅ STATUS UPDATE (2026-06-16):** This bug was subsequently **FIXED in PR #464** (commit
+> `c9197f15` — "@fix(dnn): make FallacyExplorer culture-aware"). `_FallacyExplorer_Root.cshtml` now
+> resolves `field_{lang}` → `field_en` → `field_fr` via a `loc()` cascade + a localized
+> `findOutMore` dictionary (8 langs). The finding below is preserved as the original Phase-1 record.
+
 `_FallacyExplorer_Root.cshtml` hardcodes English fields and an English label:
 
 ```razor

--- a/docs/dnn-localization/release-validation/2sxc-export-spec.md
+++ b/docs/dnn-localization/release-validation/2sxc-export-spec.md
@@ -32,7 +32,7 @@ Tant que ces 7 FR ne sont pas confirmés, les 7×7 = 49 traductions dépendantes
 
 > **Déjà localisé, pas d'export requis :** Fallacies Explorer lit le CSV taxonomy via
 > `App.Query["FallaciesFromCSV"]` → le contenu des fallacies est déjà couvert par les CSV cartes 8
-> langues. (Caveat : le template pin `_en` — bug §4, à corriger en code.)
+> langues. (✅ Le template est culture-aware depuis PR #464 — bug §4 résolu, pas d'export requis pour l'Explorer.)
 
 ## 3. Méthode A — UI 2sxc (recommandé, non destructif)
 

--- a/docs/dnn-localization/release-validation/README.md
+++ b/docs/dnn-localization/release-validation/README.md
@@ -42,20 +42,21 @@ Le track cartes est couvert. Ce dossier couvre le **track site**, qui n'existait
    tard) : parcourir chaque langue avec `validation-checklist.md`.
 4. **Langues non lues** (ar/fa/zh) : s'appuyer sur `non-latin-verification-guide.md` (chaînes
    attendues + contrôles de direction/police).
-5. **Bugs connus à vérifier** : FallacyExplorer pas culture-aware (pin `_en`) — voir §4 de
-   `../PHASE1-content-audit.md`. À corriger en Phase 2/4.
+5. **✅ FallacyExplorer culture-aware (FIXÉ PR #464)** : le template résout `field_{lang}` → `_en`
+   → `_fr` + label localisé (commit `c9197f15`). L'audit §4 (pin `_en`) est résolu ; reste à valider
+   le rendu par langue sur le site.
 
 ## 4. Prérequis / dépendances
 
 - **2sxc export** (étape 1 ci-dessus) — gate réel pour la fiabilité du FR source.
-- **Fix FallacyExplorer culture** (audit §4) — sans lui, l'Explorer affiche `text_en` quelle que soit
-  la langue → invalide toute validation ar/fa/zh/ru/pt/es de l'Explorer. À planifier Phase 2/4.
+- **✅ Fix FallacyExplorer culture (PR #464)** — RÉSOLU. L'Explorer est culture-aware (cascade
+  lang→en→fr + label localisé). Reste à valider le rendu par langue sur le site.
 - **Déploiement staging** — pour une validation représentative du prod (le local IIS suffit pour
   valider le rendu, pas la perf/SSL).
 
 ## 5. Relations avec les autres docs
 
-- `../PHASE1-content-audit.md` — audit de localisation (source des 10 chaînes + bug §4).
+- `../PHASE1-content-audit.md` — audit de localisation (source des 10 chaînes ; bug §4 **résolu PR #464**).
 - `../dnn-ui-strings.csv` — données source (#490, HELD).
 - `../../dnn/UPGRADE-ASSESSMENT.md` — assessment migration DNN 9.13→10.x (track déploiement).
 - `../../release-v0.9.0-validation-brief.md` — validation release **cartes** (l'autre track).

--- a/docs/dnn-localization/release-validation/non-latin-verification-guide.md
+++ b/docs/dnn-localization/release-validation/non-latin-verification-guide.md
@@ -87,8 +87,9 @@ Pour une validation express d'une langue non lue :
 - Ce guide couvre les **10 chaînes** de `dnn-ui-strings.csv`. Les contenus DB-only (Glossary, FAQ,
   homepage, corps des règles) ne sont **pas encore extraits** (voir `2sxc-export-spec.md`) — ils
   n'ont donc pas encore de chaînes attendues.
-- Le bug FallacyExplorer (§4 du content-audit) fait que l'Explorer affiche de l'anglais en toute
-  langue → ne pas conclure « traduction manquante » sur l'Explorer avant le fix.
+- ✅ Le bug FallacyExplorer (§4 du content-audit) est **FIXÉ (PR #464)** — l'Explorer est
+  culture-aware. Il doit rendre la langue courante ; si l'Explorer affiche de l'anglais, c'est
+  désormais une vraie régression à signaler (plus un état attendu).
 
 ---
 

--- a/docs/dnn-localization/release-validation/validation-checklist.md
+++ b/docs/dnn-localization/release-validation/validation-checklist.md
@@ -41,12 +41,11 @@ Vérifier :
 ### 3.1 Fallacy Explorer (`_FallacyExplorer_Root.cshtml`)
 
 - [ ] La liste des fallacies s'affiche.
-- [ ] **⚠️ BUG CONNU (audit §4)** : le template **pin `text_en`/`desc_en`/`link_en`** quelle que soit
-      la culture + hardcode le label `"find out more"` (EN). → Pour toute langue ≠ EN, l'Explorer
-      affiche actuellement de l'anglais. **C'est un bug à corriger (Phase 2/4), pas un échec de
-      traduction.** Le signaler ; ne pas bloquer la validation des autres features dessus.
-- [ ] Une fois le fix appliqué : le libellé du lien = chaîne localisée (`ui.fallacy.find_out_more`,
-      voir `non-latin-verification-guide.md`).
+- [ ] **✅ FIXÉ (PR #464 / commit `c9197f15`)** : le template est culture-aware — `loc()` cascade
+      `field_{lang}` → `field_en` → `field_fr` + label localisé (dictionnaire 8 langues). L'audit §4
+      (pin `_en` + label EN hardcodé) est résolu.
+- [ ] Vérifier que chaque langue rend son texte propre (pas de fallback EN involontaire) — chaînes
+      attendues dans `non-latin-verification-guide.md`.
 
 ### 3.2 Rules Explorer — liste (`_RulesExplorer_RuleList.cshtml`)
 
@@ -89,7 +88,7 @@ Pour chaque règle, vérifier les 8 sections `res.*` (FR → traduit) :
 ## 5. Issue tracking
 
 Tout écart → issue GitHub (label `dnn`/`i18n`) ou signalement dashboard. Distinguer :
-- **Bug template** (ex. FallacyExplorer §4) → fix code Phase 2/4.
+- **Bug template** (ex. FallacyExplorer §4 — **résolu PR #464**) → fix code Phase 2/4.
 - **FR source faux** (inféré ≠ DB) → corriger CSV + re-run #457.
 - **Traduction faible** → ajuster cellule ciblée.
 


### PR DESCRIPTION
## What

Corrects a **stale bug flag** in the DNN release-validation dossier (#492) and the PHASE1 content audit. Both flagged the **FallacyExplorer culture-pin bug** (template hardcoded `_en` fields + EN label) as a pending Phase 2/4 fix. Verification this tick: **the bug is ALREADY FIXED on master** — PR #464 (commit `c9197f15`, "@fix(dnn): make FallacyExplorer culture-aware") made `_FallacyExplorer_Root.cshtml` culture-aware.

## Why

The dossier is the artifact **jsboige uses to validate the DNN site**. Telling him a fixed bug is "to fix" would mislead him and waste his time. The §4 audit note persisted as the source; #464 landed afterward, so every downstream reference went stale.

## Verification (truth-first)

```
$ git log -- DNNPlatform/Portals/1/2sxc/Argumentum/_FallacyExplorer_Root.cshtml
c9197f15 @fix(dnn): make FallacyExplorer culture-aware (cascade loc lang->en->fr) (#464)
```

The template now has `loc()` cascade (`field_{lang}` → `field_en` → `field_fr`) + an 8-language `findOutMore` dictionary. The only remaining `"find out more"` is the correct EN entry in that dictionary. `grep` confirms no hardcoded `text_en`/`desc_en`/`link_en` field refs remain in any 2sxc template.

## Changes (5 files, docs-only)

| File | Change |
|------|--------|
| `release-validation/README.md` | Workflow step 5 + prerequisites: "known bug to fix" → "✅ FIXED #464, verify rendering" |
| `release-validation/validation-checklist.md` | §3.1 checklist item: "⚠️ BUG CONNU" → "✅ FIXÉ #464"; issue-tracking line |
| `release-validation/non-latin-verification-guide.md` | §5 caveat: English-in-Explorer was a bug → now a regression to flag |
| `release-validation/2sxc-export-spec.md` | §2 caveat: "pin _en to fix" → "culture-aware since #464" |
| `PHASE1-content-audit.md` | §4 header: status-update note pointing to #464 (historical finding preserved) |

Docs-only; no code/CSV/template/config change; release gate untouched.

## Note for ai-01

The dispatched primary this tick ("#457 FallacyExplorer culture-pin bug fix") is **stale** — #464 already resolved it. Reported on the dashboard. The spot-check strings in the non-latin guide remain valid (the fixed template produces them).

Refs #457, #464, #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
