### PR TITLE
test(pdf): #204 extract back-first image ordering to pure method + 7 tests

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfBackFirstOneDocPerBackContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfBackFirstOneDocPerBackContractTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Linq;
+using Argumentum.AssetConverter;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
+{
+    /// <summary>
+    /// Contract pin for <see cref="PdfManager.OrderImagesForBackFirstOneDocPerBack"/> — #204
+    /// continuation (po-2024), the per-back PDF image-ordering contract.
+    ///
+    /// <see cref="PdfManager.GenerateBackFirstOneDocPerBack"/> groups a deck's cards by their back
+    /// art and emits ONE PDF per distinct back: the shared back image FIRST, then every card's
+    /// FRONT in their original CardSet order. That back-first-then-fronts sequence is what lets a
+    /// print shop place one back behind a whole family of faces on a recto-verso sheet.
+    ///
+    /// This ordering is a fragile contract: a regression that emits fronts-first, drops the back,
+    /// duplicates it, or reorders the fronts silently misaligns every printed sheet and is caught
+    /// only by opening the PDF. It was previously inlined inside the MagickImage collection builder
+    /// (with ZERO unit coverage), asymmetric with the alternate-face-and-back format whose ordering
+    /// was already extracted into <see cref="PdfManager.OrderImagesForAlternateFaceAndBack"/>. It
+    /// has been extracted (output-neutral — the call site emits the exact same path sequence) into
+    /// the pure, deterministic <see cref="PdfManager.OrderImagesForBackFirstOneDocPerBack"/> so the
+    /// contract is unit-testable. These tests pin it additively.
+    /// </summary>
+    public class PdfBackFirstOneDocPerBackContractTests
+    {
+        // Helper: build a card list from front-path specs. Backs are irrelevant to this format's
+        // per-group ordering (the group key already selected them), so the helper takes fronts only.
+        private static List<CardImages> Cards(params string[] fronts)
+            => fronts.Select(f => new CardImages { Front = f }).ToList();
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (1) Back-first emission — the shared back art is always slot 0.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void BackIsEmittedFirst_BeforeAnyFront()
+        {
+            // THE fragile bit: the back MUST be slot 0 so it lands behind its faces recto-verso.
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "BackArt", Cards("F1", "F2", "F3"));
+
+            outSeq.First().Should().Be("BackArt");
+        }
+
+        [Fact]
+        public void SingleFront_BackThenFront()
+        {
+            // Minimal group: one shared back + one face → two slots, back first.
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "B", Cards("OnlyFace"));
+
+            outSeq.Should().Equal("B", "OnlyFace");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (2) Front order is preserved — original CardSet order, no reordering.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void FrontsPreserveOriginalCardSetOrder()
+        {
+            // The faces keep their input order; the method must NOT sort or reverse them.
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "Back", Cards("Fallacy1", "Fallacy2", "Fallacy3"));
+
+            outSeq.Should().Equal("Back", "Fallacy1", "Fallacy2", "Fallacy3");
+        }
+
+        [Fact]
+        public void FrontsAreNotReversed()
+        {
+            // Anti-regression: a naive back-first implementation that "prepends" each front to an
+            // accumulator would reverse the faces. Pin that they stay in input order.
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "B", Cards("A", "B_face", "C")).ToList();
+
+            outSeq.Skip(1).Should().Equal("A", "B_face", "C");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (3) Count semantics — back is one slot, each front is one slot.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void CountIsOneBackPlusNumberOfFronts()
+        {
+            // 1 (back) + N (fronts) = N+1 emitted paths. A regression that duplicates the back or
+            // drops a front breaks this count silently.
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "Back", Cards("F1", "F2", "F3", "F4"));
+
+            outSeq.Should().HaveCount(5);
+        }
+
+        [Fact]
+        public void BackAppearsExactlyOnce()
+        {
+            // The shared back is emitted ONCE (as the group key), not once per front. A regression
+            // that interleaves back-front-back-front would put the back N times.
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "BackArt", Cards("F1", "F2", "F3")).ToList();
+
+            outSeq.Count(p => p == "BackArt").Should().Be(1);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (4) Degenerate inputs.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void EmptyFronts_EmitsBackOnly()
+        {
+            // No faces for this back → just the back slot (matches the builder: Key + empty concat).
+            var outSeq = PdfManager.OrderImagesForBackFirstOneDocPerBack(
+                "LonelyBack", Cards());
+
+            outSeq.Should().Equal("LonelyBack");
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
@@ -92,6 +92,33 @@ namespace Argumentum.AssetConverter
         }
 
         /// <summary>
+        /// Produces the ordered image-path sequence for a SINGLE per-back PDF emitted by
+        /// <see cref="GenerateBackFirstOneDocPerBack"/>: the shared back art FIRST (one slot), then
+        /// every card's FRONT in their original CardSet order. That back-first-then-fronts ordering
+        /// is what lets a print shop lay one back behind a whole family of faces on a recto-verso
+        /// sheet.
+        /// Pure &amp; deterministic — no MagickImage, no I/O. Extracted output-neutral from the
+        /// collection builder inside <see cref="GenerateBackFirstOneDocPerBack"/> (which previously
+        /// inlined <c>new[] { key }.Concat(group.Select(c =&gt; c.Front))</c>) so this fragile
+        /// ordering contract is unit-testable in isolation — symmetric with
+        /// <see cref="OrderImagesForAlternateFaceAndBack"/>, which was already extracted for the
+        /// alternate-face-and-back format. A regression here (emitting fronts-first, dropping the
+        /// back, duplicating it, or reordering the fronts) silently misaligns every printed sheet
+        /// and is caught only by opening the PDF.
+        /// </summary>
+        /// <param name="backPath">The shared back image path for this family (the group key).</param>
+        /// <param name="fronts">The cards sharing this back, in their original CardSet order.</param>
+        public static IEnumerable<string> OrderImagesForBackFirstOneDocPerBack(
+            string backPath, IEnumerable<CardImages> fronts)
+        {
+            yield return backPath;
+            foreach (var card in fronts)
+            {
+                yield return card.Front;
+            }
+        }
+
+        /// <summary>
         /// Inserts <paramref name="suffix"/> into <paramref name="baseFileName"/> just before its
         /// FINAL dot, producing e.g. <c>Cards-1.pdf</c> from <c>Cards.pdf</c> + <c>"-1"</c>, or
         /// <c>Cards-FacesOnly.pdf</c> from <c>Cards.pdf</c> + <c>"-FacesOnly"</c>. The suffix INCLUDES
@@ -133,15 +160,15 @@ namespace Argumentum.AssetConverter
                 var closureBackIndex = backIndex;
                 var collecBuilderBF = () =>
                 {
-                    var allImages = new List<MagickImage>();
-                    
-                    // Ajouter le dos en premier
+                    // ✅ #204 image-sequence ordering extracted output-neutral into
+                    // OrderImagesForBackFirstOneDocPerBack so this fragile back-first-then-fronts
+                    // contract is unit-testable without a MagickImage render. Symmetric with
+                    // OrderImagesForAlternateFaceAndBack (the alternate-face-and-back format).
                     var frontsAndBack = cardsPerBack[closureBackIndex];
-                    allImages.Add(new MagickImage(frontsAndBack.Key));
-                    
-                    // Ajouter toutes les faces avec ce dos
-                    allImages.AddRange(frontsAndBack.Select(card => new MagickImage(card.Front)));
-                    
+                    var orderedPaths = OrderImagesForBackFirstOneDocPerBack(
+                        frontsAndBack.Key, frontsAndBack);
+                    var allImages = orderedPaths.Select(p => new MagickImage(p));
+
                     var collec = new MagickImageCollection(allImages);
                     return collec;
                 };


### PR DESCRIPTION
## What

Extract the **per-back PDF image-ordering** contract from `PdfManager.GenerateBackFirstOneDocPerBack`'s inlined MagickImage collection builder (`new[] { key }.Concat(group.Select(c => c.Front))`) into a pure, deterministic `OrderImagesForBackFirstOneDocPerBack` method, and pin it with **7 contract tests**.

This is the #204 lane's next extraction, **closing the asymmetry** with the alternate-face-and-back format whose ordering was already extracted (`OrderImagesForAlternateFaceAndBack`, tested by `PdfAlternateFaceAndBackContractTests`). **Output-neutral: the call site emits the exact same path sequence; full suite green (388/0/5).**

## Why

`GenerateBackFirstOneDocPerBack` groups a deck's cards by their back art and emits **one PDF per distinct back**: the shared back image **first**, then every card's front in original CardSet order. That back-first-then-fronts sequence is what lets a print shop place one back behind a whole family of faces on a recto-verso sheet.

This ordering was inlined inside the MagickImage collection builder with **zero unit coverage** — asymmetric with `GenerateAlternateFaceAndBack`, whose ordering was already extracted + tested. A regression here — emitting fronts-first, dropping the back, duplicating it, or reversing the fronts — **silently misaligns every printed sheet**, caught only by opening the PDF.

## How this candidate was selected (audited, not guessed)

The dispatch (`msg-20260619T231024-hy2czr`) asked me to audit `CollectPossibleSvgNodes` fragility first, then extract only if byte-identity is demonstrable by inspection (model #553 > #551), else pick a safer candidate. The audit (Explore, read-only) concluded:

- **`CollectPossibleSvgNodes` FAILS the bar** — `TitleFunc` delegate invocation + `Logger.LogProblem` side effect + deep XElement coupling make it not cleanly separable without depending on delegate-call equivalence. Confirmed the "fragilité plus haute" flag.
- The whole mindmap zone (`CollectPossibleSvgNodes`, `DisambiguateSvgNodes`, `SetNodeStyle`, `CreateRichContent`) fails for the same reasons (delegates `TitleFunc`/`DescFunc`/`ExampleFunc`, `Logger`, mutable `Node`, external `HLSColor`).
- `PrintAndPlayDocument.cs` is exhausted (`ReorderBacksForRectoVerso` + `ComputePageGeometry` already extracted; remaining `Skip/Take` is trivial padding).

→ Pivoted to the **asymmetry gap in `PdfManager.cs`**: the alternate-face-and-back format's ordering was extracted, the per-back format's was not. Same class, same fragility class, same test style — the cleanest remaining candidate.

## The extraction

**Before** — ordering inlined in the collection builder:

```csharp
var collecBuilderBF = () =>
{
    var allImages = new List<MagickImage>();
    var frontsAndBack = cardsPerBack[closureBackIndex];
    allImages.Add(new MagickImage(frontsAndBack.Key));           // back first
    allImages.AddRange(frontsAndBack.Select(card => new MagickImage(card.Front)));  // then fronts
    var collec = new MagickImageCollection(allImages);
    return collec;
};
```

**After** — one pure method, one call site:

```csharp
public static IEnumerable<string> OrderImagesForBackFirstOneDocPerBack(
    string backPath, IEnumerable<CardImages> fronts)
{
    yield return backPath;
    foreach (var card in fronts)
        yield return card.Front;
}
// call site:
var orderedPaths = OrderImagesForBackFirstOneDocPerBack(frontsAndBack.Key, frontsAndBack);
var allImages = orderedPaths.Select(p => new MagickImage(p));
```

**Byte-identity by inspection** (the #553 bar, not #551): old sequence = `[Key, F0, F1, …]` via `Add(Key)` + `AddRange(Select(Front))`; new sequence = `[Key, F0, F1, …]` via `yield Key` then `yield each Front`. Same paths, same order, one `MagickImage` per path. Obvious from the diff — does not depend on an external method's equivalence.

## The 7 contract tests (`PdfBackFirstOneDocPerBackContractTests`)

| # | What it pins |
|---|---|
| 1 | Back is emitted FIRST (slot 0) — the fragile recto-verso alignment bit |
| 2 | Minimal group: one back + one face → `[B, OnlyFace]` |
| 3 | Fronts preserve original CardSet order (no sort/reverse) |
| 4 | Fronts are NOT reversed (anti-regression on naive prepend-accumulator) |
| 5 | Count = 1 back + N fronts (catches back-duplication or front-drop) |
| 6 | Back appears EXACTLY once (not once-per-front) |
| 7 | Degenerate: empty fronts → back only |

## Verification

- **New tests**: 7/7 pass.
- **Full suite**: **388 passed / 0 failed / 5 skipped** — no regression (baseline 381 + 7 new). Byte-identical image sequence.
- Build: 0 errors.

## Related

- Dispatched by: ai-01 (`msg-20260619T231024-hy2czr`, PRIMAIRE — "audite la fragilité d'abord… si byte-identity démontrable inspection, extrait + tests de contrat. Sinon pioche un candidat plus sûr")
- Lane: #204 (test extractions)
- Model PRs: #523, #529, #551, #553
- Candidate audit: `CollectPossibleSvgNodes` rejected (fails the by-inspection bar); pivoted to the `PdfManager` asymmetry gap.
- DoD: output-neutral (byte-identical image sequence) + additive tests — mergeable without a content gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
