### PR TITLE
docs(dnn): #131 Step 1 sandbox upgrade runbook (9.11.1.19 -> 10.1.2)

### DIFF
--- a/docs/dnn-localization/131-step1-sandbox-upgrade-runbook.md
+++ b/docs/dnn-localization/131-step1-sandbox-upgrade-runbook.md
@@ -1,0 +1,121 @@
+# #131 — Step 1 Sandbox Upgrade Runbook (DNN 9.11.1.19 → 10.1.2)
+
+**Issue:** [#131 — DNN platform upgrade (sandbox → prod)](https://github.com/ArgumentumGames/Argumentum/issues/131)
+**Author:** Claude Code @ myia-po-2023 (worker)
+**Date:** 2026-06-17
+**Base:** master `87a02c19`
+**Status:** **SANDBOX-PREP (research/runbook)** — execution GATED on jsboige's target decision (10.1.2 vs 10.3.2, see #520). **No prod deploy, no live sandbox mutation** until jsboige says go.
+
+**Depends on (all merged):**
+- [131-upgrade-sandbox-plan-v2.md](131-upgrade-sandbox-plan-v2.md) (#511) — the 4-step staircase + 2sxc compat matrix.
+- [131-step0-runtime-verification.md](131-step0-runtime-verification.md) (#514) — Step 0 result: DNN 10.3.2 runtime **VERIFIED .NET Framework 4.8** (no .NET 8 jump; OpenStore blocker dissolved).
+- [131-cve-correction-and-target-refinement.md](131-cve-correction-and-target-refinement.md) (#520) — CVE map correction (9.13.x closes **0** CVEs; target refined to **10.1.2**).
+
+---
+
+## 1. What Step 1 is (scope)
+
+Step 1 of the §7 staircase = the **security upgrade jump**: lift the running sandbox from the installed **DNN 9.11.1.19** to the CVE-closure target, **on the sandbox only**, documenting a per-stage go/no-go.
+
+**The target is NOT yet chosen** (jsboige's gate, #520 §3):
+
+| Option | CVEs closed | 2sxc work | Risk |
+|--------|-------------|-----------|------|
+| **10.1.2 (recommended)** | both (CVE-2025-64095 patched **10.1.1**; CVE-2025-52488 patched **10.0.1**) | none (before the 2sxc cliff at **10.2.0+**, issue #6902) | lowest |
+| 10.3.2 (latest) | both | upgrade 2sxc 15.02 → ≥21 + template audit | higher (Argumentum's 4 bespoke `.cshtml`) |
+
+This runbook covers the **10.1.2** path (lowest disruption, closes both CVEs). A 10.3.2 execution prepends a **2sxc upgrade sub-step** before the DNN jump — out of scope here until jsboige picks it.
+
+**Authoritative version ladder (NuGet `DotNetNuke.Core`, verified 2026-06-17):** the 9.13.x line tops out at **9.13.9** (closes **0** CVEs — ruled out as a security palier). The 10.x line: 10.0.0, 10.0.1, 10.1.0, 10.1.1, 10.1.2, 10.2.0 … 10.3.2. The CVE-closure minimum is **10.0.1** (NTLM) → **10.1.1** (file-upload). **10.1.2** is the first release that has *both* and precedes the 2sxc cliff.
+
+---
+
+## 2. Sandbox baseline (repo-grounded)
+
+| Fact | Value | Source |
+|------|-------|--------|
+| Installed DNN | **9.11.1.19** | `DNNPlatform/bin/DotNetNuke.dll` FileVersion |
+| Runtime | .NET Framework **4.8** | `DNNPlatform/web.config` `targetFramework="4.8"` |
+| 2sxc (Argumentum app host) | **15.02** | MEMORY.md (Phase A boot, 2026-06-02) |
+| Argumentum custom 2sxc app | 4 bespoke `.cshtml` | `_Album List.cshtml`, `_FallacyExplorer_Root.cshtml`, `_RulesExplorer_RuleDetail.cshtml`, `_RulesExplorer_RuleList.cshtml` (`DNNPlatform/Portals/1/2sxc/Argumentum/`) |
+| Glossary3 app | version history → **14.09.00** | `…/Glossary3/App_Data/app.xml` |
+| Sandbox host | IIS Express, port **8090** | MEMORY.md Phase A (config outside repo: `.vs` gitignored) |
+
+**Step 0 carried-over fact (the gate this depends on):** installed 9.11.1 (net48) and target 10.1.2 (net48) are the **same runtime** → no .NET jump, no module recompile for runtime reasons. (Module *API* surface is a separate question — see §5.)
+
+---
+
+## 3. Pre-flight (BEFORE any sandbox mutation) — do these now, gate-safe
+
+These are non-destructive and *should* be done regardless of target choice:
+
+1. **Full sandbox backup** (the safety net for every later step):
+   - File-system copy of `DNNPlatform/` (the whole site root).
+   - Database backup (`BACKUP DATABASE` on the sandbox DB).
+   - Export the 2sxc apps (Argumentum + Glossary3) via 2sxc export, so a rollback restores app data even if the DB restore is partial.
+2. **Capture the "before" golden state:**
+   - Screenshot / note the loaded Argumentum pages (FallacyExplorer, RulesExplorer, Album List) on 8090 — the *visual* regression baseline.
+   - Record `web.config` checksum + `DotNetNuke.dll` version.
+3. **Inventory installed modules/extensions** (Host → Extensions) so a post-upgrade diff shows exactly what changed.
+4. **Confirm the .NET 4.8 runtime** is what the Windows host serves (matches Step 0). No action if already 4.8.
+
+---
+
+## 4. The upgrade execution (sandbox only) — generic DNN mechanics
+
+> ⚠️ **Honesty boundary:** the *generic* DNN upgrade-wizard mechanics below are the standard community-documented flow, but the **authoritative steps must be confirmed against the official DNN upgrade guide** (`docs.dnncommunity.org` → Upgrading) before execution. The web doc fetch was unavailable while writing this runbook (tooling outage); do not treat the bullet list below as verified procedure — confirm, then execute. Everything in §3 and §5 is repo-grounded and stands on its own.
+
+Standard community flow (to confirm vs. official guide):
+1. Take the §3 backups.
+2. Download the **Upgrade package** for the target version (10.1.2) from the DNN community release archive — *not* the Install package (Install is for greenfield; Upgrade preserves the DB).
+3. Stop the IIS Express sandbox site (free file locks).
+4. Copy the Upgrade package's files/bin over the sandbox site root (preserves `web.config`, `App_Data`, `Portals`, `DesktopModules`).
+5. Browse to `http://localhost:8090/Install/Upgrade.aspx` to run the DB-migration wizard.
+6. Watch the upgrade log; the wizard reports schema/data migration + any skipped extensions.
+7. Restart the site; smoke-test the §2 pages.
+
+---
+
+## 5. Argumentum-specific risk register (repo-grounded)
+
+These are the places a 9.11→10.1 jump could bite *this* site specifically:
+
+| Risk | Evidence | Mitigation |
+|------|----------|------------|
+| **Argumentum bespoke `.cshtml` (4)** use 2sxc v15-era APIs. | v20 "Moment-of-Truth" renamed module path (`/DesktopModules/ToSic_SexyContent/` → `…/ToSic.Sxc/`) + removed `SexyContentWebPage`/`GetBestValue`. | **Audit the 4 templates** against the v15→v20 changelog. But: target 10.1.2 does **not** force a 2sxc bump (we stay ≤ 10.1.x, before the cliff) → 2sxc stays 15.02 → templates likely untouched. This risk activates **only if target = 10.3.2** (forces 2sxc ≥21). |
+| **Glossary3 at 14.09.00** (v14-era) | `app.xml` version history. | Same logic: no 2sxc bump on the 10.1.2 path → no action. Bump to typed v3 is a separate, later hardening. |
+| **News5 / Blog5** (current-generation apps) | repo structure (`bs3/4/5`, `DnnSearch`, `api`). | LOW. Re-verify they load post-upgrade (smoke-test). |
+| **DNN 9.12/9.13/10.0/10.1 breaking changes** (CDF control constructors, #6871 in Dnn.Platform releases) | GitHub release notes. | Confirm via the 9.11→10.1 release-note diff; the empty-ctor fix (#6871) suggests DNN *re-added* compatibility — favorable signal. |
+| **Social-auth connectors** (PR #506, open) | existing branch. | Decide #506 fate *as part of* this upgrade or keep separate — don't bundle. |
+
+---
+
+## 6. Go/No-go per stage
+
+| Stage | Pass criterion | Gate |
+|-------|----------------|------|
+| Pre-flight (§3) | backups exist; before-state captured | **GO** to proceed to execution |
+| Upgrade execution (§4) | Upgrade wizard completes on sandbox; log clean | worker documents; **ai-01 + jsboige** review log |
+| Post-upgrade smoke | the 4 Argumentum pages render correctly on 8090; modules load | **visual verdict = ai-01** (worker signals, does not declare PASS) |
+| Rollback readiness | a tested path to restore 9.11.1.19 from §3 backup | **mandatory before** declaring Step 1 done |
+
+**Hard gate:** Step 1 stays **sandbox-only**. No prod deploy without explicit jsboige go (Step 4 of the v2 plan). The CVE-closure target itself (10.1.2 vs 10.3.2) is jsboige's call (#520).
+
+---
+
+## 7. What this runbook does NOT do
+
+- ❌ Does **not** execute the upgrade — execution is gated on jsboige's target decision.
+- ❌ Does **not** verify the generic DNN upgrade-wizard steps against the official guide (tooling outage this session — flagged in §4 for confirmation).
+- ❌ Does **not** touch prod, the CSV taxonomy, `dnn-ui-strings.csv`, or any consumer.
+- ❌ Does **not** decide #445 (Stripe Native) — that stays jsboige's business call.
+
+---
+
+## Sources
+
+- NuGet `DotNetNuke.Core` registration — 9.13.x (tops 9.13.9) and 10.x (→10.3.2) version lines (verified 2026-06-17).
+- #520 (#131 CVE correction) — CVE-2025-64095 patched **10.1.1**; CVE-2025-52488 patched **10.0.1**; 2sxc cliff at **10.2.0+** (issue #6902).
+- #514 (Step 0) — DNN 10.3.2 runtime = .NET Framework 4.8 (no .NET 8 jump).
+- Repo: `DNNPlatform/bin/DotNetNuke.dll`, `DNNPlatform/web.config`, `DNNPlatform/Portals/1/2sxc/{Argumentum,Glossary3}/`.
+- MEMORY.md — Phase A sandbox boot (IIS Express :8090, DNN 9.11.1 + 2sxc 15.02, 2026-06-02).


### PR DESCRIPTION
## What

**Step 1 sandbox upgrade runbook** — the prep/runbook that closes the #131 pre-execution arc (plan → Step 0 → CVE/target → **procedure**). Extends #511 (plan v2) + #514 (Step 0) + #520 (CVE refinement).

**Execution stays GATED** on jsboige's target decision: **10.1.2** (both CVEs, no 2sxc work — recommended) vs **10.3.2** (needs 2sxc ≥21 + template audit).

## Repo-grounded content

- **Sandbox baseline:** 9.11.1.19 (DotNetNuke.dll), .NET Framework 4.8 (web.config), 2sxc 15.02, 4 bespoke `.cshtml` (`Argumentum/`), Glossary3 14.09.00, IIS Express :8090.
- **Argumentum-specific risk register** — the 2sxc API-removal cliff at **10.2.0+** (issue #6902) is the key finding: it activates **only if target = 10.3.2** (forces 2sxc ≥21 + bespoke-template audit); the **10.1.2 path stays on 2sxc 15.02 → templates untouched**. This is why 10.1.2 is recommended.
- **Version ladder (NuGet-verified):** 9.13.x tops at 9.13.9 (closes 0 CVEs — ruled out); 10.1.2 = first release closing both CVEs (64095 patched 10.1.1; 52488 patched 10.0.1) and before the 2sxc cliff.
- **Per-stage go/no-go** + **mandatory rollback readiness** before declaring Step 1 done.
- **Pre-flight (§3)** is gate-safe and non-destructive — can be done now regardless of target choice.

## Honesty boundary (not greenwashed)

The **generic DNN upgrade-wizard mechanics (§4)** were NOT verified against the official DNN upgrade guide this session — the doc-fetch tooling was unavailable (500s). §4 is flagged **"confirm against the official guide before execution"**, not presented as verified procedure. Everything in §3 (pre-flight) and §5 (risk register) is repo-grounded and stands on its own.

## Gate boundaries

- ❌ No execution (gated on jsboige target decision). ❌ No prod deploy. ❌ No CSV/taxonomy/`dnn-ui-strings.csv`/OWL/cards/mindmaps touch.
- **Visual verdict = ai-01** (worker signals, does not declare PASS).

## For jsboige

The only open decision remains: **10.1.2** (recommended — both CVEs, minimal disruption, no 2sxc/template work) vs **10.3.2** (latest — requires 2sxc upgrade + bespoke-template audit). On your go, Step 1 execution proceeds on the sandbox only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
