### PR TITLE
chore(config): FreeMindPath + Mindmapper-isolate for attended 8-lang mindmap regen (SCOPE PENDING)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -34,7 +34,7 @@ namespace Argumentum.AssetConverter
 	    public bool SkipConfigFile { get; set; } = true;
 
 	       [JsonConverter(typeof(JsonStringEnumConverter))]
-	       public ConverterMode Mode { get; set; } = ConverterMode.WebBasedImageGeneration | ConverterMode.QuestPdfGeneration;
+	       public ConverterMode Mode { get; set; } = ConverterMode.Mindmapper;
 
 		public bool ForceDebugParams { get; set; }
 
@@ -275,7 +275,7 @@ namespace Argumentum.AssetConverter
 		public VirtueMindMapCreatorConfig VirtueMindMapCreatorConfig { get; set; } = new VirtueMindMapCreatorConfig();
 
 		public string FreeplanePath { get; set; } = "";
-		public string FreeMindPath { get; set; } = "";
+		public string FreeMindPath { get; set; } = @"C:\Program Files (x86)\FreeMind\FreeMind.exe";
 
 
 		public Dnn2sxcConfig Dnn2sxcConfig { get; set; } = new Dnn2sxcConfig();

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -34,7 +34,7 @@ namespace Argumentum.AssetConverter
 	    public bool SkipConfigFile { get; set; } = true;
 
 	       [JsonConverter(typeof(JsonStringEnumConverter))]
-	       public ConverterMode Mode { get; set; } = ConverterMode.Mindmapper;
+	       public ConverterMode Mode { get; set; } = ConverterMode.WebBasedImageGeneration | ConverterMode.QuestPdfGeneration;
 
 		public bool ForceDebugParams { get; set; }
 
@@ -275,7 +275,9 @@ namespace Argumentum.AssetConverter
 		public VirtueMindMapCreatorConfig VirtueMindMapCreatorConfig { get; set; } = new VirtueMindMapCreatorConfig();
 
 		public string FreeplanePath { get; set; } = "";
-		public string FreeMindPath { get; set; } = @"C:\Program Files (x86)\FreeMind\FreeMind.exe";
+		// FreeMindPath default stays empty (machine-specific — set via ARGUMENTUM_FREEMIND_PATH env var
+		// or config, never hardcoded). See TryFreeMindSvgExportCore env-var fallback.
+		public string FreeMindPath { get; set; } = "";
 
 
 		public Dnn2sxcConfig Dnn2sxcConfig { get; set; } = new Dnn2sxcConfig();

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -553,10 +553,18 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 		private static bool TryFreeMindSvgExportCore(string sourceMmPath, string destinationSvgPath, AssetConverterConfig config)
 		{
+			// FreeMindPath is machine-specific (absolute Windows path), so the C# default stays "".
+			// It resolves at runtime from (1) config.FreeMindPath, then (2) the ARGUMENTUM_FREEMIND_PATH
+			// env var. This avoids hardcoding a path that would break on machines where FreeMind isn't
+			// installed at that exact location, while still letting an attended run find it.
 			var freemindPath = config.FreeMindPath;
+			if (string.IsNullOrEmpty(freemindPath))
+			{
+				freemindPath = Environment.GetEnvironmentVariable("ARGUMENTUM_FREEMIND_PATH");
+			}
 			if (string.IsNullOrEmpty(freemindPath) || !File.Exists(freemindPath))
 			{
-				Logger.LogWarning($"FreeMind not found at '{freemindPath}'. Skipping GUI export.");
+				Logger.LogWarning($"FreeMind not found (config.FreeMindPath='{config.FreeMindPath}', env ARGUMENTUM_FREEMIND_PATH unset or invalid). Skipping GUI export.");
 				return false;
 			}
 


### PR DESCRIPTION
## What

Runtime plumbing to enable the **attended** mindmap regen (es/ar/fa/zh + uniformisation) via **FreeMind native rendering**, **without changing permanent defaults**. Requested by jsboige interactively ("lance la regen des mindmaps" → FreeMind attended + 8-lang uniformise).

## Changes (2 files, +13/-3)

### `AssetConverterConfig.cs` — no permanent default change
- `FreeMindPath` default: stays `""` (reverted from a hardcoded Windows path — that was machine-specific and would break on other machines, inconsistent with `FreeplanePath=""`).
- `Mode` default: stays `WebBasedImageGeneration | QuestPdfGeneration` (reverted — `Mindmapper` isolation is a **run-scoped** action, not a permanent default, otherwise every future `dotnet run` would only do MindMaps).

### `FallacyMindMapDocumentConfig.cs` — `ARGUMENTUM_FREEMIND_PATH` env fallback
`TryFreeMindSvgExportCore` (shared by Fallacy + Virtue) now resolves the FreeMind path at runtime:
1. `config.FreeMindPath` first,
2. then the `ARGUMENTUM_FREEMIND_PATH` env var.

Default stays `""` → **no machine is broken** by this merge. An attended run sets the env var (or config) to point at its local `FreeMind.exe`.

## ⚠️ Scope contradiction to resolve before the run — jsboige decision

Two sources disagree on the regen scope:

| Source | Scope |
|--------|-------|
| **Dashboard decision #12** (ai-01, 2026-06-18) | MindMap SVG on **es/ar/fa/zh ONLY** — *préserver les 20 SVGs fr/en/ru/pt validés* |
| **jsboige interactive** (2026-06-18) | **8 langues (uniformise)** — regenerate all 8 with FreeMind native |

Resolution is **runtime config**, not part of this PR's merged code:
- **8-lang uniformise** (interactive choice): `OverwriteExistingDocs=true` (current default) + run all 8.
- **Preserve fr/en/ru/pt** (dashboard #12): set `OverwriteExistingDocs=false` at runtime (skip the 8 existing `.mm`/SVGs) OR comment en/ru/pt in `Translations` lists. Generates only es/ar/fa/zh.

## How to run (ATTENDED only — foreground-lock)

FreeMind SendKeys needs an **interactive desktop** (Windows foreground-lock; memory `feedback-mindmap-freemind-unattended-foreground`). A worker (po-2023) cannot run this unattended. Run from a RDP/local attended session:

```powershell
cd d:\Dev\Argumentum
git checkout chore/regen-mindmap-freemind-8lang
# Point at the local FreeMind (machine-specific — do NOT hardcode in C#)
$env:ARGUMENTUM_FREEMIND_PATH = "C:\Program Files (x86)\FreeMind\FreeMind.exe"
# Isolate to MindMap stage (run-scoped — does NOT change the permanent Mode default)
# Temporarily set Mode=Mindmapper in C# for the run, OR run full pipeline.
dotnet run --project "Generation\Converters\Argumentum.AssetConverter\Argumentum.AssetConverter.csproj"
```

- ~30-40 min, FreeMind takes foreground per file (16 `.mm` → SVG).
- **Stay on the desktop** — don't switch windows during keystrokes.
- The Fallacy path has **no active XSLT fallback** (only Virtue does) — if FreeMind loses focus on a Fallacy file, that SVG won't be produced.

## State of the lane (verified)

- **PDFs es/ar/fa/zh: already built** (64 PDFs total, 8×8 parity, `bin/Release/net9.0-windows/Target/{lang}/Documents/density-0/`). No gap.
- **MindMaps es/ar/fa/zh: missing** — the only real gap, blocked by foreground-lock (environmental, not data).

## Review response

@NanoClaw's COMMENT_WITH_CONCERNS was correct on both points — addressed by this revision (defaults reverted, env-var fallback added). The PR is now mergeable as runtime plumbing (no permanent default change); the regen itself is an attended action gated on the scope decision.

🤖 Worker po-2023 · run = jsboige (attended) or ai-01 (Opus) · scope decision pending

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
