### PR TITLE
docs(dnn): #131 CVE correction + target refinement — 9.13.x closes 0 CVEs, pragmatic target 10.1.2

### DIFF
--- a/docs/dnn-localization/131-cve-correction-and-target-refinement.md
+++ b/docs/dnn-localization/131-cve-correction-and-target-refinement.md
@@ -1,0 +1,108 @@
+# #131 — CVE Reconciliation Correction + Upgrade-Target Refinement
+
+**Issue:** [#131 — DNN platform upgrade](https://github.com/ArgumentumGames/Argumentum/issues/131)
+**Author:** Claude Code @ myia-po-2023 (worker)
+**Date:** 2026-06-17
+**Base:** master `26d3a9c5`
+**Status:** **CORRIGENDUM + decision-support.** Corrects a CVE-patched-version error in the merged v2 plan (#511) and the Step 0 doc (#514), and refines the upgrade target using a newly-surfaced 2sxc compatibility cliff.
+
+> ⚠️ **Read this before acting on #511 §2 (CVE reconciliation) or §7 Step 1.** Both stated that 9.13.x closes CVE-2025-64095. That is **incorrect** — authoritative sources (NVD + the official GitHub advisories) show it is patched in **10.1.1**. The 9.13.x hop closes **zero** of the two critical/high CVEs.
+
+---
+
+## 1. The correction (anti-fabrication catch)
+
+The v2 plan (#511, §2 and §7 Step 1) and the Step 0 doc (#514) carry the claim:
+
+> *"9.11.1 → 9.13.x (closes CVE-2025-64095 only)"* — i.e. the 9.13.x palier closes 1 of the 2 critical CVEs.
+
+Verification against the **primary authoritative sources** (NVD + the official DNN GitHub Security Advisories, which NVD references) shows this is **wrong**. CVE-2025-64095 is patched in **10.1.1**, not 9.13.x. The claim propagated from an unverified assumption during tick I; it is retracted here. **The 9.13.x hop closes NEITHER** of the two CVEs (CVE-2025-52488 needs 10.0.1; CVE-2025-64095 needs 10.1.1 — both 10.x).
+
+## 2. Authoritative CVE map (NVD + GHSA, machine-verified 2026-06-17)
+
+| CVE | Type | CVSS v3.1 | Vulnerable range | **First patched** | Advisory |
+|---|---|---|---|---|---|
+| **CVE-2025-64095** | Unauthenticated file upload via default HTML editor provider → file overwrite / defacement / XSS chain | **10.0 CRITICAL** (`S:C`) / 9.8 (`S:U`) | `< 10.1.1` | **10.1.1** | [GHSA-3m8r-w7xg-jqvw](https://github.com/dnnsoftware/Dnn.Platform/security/advisories/GHSA-3m8r-w7xg-jqvw) |
+| **CVE-2025-52488** | NTLM hash exposure to a malicious SMB server via crafted input | **8.6 HIGH** | `>= 6.0.0, < 10.0.1` | **10.0.1** | [GHSA-mgfv-2362-jq96](https://github.com/dnnsoftware/Dnn.Platform/security/advisories/GHSA-mgfv-2362-jq96) |
+
+**Implication:** full closure of both disclosed issues requires reaching **≥ 10.1.1**. The installed baseline is **9.11.1.19**. The 9.13.x line (latest = **9.13.9**, NuGet-verified) closes **neither**.
+
+*Calibration note:* CVE-2025-64095 is the more severe of the two (CVSS 10.0, scope-changed) — the v2 plan under-stated it as "9.8". Both are pre-authentication; 64095 is unauthenticated (`PR:N`).
+
+## 3. The 2sxc compatibility cliff (issue #6902) — newly surfaced, decision-relevant
+
+[Issue #6902](https://github.com/dnnsoftware/Dnn.Platform/issues/6902) (`[Bug]: Dnn 10.2.1 breaks 2sxc because of changes in DnnJsInclude`, opened 2026-01-10, **OPEN**):
+
+- Starting in **DNN 10.2.0**, changes to `DnnJsInclude` (ClientDependency framework) **crash 2sxc** — a full **IIS worker-process crash (`unhandled win32 exception`)** when 2sxc creates a `DnnJsInclude`.
+- "Fixed" in 10.2.1 but "not working properly"; the 2sxc team stated they would add a code-side workaround.
+- **Argumentum runs 2sxc 15.02** (verified, MEMORY.md / Phase A boot 2026-06-02). That version **predates the workaround**, which entered 2sxc only in recent releases (≈ v21, post-2026-01-10).
+
+**Crucial interaction with the CVE targets:** the cliff starts at **10.2.0**. The CVE-closure versions (**10.0.1**, **10.1.1/10.1.2**) are all **before** 10.2.0 — so they are **safe from the cliff**. Only continuing onward to **10.2.x–10.3.2** (latest) crosses it, and that requires upgrading 2sxc 15.02 → a workaround-bearing release **plus** re-auditing 2sxc v20 breaking changes (the `SexyContentWebPage`/`GetBestValue` API removals the v2 plan §6 flagged for the custom Argumentum app).
+
+This refines the v2 plan's "2sxc v21 runs on DNN 10.02.1" circumstantial proof: it is true for 2sxc **v21** (workaround present), but **Argumentum's installed 2sxc 15.02 does not have that workaround** — so the proof does not transfer to Argumentum's current 2sxc on a 10.2.x+ target without a 2sxc upgrade.
+
+## 4. Refined target recommendation
+
+| Target | CVEs closed | 2sxc 15.02 compat | Cost | Verdict |
+|---|---|---|---|---|
+| **9.13.9** (latest 9.13.x) | **0** (neither) | ✅ safe (pre-10.x, pre-cliff) | Low (incremental hop) | **Migration stepping-stone only** — not a security step |
+| **10.0.1** | 1 (NTLM / 52488) | ✅ safe (pre-10.2.0 cliff) | Medium (9.x→10.x jump) | Partial security |
+| **10.1.2** (latest 10.1.x) | **2 (both 52488 + 64095)** | ✅ safe (pre-10.2.0 cliff) | Medium | **Pragmatic security target** — both CVEs, **no 2sxc upgrade** |
+| **10.2.x–10.3.2** (latest) | 2 (both) | ❌ cliff at 10.2.0 → needs **2sxc upgrade** + template audit | High | Only if latest features justify the 2sxc work |
+
+**Headline:** the optimal security stop is **10.1.2** — it closes both disclosed CVEs while staying **before** the 2sxc cliff, so Argumentum's current 2sxc 15.02 and templates need no rework. Reaching 10.3.2 (latest) is an optional follow-on that buys newer features but costs a 2sxc upgrade + a template/API audit.
+
+## 5. Refined staircase (supersedes #511 §7)
+
+```
+9.11.1.19 (installed)
+   │
+   ├─[optional]─ 9.13.9   (migration stepping-stone; reduces 9.x→10.x schema-migration
+   │                      jump risk — NOT for security. Skip only if 9.11.1→10.x direct
+   │                      upgrade proves clean in sandbox.)
+   │
+   ├────────── 10.0.1     ← closes CVE-2025-52488 (NTLM, 8.6)
+   │
+   ├────────── 10.1.2     ← closes CVE-2025-64095 (file-upload, 10.0)  ★ BOTH CVEs CLOSED
+   │                       ★ pre-2sxc-cliff — no 2sxc/template rework
+   │                       ── RECOMMENDED SECURITY STOP ──
+   │
+   └─[optional]─ 10.3.2   ← crosses 2sxc cliff (10.2.0): REQUIRES 2sxc 15.02 → ≥v21
+                            upgrade + custom-Argumentum-app template/API audit (#511 §6)
+```
+
+**Step labels re-mapped vs #511 §7:**
+- **Step 1 (revised):** 9.11.1 → (9.13.9 optional) → **10.0.1 → 10.1.2**. Goal = both CVEs closed, pre-cliff. *This is the security objective.*
+- **Step 2 (unchanged):** template/API audit of the custom Argumentum 2sxc app + Glossary3 bump — **now strictly required only if continuing past 10.1.2** toward 10.2.x+.
+- **Step 3 (revised):** 10.1.2 → 10.3.2 = **optional latest-features hop**, gated on a 2sxc upgrade (15.02 → ≥v21) + the Step 2 audit passing.
+- **Step 4 (unchanged):** prod deploy = jsboige exclusively.
+
+## 6. What this changes for jsboige's decision
+
+The v2 plan §8 Q1 framed the choice as *"stop at 9.13.x (1/2 CVE) or require 10.0.1+ (both)?"* That framing was based on the error. The real choice is now crisper:
+
+- **(A) Security stop at 10.1.2** — closes both CVEs, **no 2sxc upgrade**, no template audit. Recommended if the goal is "close the disclosed CVEs with least disruption."
+- **(B) Go to latest (10.3.2)** — same CVEs + newest DNN, but **requires upgrading 2sxc 15.02 → ≥v21** and auditing the custom Argumentum app against 2sxc v20 API removals (the §6 breaking changes). Choose only if there is a feature need for 10.2.x+.
+- **9.13.x is off the table as a security target** — it closes nothing. Its only role is an optional migration stepping-stone to de-risk the 9.11.1→10.1.x schema jump (confirm in sandbox whether the direct hop is clean).
+
+The #445 (Stripe Native) re-decision from the Step 0 doc (#514) stands unchanged: the OpenStore blocker dissolves regardless of whether the target is 10.1.2 or 10.3.2 (both are .NET Framework 4.8, per #514).
+
+## 7. Honesty calibration
+
+- **VERIFIED (primary source, machine-readable):** CVE patched versions (NVD API + GHSA `first_patched_version`); 9.13.9 / 10.0.1 / 10.1.2 / 10.2.0 version existence (NuGet registration); 2sxc cliff onset at 10.2.0 + IIS-crash symptom (issue #6902 body); Argumentum's installed 2sxc = 15.02 (MEMORY.md / Phase A boot).
+- **RETRACTED:** #511 §2 / §7 Step 1 and #514's "9.13.x closes CVE-64095" claim (incorrect; patched 10.1.1).
+- **TO-CONFIRM in sandbox:** whether 9.11.1 → 10.1.x can be upgraded directly (clean schema migration) or should step through 9.13.9 first; the exact 2sxc version that introduced the #6902 workaround (≥v21 inferred from release date; confirm against 2sxc changelog before relying on it for a 10.2.x+ hop).
+
+## 8. Sources
+
+1. NVD CVE-2025-64095: `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2025-64095` → `< 10.1.1`, CVSS 10.0
+2. NVD CVE-2025-52488: `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2025-52488` → `< 10.0.1`, CVSS 8.6
+3. GHSA-3m8r-w7xg-jqvw (64095): `https://github.com/dnnsoftware/Dnn.Platform/security/advisories/GHSA-3m8r-w7xg-jqvw`
+4. GHSA-mgfv-2362-jq96 (52488): `https://github.com/dnnsoftware/Dnn.Platform/security/advisories/GHSA-mgfv-2362-jq96`
+5. Issue #6902 (2sxc/DnnJsInclude cliff): `https://github.com/dnnsoftware/Dnn.Platform/issues/6902`
+6. NuGet `DotNetNuke.Core` registration (version lines): `https://api.nuget.org/v3/registration5-semver1/dotnetnuke.core/index.json`
+7. Prior: #511 v2 plan (`131-upgrade-sandbox-plan-v2.md`) + #514 Step 0 (`131-step0-runtime-verification.md`)
+
+---
+
+*Worker research deliverable (sandbox/research only, no prod deploy). This document retracts an unverified CVE claim from #511/#514 and reframes jsboige's upgrade-target decision. Verdict on target = ai-01 review + jsboige business call.*


### PR DESCRIPTION
## Corrigendum + decision-support (supersedes the CVE claims in #511 §2/§7 Step 1 and #514)

🚨 **Anti-fabrication catch.** Authoritative NVD + the official DNN GitHub Security Advisories disprove a claim I made in the merged v2 plan (#511) and Step 0 doc (#514): *"CVE-2025-64095 patched in 9.13.x"* is **wrong** — it is patched in **10.1.1**. The 9.13.x palier closes **zero** of the two CVEs, not one.

### Authoritative CVE map (NVD + GHSA, machine-verified 2026-06-17)
| CVE | CVSS | Patched | Advisory |
|---|---|---|---|
| CVE-2025-64095 (unauth file upload) | **10.0 CRITICAL** (`S:C`) | **10.1.1** | GHSA-3m8r-w7xg-jqvw |
| CVE-2025-52488 (NTLM hash leak) | 8.6 HIGH | **10.0.1** | GHSA-mgfv-2362-jq96 |

Both require 10.x. Installed baseline = 9.11.1.19. The 9.13.x line (latest 9.13.9) closes **neither**.

### Newly-surfaced 2sxc compatibility cliff (issue #6902, OPEN)
DNN **10.2.0+** breaks 2sxc via `DnnJsInclude` (full IIS worker crash). Argumentum runs **2sxc 15.02** (predates the ≥v21 workaround) → 10.2.x+ needs a 2sxc upgrade. **The CVE targets (10.0.1, 10.1.2) are before 10.2.0 → safe from the cliff.** This also refines the v2 plan's "2sxc v21 on 10.02.1" proof: it holds for 2sxc v21 (workaround present) but NOT for Argumentum's 2sxc 15.02 on a 10.2.x+ target.

### Refined target
- **10.1.2** (latest 10.1.x) = closes **both** CVEs + **before** the 2sxc cliff → **no 2sxc upgrade, no template audit**. **Pragmatic security stop.**
- 9.13.9 = optional migration stepping-stone only (0 CVEs; just de-risks the 9.x→10.x schema jump).
- 10.2.x–10.3.2 (latest) = optional; requires 2sxc 15.02→≥v21 upgrade + custom-Argumentum-app template/API audit (#511 §6).

### Reframes jsboige's decision
~~"9.13.x (1/2 CVE) vs 10.0.1+ (both)"~~ → **"stop at 10.1.2 (both CVEs, least disruption) vs go 10.3.2 latest (needs 2sxc work)"**. The #445 (Stripe Native) re-decision from #514 is unchanged (both targets are .NET Framework 4.8).

### Scope
Doc-only corrigendum + decision-support. No code, no CSV, no deploy. Memory `project-dnn10-net-framework-not-net8` + MEMORY.md pointer updated with the correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)