### PR TITLE
docs(dnn): #131 errata banner on #511 plan-v2 — CVE table superseded by #520

### DIFF
--- a/docs/dnn-localization/131-upgrade-sandbox-plan-v2.md
+++ b/docs/dnn-localization/131-upgrade-sandbox-plan-v2.md
@@ -6,6 +6,22 @@
 **Base:** master `fc8313b3` (clean, in sync with origin)
 **Status:** **SANDBOX/RESEARCH document. No production deploy. No CSV touch. Awaits jsboige go/no-go per step.**
 
+> ⚠️ **ERRATA — CVE TABLE BELOW IS SUPERSEDED.** The CVE reconciliation in §2 (and the §1 title
+> staircase, §7 Step 1) states that **9.13.x closes CVE-2025-64095**. That is **incorrect** and was
+> corrected in the follow-up corrigendum
+> [131-cve-correction-and-target-refinement.md](131-cve-correction-and-target-refinement.md) (#520),
+> grounded in NVD + the official DNN GitHub Security Advisories:
+>
+> - **CVE-2025-64095** is first patched in **10.1.1** (not 9.13.x).
+> - **CVE-2025-52488** is first patched in **10.0.1**.
+> - The **9.13.x line closes NEITHER** (0 of 2), not 1 of 2 as this doc's §2/§1-consequence state.
+>
+> **For all security/target decisions, read [#520](131-cve-correction-and-target-refinement.md)
+> (target = 10.1.2) as the source of truth, and [132-deployment-runbook.md](132-deployment-runbook.md)
+> (#527) for the go-live procedure.** This v2 doc is retained for its runtime-finding (§3: DNN 10 =
+> .NET Framework 4.8) and 2sxc-compatibility matrix (§5-6), which remain valid. The §2 CVE table and
+> the "9.13.x closes 1 CVE" framing are retracted per #520.
+
 This document **EXTENDS** (does not duplicate) two prior analyses:
 - [`131-upgrade-9.13-sandbox-plan.md`](./131-upgrade-9.13-sandbox-plan.md) — the #479 9.11.1→9.13.x security-palier plan (CVE table, disk blocker, sandbox sketch).
 - [`../dnn/UPGRADE-ASSESSMENT.md`](../dnn/UPGRADE-ASSESSMENT.md) — the comprehensive 2026-06-07 assessment (current-state inventory, Option A staircase, dependency CVEs, jsboige = Stripe Native decision).


### PR DESCRIPTION
## What

Idle-light coherence pass on the DNN doc arc found a **real cross-document safety contradiction**. The merged **#511** (sandbox plan-v2) still states — in its §2 CVE table, §1 title staircase, and §7 Step 1 — that **9.13.x closes CVE-2025-64095** and is a "security palier" closing 1 of 2 critical CVEs. The follow-up corrigendum **#520** (merged) corrected this with authoritative sources, but **#511 itself was never updated**, so a reader hitting #511 still sees the wrong claim.

## The error (per #520, grounded in NVD + official DNN GHSA)

| Claim in #511 | Corrected by #520 |
|---------------|-------------------|
| 9.13.x closes CVE-2025-64095 | First patched in **10.1.1** (not 9.13.x) |
| 9.13.x is a "security palier" closing 1 of 2 CVEs | 9.13.x closes **0 of 2** (neither) |
| "stopping at 9.13.x closes the file-upload RCE" | Closes nothing — target = **10.1.2** for both CVEs |

The risk: a reader could believe a 9.13.x hop is a security step.

## Fix — minimal, history-faithful errata banner

Added a top-of-document **ERRATA banner** pointing to #520 as source of truth + #527 for the go-live procedure, explicitly retracting §2 and the "1 of 2" framing. The doc's **still-valid** parts (§3 runtime finding: DNN 10 = .NET Framework 4.8; §5-6 2sxc compatibility matrix) are explicitly retained.

This matches #520's own "read-before-action" discipline — it does **not** rewrite #511's merged history, just ensures no one acts on the superseded CVE claim.

## Doc-only hygiene, non-gated

- 1 file, +16/-0 (`docs/dnn-localization/131-upgrade-sandbox-plan-v2.md`).
- No content rewrite of merged history, no target change (target stays #520 = 10.1.2), no prod mutation.
- Base master `7a07abc9`.

Refs #131 #520 #522 #527.
