### PR TITLE
test(gsheet-sync): #204 pin CSV<->grid round-trip contract (11 edge-case tests)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/GSheetSync/CsvGridConversionContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/GSheetSync/CsvGridConversionContractTests.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Linq;
+using Argumentum.AssetConverter.GSheetSync;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.GSheetSync
+{
+    /// <summary>
+    /// Contract tests for the home-grown CSV↔grid converters (<see cref="GSheetService.CsvToGrid"/>
+    /// and <see cref="GSheetService.GridToCsv"/>). These two functions are the bridge between a
+    /// Google Sheet download and a local CSV, and between a local CSV and a Sheets upload — so the
+    /// invariant that matters most is **round-trip symmetry** (grid → csv → grid identity) on the
+    /// edge-case data that real Argumentum CSVs actually contain: embedded newlines inside quoted
+    /// fields (descriptions, examples), escaped double-quotes, empty cells, ragged rows.
+    ///
+    /// Two fragile behaviours are pinned here that are NOT obvious from reading the code:
+    ///
+    /// 1. <see cref="GSheetService.CsvToGrid"/> is configured with <c>HasHeaderRecord = true</c>,
+    ///    but because the parse loop is manual (<c>while (csv.Read())</c> reading fields each
+    ///    iteration, with no separate <c>ReadHeader()</c> step), the header line is NOT dropped —
+    ///    it is returned as the first grid row. This is deliberate: Sheets expects the header row
+    ///    in the uploaded grid. A "cleanup" that switched to <c>GetRecords&lt;T&gt;()</c> or added
+    ///    an explicit header skip would silently drop row 0 and break every upload.
+    ///
+    /// 2. The read loop is bounded by <c>csv.Parser.Count</c>, which is the **current record's**
+    ///    field count (dynamic, per-row), not the header's. Ragged rows (rows with fewer/more
+    ///    fields than the header) are therefore preserved without throwing, and round-trip without
+    ///    padding/truncation.
+    /// </summary>
+    public class CsvGridConversionContractTests
+    {
+        private static readonly GSheetService Service = new GSheetService(null!);
+
+        /// <summary>
+        /// Asserts the critical round-trip invariant: grid → GridToCsv → CsvToGrid yields a grid
+        /// structurally identical to the input (same row count, same cells per row).
+        /// </summary>
+        private static void AssertRoundTripIdentity(IList<IList<object>> original)
+        {
+            var csv = Service.GridToCsv(original);
+            var roundTripped = GSheetService.CsvToGrid(csv);
+
+            roundTripped.Should().HaveCount(original.Count,
+                "round-trip must not add or drop rows");
+            for (int i = 0; i < original.Count; i++)
+            {
+                roundTripped[i].Select(c => c.ToString())
+                    .Should().Equal(original[i].Select(c => c.ToString()),
+                        $"row {i} must round-trip cell-for-cell");
+            }
+        }
+
+        // --- CsvToGrid: RFC 4180 edge cases on the parse direction ---
+
+        [Fact]
+        public void CsvToGrid_ParsesQuotedFieldWithEmbeddedNewline()
+        {
+            // A newline embedded inside a quoted field must be read as part of that single field,
+            // NOT as a record separator. This is RFC 4180 §2.6 and the highest-risk CSV edge case
+            // for Argumentum data (descriptions/examples routinely span multiple lines).
+            var csv = "pk,desc\n1,\"line1\nline2\"\n";
+
+            var grid = GSheetService.CsvToGrid(csv);
+
+            grid.Should().HaveCount(2, "the embedded newline must not create a third row");
+            grid[1].Should().HaveCount(2);
+            grid[1][1].ToString().Should().Be("line1\nline2");
+        }
+
+        [Fact]
+        public void CsvToGrid_ParsesEscapedDoubleQuotes()
+        {
+            // RFC 4180: a double-quote inside a quoted field is escaped by doubling it ("").
+            var csv = "pk,quote\n1,\"He said \"\"hi\"\"\"\n";
+
+            var grid = GSheetService.CsvToGrid(csv);
+
+            grid[1][1].ToString().Should().Be("He said \"hi\"");
+        }
+
+        // --- Round-trip symmetry on edge-case content (the sync invariant) ---
+
+        [Fact]
+        public void RoundTrip_PreservesQuotedFieldWithEmbeddedNewline()
+        {
+            var original = new List<IList<object>>
+            {
+                new List<object> { "pk", "desc" },
+                new List<object> { "1", "First line\nSecond line\nThird line" },
+            };
+
+            AssertRoundTripIdentity(original);
+        }
+
+        [Fact]
+        public void RoundTrip_PreservesEscapedDoubleQuotes()
+        {
+            var original = new List<IList<object>>
+            {
+                new List<object> { "pk", "quote" },
+                new List<object> { "1", "She said \"hello\", then \"goodbye\"" },
+            };
+
+            AssertRoundTripIdentity(original);
+        }
+
+        [Fact]
+        public void RoundTrip_PreservesEmptyAndCommaFields()
+        {
+            // Empty cells and cells containing commas (which force quoting on write) must survive
+            // the round-trip without loss or re-splitting.
+            var original = new List<IList<object>>
+            {
+                new List<object> { "pk", "name", "note" },
+                new List<object> { "1", "", "a,b,c" },
+                new List<object> { "2", "Foo, Bar", "" },
+            };
+
+            AssertRoundTripIdentity(original);
+        }
+
+        [Fact]
+        public void RoundTrip_PreservesRaggedRows()
+        {
+            // Rows with differing field counts must round-trip without padding or truncation.
+            // This pins the dynamic csv.Parser.Count bound (see class XML doc, behaviour #2).
+            var original = new List<IList<object>>
+            {
+                new List<object> { "a", "b", "c" },
+                new List<object> { "1", "2" },          // fewer fields than header
+                new List<object> { "x", "y", "z", "w" }, // more fields than header
+            };
+
+            AssertRoundTripIdentity(original);
+        }
+
+        [Fact]
+        public void RoundTrip_SingleColumnCsv_NoCommas()
+        {
+            // Degenerate single-column CSV (no delimiter at all) must still round-trip.
+            var original = new List<IList<object>>
+            {
+                new List<object> { "header" },
+                new List<object> { "value1" },
+                new List<object> { "value2" },
+            };
+
+            AssertRoundTripIdentity(original);
+        }
+
+        // --- Degenerate inputs (no NRE, no spurious rows) ---
+
+        [Fact]
+        public void CsvToGrid_EmptyString_ReturnsEmptyGrid()
+        {
+            var grid = GSheetService.CsvToGrid("");
+
+            grid.Should().BeEmpty("an empty CSV must not yield a phantom empty row");
+        }
+
+        [Fact]
+        public void GridToCsv_EmptyOrNullGrid_ReturnsEmptyString()
+        {
+            Service.GridToCsv(new List<IList<object>>()).Should().BeEmpty();
+            Service.GridToCsv(null).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GridToCsv_NullCells_BecomeEmptyStrings()
+        {
+            // Pins the `cell?.ToString() ?? ""` guard: a null cell serialises as an empty string,
+            // not as the literal text "null", and must not throw.
+            var grid = new List<IList<object>>
+            {
+                new List<object> { "a", null, "c" },
+            };
+
+            var csv = Service.GridToCsv(grid);
+            var roundTripped = GSheetService.CsvToGrid(csv);
+
+            roundTripped[0].Select(c => c.ToString()).Should().Equal("a", "", "c");
+        }
+
+        [Fact]
+        public void CsvToGrid_TrailingNewline_DoesNotCreatePhantomRow()
+        {
+            // A single trailing newline (the normal CSV terminator) must not produce an extra empty
+            // row. Two trailing newlines (one genuine empty line) DO produce one empty row.
+            var csvWithTerminator = "a,b\n1,2\n";
+
+            var grid = GSheetService.CsvToGrid(csvWithTerminator);
+
+            grid.Should().HaveCount(2, "the terminator newline must not add a third row");
+        }
+    }
+}


### PR DESCRIPTION
## What

Secondaire of ai-01 dispatch `bwpx5q` (gate-safe #204 deep-queue). Pins the home-grown **`CsvToGrid` / `GridToCsv`** converters — the bridge between a Google Sheet download and a local CSV, and between a local CSV and a Sheets upload — with 11 edge-case contract tests. The invariant that matters most is **round-trip symmetry** (grid → csv → grid identity) on the multiline / quoted / ragged data that real Argumentum CSVs actually contain.

This is the **2nd pure target** the dispatch offered ("`CsvToGrid` edge"). The converters are **already pure** (static `CsvToGrid`, instance `GridToCsv` — both plain string→grid / grid→string transforms), so there is no inline logic to extract: this PR is **additive test coverage on the fragile CSV round-trip contract**, matching the spirit of #204 (expand coverage on fragile contracts).

## Two non-obvious behaviours now pinned

Reading the code, two things are easy to "clean up" into a regression. Both are documented in the test file's XML doc and pinned by tests:

1. **`CsvToGrid` is configured with `HasHeaderRecord = true`, but the manual `while (csv.Read())` loop returns the header as the first grid row** (there is no separate `ReadHeader()` skip). This is *deliberate*: Sheets expects the header row inside the uploaded grid. A "cleanup" that switched to `GetRecords<T>()` or added an explicit header skip would **silently drop row 0 and break every upload**. (Pinned by `RoundTrip_*` identity + the existing `CsvToGrid_PreservesHeaderRow`.)

2. **The read loop is bounded by `csv.Parser.Count`, which is the *current record's* field count (dynamic, per-row)**, not the header's. So **ragged rows** (rows with fewer/more fields than the header) are preserved without throwing `MissingFieldException`, and round-trip without padding or truncation. (Pinned by `RoundTrip_PreservesRaggedRows`.)

## Tests — `CsvGridConversionContractTests` (11)

**Parse direction (RFC 4180):**
- `CsvToGrid_ParsesQuotedFieldWithEmbeddedNewline` — a newline inside a quoted field is part of that field, not a record separator (highest-risk CSV edge case for Argumentum descriptions/examples).
- `CsvToGrid_ParsesEscapedDoubleQuotes` — `""` → `"`.

**Round-trip symmetry (the sync invariant):**
- `RoundTrip_PreservesQuotedFieldWithEmbeddedNewline` — multiline cell survives grid→csv→grid.
- `RoundTrip_PreservesEscapedDoubleQuotes`
- `RoundTrip_PreservesEmptyAndCommaFields` — empty cells + comma-forcing cells.
- `RoundTrip_PreservesRaggedRows` — rows of differing lengths.
- `RoundTrip_SingleColumnCsv_NoCommas` — degenerate single-column CSV.

**Degenerate inputs (no NRE, no phantom rows):**
- `CsvToGrid_EmptyString_ReturnsEmptyGrid`
- `GridToCsv_EmptyOrNullGrid_ReturnsEmptyString`
- `GridToCsv_NullCells_BecomeEmptyStrings` — pins the `cell?.ToString() ?? ""` guard (null → empty, not literal `"null"`).
- `CsvToGrid_TrailingNewline_DoesNotCreatePhantomRow` — the terminator newline must not add an empty row.

## Verification

- New class: **11/11 pass**.
- Full suite on branch: **329 passed / 0 failed / 5 skipped** (306 master baseline → 318 post-#504 → **329** with these 11). No regression.
- Diff: **1 new test file, 0 production change.** No CSV, no config, no `RowsetNb`/`rscount`, no workflow/rules.

## Scope notes

- **Test-only / output-neutral → mergeable during the release gate** per ai-01's gate-safe framing (the gate holds even output-neutral pipeline behaviour changes; this PR changes no behaviour at all).
- `SyncSafetyChecker` (the other dispatch candidate) already has 11 tests covering its thresholds/boundaries/zero-rows/custom-config — well-covered, lower value, so not touched.

Contributes to #204. Refs #193 (GSheetSync), #216.

🤖 Worker po-2024 — secondaire of dispatch `bwpx5q`.
