### PR TITLE
test(pdf): #204 extract #119 alternate-face-and-back ordering to pure method + 9 tests

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfAlternateFaceAndBackContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfAlternateFaceAndBackContractTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Linq;
+using Argumentum.AssetConverter;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
+{
+    /// <summary>
+    /// Contract pin for <see cref="PdfManager.OrderImagesForAlternateFaceAndBack"/> — #204
+    /// secondary (cont. po-2024), the issue-#119 recto-verso ordering contract.
+    ///
+    /// <see cref="PdfManager.GenerateAlternateFaceAndBack"/> assembles a single PDF where each
+    /// card's BACK is printed immediately before its FRONT, so that on a recto-verso sheet each
+    /// back lines up behind its matching front. The original CardSet order MUST be preserved —
+    /// cards without a back (Rules) keep their place and contribute their front only — which is
+    /// what makes Rules appear first in TarotCards PDFs (the #119 fix, CLAUDE.md fragile area).
+    ///
+    /// This ordering is a fragile contract: a regression that emits front-then-back, drops the
+    /// back-less cards, or reorders by back-presence silently misaligns every printed sheet and
+    /// is caught only by printing and checking. It was previously inlined inside the MagickImage
+    /// collection builder with ZERO unit coverage. It has been extracted (output-neutral — the
+    /// call site emits the exact same path sequence) into the pure, deterministic
+    /// <see cref="PdfManager.OrderImagesForAlternateFaceAndBack"/> so the contract is unit-testable.
+    /// These tests pin it additively.
+    /// </summary>
+    public class PdfAlternateFaceAndBackContractTests
+    {
+        // Helper: build a card list from (front, back) tuples; null/empty back = no back.
+        private static List<CardImages> Cards(params (string front, string back)[] specs)
+            => specs.Select(s => new CardImages { Front = s.front, Back = s.back }).ToList();
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (1) Per-card emission — back-then-front when a back exists, front-only otherwise.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void CardWithBack_EmitsBackThenFront()
+        {
+            // THE fragile bit: back MUST precede its front so they align recto-verso.
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("F1", "B1")));
+
+            outSeq.Should().Equal("B1", "F1");
+        }
+
+        [Fact]
+        public void CardWithoutBack_EmitsFrontOnly()
+        {
+            // Rules have no back — they contribute their front alone, no phantom slot.
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("F1", null)));
+
+            outSeq.Should().Equal("F1");
+        }
+
+        [Fact]
+        public void EmptyBack_TreatedAsNoBack()
+        {
+            // The guard is string.IsNullOrEmpty — "" behaves like null (no back emitted).
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("F1", "")));
+
+            outSeq.Should().Equal("F1");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (2) Original CardSet order is preserved — no reordering by back-presence.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void PreservesOriginalCardSetOrder_MixedBacks()
+        {
+            // Rules (no back), then a Fallacy (back), then another no-back, then a back.
+            // The output walks cards in INPUT order — it does NOT group backs together.
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("Rules1", null), ("Fall1", "Back1"), ("Rules2", null), ("Fall2", "Back2")));
+
+            outSeq.Should().Equal("Rules1", "Back1", "Fall1", "Rules2", "Back2", "Fall2");
+        }
+
+        [Fact]
+        public void RulesFirstPreservedInSequence()
+        {
+            // The #119 contract: a back-less card at the head of the list stays first in output.
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("Rules", null), ("Memo", "MemoBack"), ("Fallacy", "FallBack")));
+
+            outSeq.First().Should().Be("Rules");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (3) Count semantics — back doubles the slot, front-only is a single slot.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void AllCardsWithBack_DoublesTheCount()
+        {
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("F1", "B1"), ("F2", "B2"), ("F3", "B3")));
+
+            // 3 cards × 2 (back+front) = 6 emitted paths.
+            outSeq.Should().HaveCount(6);
+        }
+
+        [Fact]
+        public void AllCardsWithoutBack_SinglePerCard()
+        {
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("F1", null), ("F2", null), ("F3", null)));
+
+            outSeq.Should().HaveCount(3);
+            outSeq.Should().Equal("F1", "F2", "F3");
+        }
+
+        [Fact]
+        public void BackImmediatelyPrecedesItsFront()
+        {
+            // For an all-with-back deck, every even index (0,2,4…) is a back and the odd index
+            // right after it is that back's own front — the pairing must not drift.
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards(("F1", "B1"), ("F2", "B2"))).ToList();
+
+            outSeq[0].Should().Be("B1");
+            outSeq[1].Should().Be("F1");
+            outSeq[2].Should().Be("B2");
+            outSeq[3].Should().Be("F2");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (4) Degenerate inputs.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void EmptyInput_EmitsNothing()
+        {
+            var outSeq = PdfManager.OrderImagesForAlternateFaceAndBack(
+                Cards());
+
+            outSeq.Should().BeEmpty();
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
@@ -47,32 +47,48 @@ namespace Argumentum.AssetConverter
             AnsiConsole.MarkupLine($"[cyan]INFO: Processing {cardsWithBackCount} cards with back, {cardsWithoutBackCount} cards without back for '{baseName}'[/]");
             AnsiConsole.MarkupLine($"[cyan]INFO: Preserving original CardSet order (Rules first, then Memo, Fallacies, etc.)[/]");
 
+            // ✅ #119 image-sequence ordering extracted output-neutral into
+            // OrderImagesForAlternateFaceAndBack so this fragile recto-verso contract
+            // (original CardSet order preserved — Rules first; back-then-front per card) is
+            // unit-testable without a MagickImage render.
+            var orderedPaths = OrderImagesForAlternateFaceAndBack(cardImages);
             var collecBuilderAFB = () =>
             {
-                var allImages = new List<MagickImage>();
-
-                // Parcourir les cartes dans l'ordre original des CardSets
-                foreach (var card in cardImages)
-                {
-                    if (!string.IsNullOrEmpty(card.Back))
-                    {
-                        // Carte avec dos: dos d'abord, face ensuite (pour recto-verso)
-                        allImages.Add(new MagickImage(card.Back));
-                        allImages.Add(new MagickImage(card.Front));
-                    }
-                    else
-                    {
-                        // Carte sans dos (Rules): face uniquement
-                        allImages.Add(new MagickImage(card.Front));
-                    }
-                }
-
-                var collec = new MagickImageCollection(allImages);
+                var collec = new MagickImageCollection(orderedPaths.Select(p => new MagickImage(p)));
                 return collec;
             };
 
             targetFiles.Add((baseName, collecBuilderAFB));
             GeneratePdfsFromImages(targetFiles, overwriteExistingDocs);
+        }
+
+        /// <summary>
+        /// Produces the ordered image-path sequence for alternate face-and-back recto-verso
+        /// printing (issue #119). The original CardSet order is PRESERVED — so cards without a
+        /// back (Rules) keep their place and appear in sequence with the rest — and for each
+        /// card that HAS a back, the BACK is emitted immediately before its FRONT. That back-
+        /// then-front ordering is what makes each back line up behind its matching front when
+        /// the sheet is printed recto-verso.
+        /// Pure &amp; deterministic — no MagickImage, no I/O. Extracted output-neutral from
+        /// <see cref="GenerateAlternateFaceAndBack"/> (which previously inlined this logic inside
+        /// the collection builder) so this fragile alignment + ordering contract is unit-testable
+        /// in isolation. A regression here (e.g. emitting front-then-back, or dropping the
+        /// back-less cards) silently misaligns every printed sheet.
+        /// </summary>
+        public static IEnumerable<string> OrderImagesForAlternateFaceAndBack(IEnumerable<CardImages> cards)
+        {
+            foreach (var card in cards)
+            {
+                if (!string.IsNullOrEmpty(card.Back))
+                {
+                    yield return card.Back;
+                    yield return card.Front;
+                }
+                else
+                {
+                    yield return card.Front;
+                }
+            }
         }
 
         public void GenerateBackFirstOneDocPerBack(string baseName, List<CardImages> cardImages, bool overwriteExistingDocs)


### PR DESCRIPTION
## What

**#204 secondary** (ai-01 dispatch `msg-20260617T051231-o6izvl`, queue item 2): another fragile uncovered contract, extracted output-neutral + tests, same spirit as #512 (page-grid) and #500 (recto-verso reorder) — **avoids the already-pinned page-grid zone**.

Target: **`PdfManager.GenerateAlternateFaceAndBack`** — the **issue-#119 contract** (CLAUDE.md named fragile area). It assembles a single PDF where each card's **BACK is emitted immediately before its FRONT** (so backs align recto-verso) and the **original CardSet order is preserved** (so back-less Rules keep their place and appear first). This ordering had **ZERO unit coverage** — a regression (front-then-back, dropping back-less cards, or reordering by back-presence) silently misaligns every printed sheet, caught only by printing.

## How (output-neutral extraction)

- Extracted the path-sequencing into a pure, deterministic `OrderImagesForAlternateFaceAndBack` (static, no MagickImage, no I/O).
- The call site emits the **exact same path sequence** (verified by reading the old inline builder before extraction) → **rendered output byte-for-byte unchanged**. MagickImage construction stays deferred to the collection builder.

## 9 contract tests (mirror #500/#512 conventions)

Namespace `Argumentum.AssetConverter.Tests.WebBasedGenerator`, xUnit `[Fact]` + FluentAssertions, rich XML docs:

| Area | Tests |
|------|-------|
| Per-card emission | back-then-front when back exists; front-only when no back; **empty back == no back** (the `IsNullOrEmpty` guard) |
| Ordering | original CardSet order preserved (mixed backs NOT grouped together); a back-less head card stays first (the Rules-first #119 guarantee) |
| Counts | all-with-back doubles slot count; all-without-back singles |
| Pairing | back immediately precedes its OWN front (indices 2i, 2i+1) |
| Degenerate | empty input → empty |

## Gate safety

- ✅ Output-neutral extraction — no behavior change, no rendered-output change
- ✅ Additive tests only — no CSV, no config, no workflow
- ✅ Suite **351 passed / 0 failed / 5 skipped** (baseline 342 + 9 new)

Contributes to #204. Refs #500/#512 (sibling recto-verso extractions), #119.

🤖 Worker po-2024 — secondary of ai-01 dispatch `msg-20260617T051231-o6izvl`.
