### PR TITLE
docs(dnn): #131 fix Phase 2 §4.2 RESTORE order — VERIFYONLY before RESTORE

### DIFF
--- a/docs/dnn-localization/131-dnn-phase2-exec-rollback.md
+++ b/docs/dnn-localization/131-dnn-phase2-exec-rollback.md
@@ -135,13 +135,15 @@ upgrade). Use the **Step 1.5.0 backup** only if you want to reset everything (in
 
 ```
 1. STOP the IIS site (free all file locks).
-2. DB RESTORE:
+2. DB RESTORE (VERIFYONLY FIRST — the rollback contract, #527 §6 / §4.3 here):
+     -- (a) verify the backup is restorable BEFORE overwriting anything:
+     RESTORE VERIFYONLY FROM DISK = '…\<anchor>.bak' WITH CHECKSUM;
+     -- (b) ONLY if (a) is green, kick everyone out and overwrite:
      ALTER DATABASE [DotNetNuke] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
      RESTORE DATABASE [DotNetNuke]
        FROM DISK = '…\<anchor>.bak'
        WITH REPLACE, RECOVERY, CHECKSUM;
-     -- VERIFYONLY first, always (the rollback contract, #527 §6):
-     RESTORE VERIFYONLY FROM DISK = '…\<anchor>.bak' WITH CHECKSUM;
+     -- (c) abort if (a) failed — do NOT run (b) on an unverifiable backup.
 3. WEBROOT RESTORE:
      - delete the upgraded webroot's bin/ + the wizard-touched files
      - restore bin/, web.config, Portals/, DesktopModules/, App_Data/ from the anchor's files backup


### PR DESCRIPTION
## What

Follow-up safety fix on [#548](https://github.com/ArgumentumGames/Argumentum/pull/548) (merged). Addresses the NanoClaw concern flagged during ai-01's review (process slip: review-grep + merge batched → merged despite the concern). Per ai-01 dispatch `msg-20260619T170757`.

## The bug

The §4.2 SQL block ran `RESTORE DATABASE … WITH REPLACE` **THEN** `RESTORE VERIFYONLY … WITH CHECKSUM`. But verifying a backup **after** overwriting the DB is useless — by the time VERIFYONLY fails, the production DB is already destroyed. The block contradicted:
- its own inline comment ("VERIFYONLY first, always (the rollback contract)"),
- §4.3 of the same doc ("the anchor must be green **before** starting Step 2.2"),
- the #527 §6 rollback contract it cited.

## The fix

Move `RESTORE VERIFYONLY` to step **(a)**, BEFORE `RESTORE DATABASE` **(b)**, with explicit conditional logic:
- **(a)** verify the backup is restorable before overwriting anything,
- **(b)** ONLY if (a) is green, kick users out (`SET SINGLE_USER`) and overwrite,
- **(c)** abort if (a) failed — do NOT run (b) on an unverifiable backup.

Now consistent with §4.3 and the rollback contract.

## Gate boundaries

- ✅ Doc-only, safety correction (+5/-3 lines).
- ❌ No execution, no deploy.

**Base:** `e32c8ae2` · **Branch:** `docs/131-fix-phase2-restore-order` · **Worker:** po-2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)