### PR TITLE
docs(dnn): #131 target revision 10.1.2 → 10.3.2 FULL upgrade + 2sxc 15→≥21 (decision #2)

### DIFF
--- a/docs/dnn-localization/131-cve-correction-and-target-refinement.md
+++ b/docs/dnn-localization/131-cve-correction-and-target-refinement.md
@@ -6,6 +6,12 @@
 **Base:** master `26d3a9c5`
 **Status:** **CORRIGENDUM + decision-support.** Corrects a CVE-patched-version error in the merged v2 plan (#511) and the Step 0 doc (#514), and refines the upgrade target using a newly-surfaced 2sxc compatibility cliff.
 
+> ⚠️ **TARGET-SUPERSEDED (the "recommended target = 10.1.2" conclusion only).** jsboige interactive
+> decision #2 (issue #458, 2026-06-18) chose **10.3.2 full upgrade** instead. Read
+> [131-target-revision-10.3.2-full-upgrade.md](131-target-revision-10.3.2-full-upgrade.md) as the source of
+> truth. **The CVE facts in this doc remain correct** (64095→10.1.1, 52488→10.0.1, 9.13.x closes 0, cliff
+> @10.2.0); only the *recommendation* to stop at 10.1.2 is overridden — jsboige accepts crossing the cliff.
+>
 > ⚠️ **Read this before acting on #511 §2 (CVE reconciliation) or §7 Step 1.** Both stated that 9.13.x closes CVE-2025-64095. That is **incorrect** — authoritative sources (NVD + the official GitHub advisories) show it is patched in **10.1.1**. The 9.13.x hop closes **zero** of the two critical/high CVEs.
 
 ---

--- a/docs/dnn-localization/131-step1-sandbox-upgrade-runbook.md
+++ b/docs/dnn-localization/131-step1-sandbox-upgrade-runbook.md
@@ -6,6 +6,12 @@
 **Base:** master `87a02c19`
 **Status:** **SANDBOX-PREP (research/runbook)** — execution GATED on jsboige's target decision (10.1.2 vs 10.3.2, see #520). **No prod deploy, no live sandbox mutation** until jsboige says go.
 
+> ⚠️ **TARGET SUPERSEDED — jsboige decided 10.3.2 (decision #2, issue #458, 2026-06-18).** The 10.1.2
+> target below is superseded; read
+> [131-target-revision-10.3.2-full-upgrade.md](131-target-revision-10.3.2-full-upgrade.md) as the source of
+> truth. This sandbox procedure is **reusable for the 10.3.2 path** (the 4-step staircase + pre-flight +
+> risk-register structure hold); the delta is the 2sxc upgrade + template audit the revision doc §4 adds.
+
 **Depends on (all merged):**
 - [131-upgrade-sandbox-plan-v2.md](131-upgrade-sandbox-plan-v2.md) (#511) — the 4-step staircase + 2sxc compat matrix.
 - [131-step0-runtime-verification.md](131-step0-runtime-verification.md) (#514) — Step 0 result: DNN 10.3.2 runtime **VERIFIED .NET Framework 4.8** (no .NET 8 jump; OpenStore blocker dissolved).

--- a/docs/dnn-localization/131-target-revision-10.3.2-full-upgrade.md
+++ b/docs/dnn-localization/131-target-revision-10.3.2-full-upgrade.md
@@ -1,0 +1,141 @@
+# #131 — Target Revision: 10.1.2 → 10.3.2 FULL upgrade (+ 2sxc 15→≥21)
+
+**Issue:** [#131 — DNN platform + déploiement](https://github.com/ArgumentumGames/Argumentum/issues/131)
+**Author:** Claude Code @ myia-po-2023 (worker)
+**Date:** 2026-06-18
+**Base:** master `cae93dc8`
+**Status:** DECISION-SPEC (docs, non-gated). **Supersedes the 10.1.2 target** of [#520](131-cve-correction-and-target-refinement.md)
+/ [#522](131-step1-sandbox-upgrade-runbook.md) / [#527](132-deployment-runbook.md) / [#528 errata](131-upgrade-sandbox-plan-v2.md),
+per jsboige interactive decision #2 (issue [#458](https://github.com/ArgumentumGames/Argumentum/issues/458) comment
+2026-06-18). **Execution stays GATED** — this revises the *target*, it does not deploy.
+
+> **jsboige decision #2 (VÉRIFIÉ, canal interactif):** *"Je suis pour l'upgrade complète, même si c'est plus
+> lourde."* → target = **10.3.2-latest + 2sxc 15→≥21 + template audit**. This crosses the 2sxc compatibility
+> cliff at 10.2.0 (#520 §3) that the 10.1.2 target deliberately avoided. **#445 (Stripe Native) is unblocked**
+> by this decision (the OpenStore/.NET-8 blocker is dissolved — DNN 10 = .NET Framework 4.8, #514).
+
+---
+
+## 1. What changed (why the 10.1.2 runbooks are now superseded)
+
+The earlier target refinement (#520) chose **10.1.2** specifically to *avoid* the 2sxc compatibility cliff:
+10.1.2 closes both CVEs while staying pre-10.2.0, so 2sxc 15.02 and the Argumentum templates need no rework.
+jsboige has now overridden that trade-off — accepting the heavier path to reach **10.3.2** (latest), which
+*does* cross the cliff and *requires* the 2sxc upgrade + template audit. The motivation: latest platform +
+modernized 2sxc + resolved Stripe decision, accepting the extra work.
+
+**The 10.1.2 runbooks are not wrong, they are superseded for the chosen target.** Their procedure (backup →
+staging → restore → schema analysis → migration plan → sandbox test → go-live → rollback), the rollback
+contract, and the runtime finding (DNN 10 = .NET Framework 4.8, #514) all remain valid. Only the *target
+version* and the *2sxc/template scope* change.
+
+| Doc | Status after this revision |
+|-----|----------------------------|
+| [131-cve-correction-and-target-refinement.md](131-cve-correction-and-target-refinement.md) (#520) | ⚠️ "Recommended target = 10.1.2" superseded; CVE facts (64095→10.1.1, 52488→10.0.1, 9.13.x closes 0) still correct |
+| [131-step1-sandbox-upgrade-runbook.md](131-step1-sandbox-upgrade-runbook.md) (#522) | ⚠️ Target 10.1.2 superseded; sandbox procedure reusable for 10.3.2 path |
+| [132-deployment-runbook.md](132-deployment-runbook.md) (#527) | ⚠️ Target 10.1.2 superseded (§4 "no 2sxc migration" NO LONGER HOLDS for 10.3.2); go-live procedure + rollback contract reusable |
+| [131-upgrade-sandbox-plan-v2.md](131-upgrade-sandbox-plan-v2.md) (#511) | Already under errata (#528); 2sxc-compat matrix §5-6 now *central* (was a caveat) |
+| **This doc** | 🆕 net-new decision-spec: target 10.3.2, 2sxc upgrade path, template-audit finding |
+
+## 2. The new target — 10.3.2 + 2sxc ≥21 (what crosses the cliff)
+
+### 2.1 Platform: 9.11.1.19 → 10.3.2
+
+| Step | Version | CVEs closed | 2sxc cliff? | Notes |
+|------|---------|-------------|-------------|-------|
+| (optional stepping-stone) | 9.13.9 | 0 | safe (pre-10.x) | migration aid only |
+| 1 | 10.0.1 | 1 (CVE-2025-52488) | safe | first 10.x |
+| 2 | 10.1.1 | +1 (CVE-2025-64095) | safe | both CVEs closed here |
+| **3 (new target)** | **10.3.2 (latest)** | **2** | **⚠️ crossed** | jsboige decision #2 |
+
+The DNN upgrade wizard handles the platform schema migration 9.11.1 → 10.3.2 (the 6-step strategy of
+[#132](132-deployment-runbook.md) Phase 2-4 applies unchanged). The cliff consequence is a **2sxc** problem,
+not a DNN-schema problem.
+
+### 2.2 2sxc: 15.02 → ≥21.07 LTS (the cliff work)
+
+Per #511 §6 + #520 §3, the cliff is a **Client Dependency Management change in DNN 10.2.0+** that breaks
+2sxc 15.02's asset loading (`DnnJsInclude` → IIS crash). Resolution:
+
+1. **Upgrade 2sxc 15.02 → 21.07 LTS** (min DNN 9.11.02 — our 9.11.1 is sufficient; LTS line runs on
+   DNN 10.3.2, ships the `DnnJsInclude` workaround from 2sxc 21.00.02).
+2. **2sxc v20 breaking changes** (the "Moment-of-Truth" flagged in #511 §6): `SexyContentWebPage`
+   deprecation, module-path rename, SQL reorg. **See §3 — the Argumentum templates are already on the
+   surviving path.**
+
+## 3. 🔑 Grounded finding: the template audit is LARGELY ALREADY DONE
+
+The body of issue #131 flags `_FallacyExplorer_Root.cshtml` as the migration risk: *"using deprecated
+`@inherits ToSic.Sxc.Dnn.RazorComponent` → migrate to `Custom.Hybrid.Razor14`."* **That migration is
+already complete in the repo.** Verified against the source (not asserted):
+
+```
+$ grep -rhoE '@inherits [A-Za-z0-9._]+' DNNPlatform/Portals/1/2sxc/Argumentum/*.cshtml | sort | uniq -c
+      4 @inherits Custom.Hybrid.Razor14
+```
+
+All **4** custom Argumentum templates (`_FallacyExplorer_Root`, `_RulesExplorer_RuleDetail`,
+`_RulesExplorer_RuleList`, `_Album List`) already inherit `Custom.Hybrid.Razor14` — the modern base that
+**survives 2sxc 21**. None use the deprecated `ToSic.Sxc.Dnn.RazorComponent`. The APIs they call are all in
+the *maintained-in-2sxc-21* list from issue #131 itself:
+
+| API | Occurrences in Argumentum templates | Status in 2sxc 21 |
+|-----|-------------------------------------|-------------------|
+| `App.Query` | 1 | ✅ maintained |
+| `AsList` | 4 | ✅ maintained |
+| `CmsContext` | 4 | ✅ maintained |
+| `Link.To` | 3 | ✅ maintained |
+| `Edit.TagToolbar` | 5 | ✅ maintained |
+
+**Implication:** the template-audit work that made the 10.3.2 target "heavier" is **substantially
+pre-completed**. The residual 2sxc upgrade risk is the v20 **infra** breaking changes
+(`SexyContentWebPage` auto-`web.config` deprecation, module-path rename, SQL reorg) on the **stock 2sxc
+apps** (the other 25 of 26 — Accordion4, Blog5, Glossary3, etc.), not the custom Argumentum app.
+
+> §3 honesty boundary: this is verified against the *repo* templates. The 2sxc v20 infra changes touch
+> **installed-app data and web.config**, which live in the portal DB / runtime, not the repo (#525). The
+> §3 finding covers the **Argumentum custom templates** (repo-grounded); the stock-app infra risk is a
+> **staging-test** item (Phase 4 of #132), not a repo-audit item.
+
+## 4. Revised upgrade procedure (delta vs the 10.1.2 runbooks)
+
+On top of the 6-phase go-live procedure in [#132](132-deployment-runbook.md), the 10.3.2 target adds:
+
+- **Phase 1.5 (NEW) — 2sxc upgrade on the current DNN.** Before crossing 10.2.0, upgrade 2sxc 15.02 →
+  21.07 LTS **on DNN 9.11.1** (the 2sxc-first path from #131 research findings). Verify the Argumentum
+  app still serves (it's already Razor14 — §3). This isolates 2sxc risk from DNN risk.
+- **Phase 4 (EXPANDED) — sandbox test must cover the cliff.** The staging test (restored prod DB) must
+  confirm: (a) no `DnnJsInclude` IIS crash after 10.2.0, (b) the 25 stock 2sxc apps still load, (c) the
+  Argumentum app templates bind. **Go/no-go gate → jsboige** before prod.
+- **Phase 3 (EXPANDED) — migration plan includes 2sxc content-types/entities/metadata.** Unlike the 10.1.2
+  no-op (old #527 §4), 10.3.2 crosses the 2sxc v20 boundary → the 2sxc content migration is a real step
+  (run by the 2sxc 21 upgrade wizard on the staging-restored prod DB first).
+- **#445 (Stripe Native) unblocked.** With OpenStore's .NET-8 blocker dissolved (#514), jsboige can
+  re-decide keep-OpenStore vs migrate-to-Stripe-managed-products. This is a **separate decision** (Phase B
+  of #131), not blocking the platform upgrade — but the 10.3.2 upgrade window is the natural moment to
+  act on it.
+
+## 5. Gate boundaries
+
+- ❌ Does **not** deploy, upgrade, back up, or restore anything on production (execution GATED jsboige).
+- ❌ Does **not** touch the live DB / RDP / portal / 2sxc runtime (all steps *described*, not *performed*).
+- ❌ Does **not** rewrite the merged 10.1.2 runbooks — adds superseded banners pointing here (separate edits).
+- ❌ Does **not** decide #445 (Stripe) — surfaces it as unblocked, jsboige decides.
+- ❌ Does **not** declare a QA verdict (ai-01 only).
+
+## 6. What this does NOT cover (still gated / separate)
+
+- The **stock 2sxc apps' v20 infra risk** (25 of 26 apps) — staging-test item, not repo-audit.
+- The **#445 Stripe decision** content (keep OpenStore vs Stripe managed) — jsboige business decision.
+- The **live DB export** needed to fill the #132 runbook's "à confirmer" sections — jsboige portal export.
+- The **"Materiel" typo** fix — DB/2sxc content (#525), gated to the DNN upgrade session (jsboige decision #7).
+
+## Sources
+
+- jsboige decision #2 (issue #458 comment 2026-06-18, VÉRIFIÉ canal interactif) — target 10.3.2 + 2sxc upgrade + #445 unblocked.
+- Repo templates: `DNNPlatform/Portals/1/2sxc/Argumentum/*.cshtml` (4 files, all `@inherits Custom.Hybrid.Razor14`).
+- [131-cve-correction-and-target-refinement.md](131-cve-correction-and-target-refinement.md) (#520) — CVE facts + cliff @10.2.0.
+- [131-step0-runtime-verification.md](131-step0-runtime-verification.md) (#514) — DNN 10 = .NET Framework 4.8.
+- [131-upgrade-sandbox-plan-v2.md](131-upgrade-sandbox-plan-v2.md) (#511 §6) — 2sxc v20 breaking changes inventory.
+- [132-deployment-runbook.md](132-deployment-runbook.md) (#527) — 6-phase go-live procedure + rollback contract.
+- Issue #131 body (topology, 2sxc APIs maintained in v21, eshop scope).

--- a/docs/dnn-localization/131-upgrade-sandbox-plan-v2.md
+++ b/docs/dnn-localization/131-upgrade-sandbox-plan-v2.md
@@ -16,11 +16,13 @@
 > - **CVE-2025-52488** is first patched in **10.0.1**.
 > - The **9.13.x line closes NEITHER** (0 of 2), not 1 of 2 as this doc's §2/§1-consequence state.
 >
-> **For all security/target decisions, read [#520](131-cve-correction-and-target-refinement.md)
-> (target = 10.1.2) as the source of truth, and [132-deployment-runbook.md](132-deployment-runbook.md)
-> (#527) for the go-live procedure.** This v2 doc is retained for its runtime-finding (§3: DNN 10 =
-> .NET Framework 4.8) and 2sxc-compatibility matrix (§5-6), which remain valid. The §2 CVE table and
-> the "9.13.x closes 1 CVE" framing are retracted per #520.
+> **For CVE facts, read [#520](131-cve-correction-and-target-refinement.md) (corrected patch versions).
+> For the upgrade TARGET, read
+> [131-target-revision-10.3.2-full-upgrade.md](131-target-revision-10.3.2-full-upgrade.md) — jsboige
+> decision #2 (issue #458, 2026-06-18) chose **10.3.2 full upgrade**, superseding the 10.1.2 target #520
+> recommended.** This v2 doc is retained for its runtime-finding (§3: DNN 10 = .NET Framework 4.8) and
+> **2sxc-compatibility matrix (§5-6), which is now central** (the 10.3.2 path crosses the cliff it maps).
+> The §2 CVE table and the "9.13.x closes 1 CVE" framing are retracted per #520.
 
 This document **EXTENDS** (does not duplicate) two prior analyses:
 - [`131-upgrade-9.13-sandbox-plan.md`](./131-upgrade-9.13-sandbox-plan.md) — the #479 9.11.1→9.13.x security-palier plan (CVE table, disk blocker, sandbox sketch).

--- a/docs/dnn-localization/132-deployment-runbook.md
+++ b/docs/dnn-localization/132-deployment-runbook.md
@@ -8,6 +8,14 @@
 upgrade, no go-live on production without jsboige's explicit go. This is the **go-live procedure**,
 distinct from the sandbox-upgrade procedure ([#522](131-step1-sandbox-upgrade-runbook.md)).
 
+> ⚠️ **TARGET SUPERSEDED — 10.1.2 → 10.3.2.** jsboige interactive decision #2 (issue #458, 2026-06-18)
+> chose the **full upgrade to 10.3.2-latest + 2sxc 15→≥21 + template audit**. The **10.1.2 target below is
+> superseded**; read [131-target-revision-10.3.2-full-upgrade.md](131-target-revision-10.3.2-full-upgrade.md)
+> as the source of truth. **Specifically §4 of this doc ("no 2sxc migration for 10.1.2") NO LONGER HOLDS**
+> — 10.3.2 crosses the 2sxc cliff, so 2sxc content migration + the 2sxc upgrade are real steps (see the
+> revision doc §4: a new Phase 1.5 + expanded Phase 3/4). The 6-phase go-live procedure, the rollback
+> contract, and the runtime finding (.NET 4.8) here remain valid; only the target + 2sxc scope changed.
+>
 > **Migration strategy (jsboige, issue #132 body):** recover the production database → restore to
 > dev/staging → analyze schema & data → migration plan (dev↔prod delta) → test on the backup →
 > go-live. This runbook follows that 6-step shape and flags every section that can only be completed


### PR DESCRIPTION
## What

jsboige interactive **decision #2** (issue #458, 2026-06-18): *"Je suis pour l'upgrade complète, même si c'est plus lourde"* → DNN target is now **10.3.2-latest + 2sxc 15→≥21 + template audit**. This **supersedes the 10.1.2 target** I built across #520/#522/#527/#528. **#445 Stripe Native is unblocked** (OpenStore .NET-8 blocker dissolved — DNN 10 = .NET Framework 4.8).

This PR brings the DNN doc arc in line with the decision.

## Net-new decision-spec (+141)

`131-target-revision-10.3.2-full-upgrade.md` — the source of truth for the new target:
- The 6-phase go-live procedure (#527) + rollback contract + .NET 4.8 runtime finding **remain valid**; only the target version + 2sxc scope change.
- **2sxc upgrade path**: 15.02 → 21.07 LTS on DNN 9.11.1 (2sxc-first), then DNN → 10.3.2. New Phase 1.5 + expanded Phase 3/4 (content migration is now real, vs the 10.1.2 no-op).
- **🔑 Grounded finding (§3): the template audit is LARGELY ALREADY DONE.** All 4 Argumentum custom templates already use `@inherits Custom.Hybrid.Razor14` (verified against source, not asserted) — the legacy `RazorComponent` migration #131 flagged is complete. APIs in use (App.Query, AsList, CmsContext, Link.To, Edit.TagToolbar) are all in the *maintained-in-2sxc-21* list from #131 itself. Residual risk = the 25 stock 2sxc apps' v20 infra changes = a staging-test item, not a repo-audit item.

This finding materially de-risks the decision: 10.3.2 is far less scary when the custom-app templates are already Razor14-compatible.

## Superseded banners (history-faithful, no rewrite)

Added banners to the 4 target-bearing runbooks pointing to the new spec:
- **#520** (CVE correction): "recommended target = 10.1.2" superseded; CVE facts stay correct.
- **#522** (sandbox runbook): target superseded; procedure reusable for 10.3.2 path.
- **#527** (deploy runbook): target superseded; **§4 "no 2sxc migration" explicitly NO LONGER HOLDS**.
- **#511** (plan-v2): existing #528 errata redirected to the new spec; 2sxc-compat matrix §5-6 now central.

## Doc-only, non-gated

- ❌ No deploy/upgrade/2sxc execution (GATED jsboige). No DB/RDP. No template edit.
- ❌ No merged-history rewrite (banners, not rewrites).
- 5 files: +168/-5. Base master `cae93dc8`.

Refs #131 #458 #445 #514 #520 #522 #527 #528.
