### PR TITLE
test(parse): close ClassMap matrix — TestFallacyCard regression (5 tests)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/TestFallacyCardClassMapRegressionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/TestFallacyCardClassMapRegressionTests.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using Argumentum.AssetConverter.Entities;
+using CsvHelper;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Parsing
+{
+    /// <summary>
+    /// Regression tests for <see cref="TestFallacyCardClassMap"/> via the real load path
+    /// <see cref="CsvBase{T,TMap}.LoadFromContent"/>. <see cref="TestFallacyCard"/> is the simplified
+    /// fallacy entity used for visual-test card generation — the LAST entity ClassMap without a
+    /// dedicated regression suite (this PR closes the ClassMap matrix at 100%: Fallacy #485,
+    /// Rule/ArgumentVirtue/Scenario #476, Virtue #559, DnnUiString, and now TestFallacyCard).
+    ///
+    /// The ClassMap declares 5 columns, ALL required (non-<c>.Optional()</c>): Id, Title, Type,
+    /// IllustrationPath, Description. The guards these tests pin:
+    /// <list type="bullet">
+    /// <item><description>All 5 columns map to their properties (a header-name drift = silent null
+    /// properties = empty visual-test cards).</description></item>
+    /// <item><description><c>GetId()</c> returns <c>Id</c> — the key used by the image generator's
+    /// output dictionary; if the binding breaks, cards have no key.</description></item>
+    /// <item><description>A required column absent from the header throws
+    /// <see cref="HeaderValidationException"/> (CsvHelper strict default — the contract that
+    /// prevents silent data loss).</description></item>
+    /// <item><description>A short data row (fewer cells than the header) does NOT throw —
+    /// <c>MissingFieldFound</c> is a log callback in <see cref="CsvBase{T,TMap}.LoadFromContent"/>,
+    /// so a ragged row logs and yields missing fields as null (the documented
+    /// <c>CsvBaseStrictContractTests</c> behavior).</description></item>
+    /// </list>
+    ///
+    /// Additive only: no existing test or production code is modified. Inline CSV keeps each test
+    /// self-contained. Companion to <c>VirtueClassMapRegressionTests</c> (#559) and
+    /// <c>EntityClassMapRegressionTests</c> (#476).
+    /// </summary>
+    public class TestFallacyCardClassMapRegressionTests
+    {
+        private const string Header = "Id,Title,Type,IllustrationPath,Description";
+        private const string FullRow = "card-1,Ad Hominem,fallacy,/img/adhominem.png,Attacking the person";
+
+        /// <summary>
+        /// All 5 required columns map to their properties.
+        /// </summary>
+        [Fact]
+        public void TestFallacyCard_LoadFromContent_MapsAllColumns()
+        {
+            var csv = Header + "\n" + FullRow + "\n";
+
+            var cards = TestFallacyCard.LoadFromContent(csv);
+
+            cards.Should().ContainSingle();
+            var c = cards[0];
+            c.Id.Should().Be("card-1");
+            c.Title.Should().Be("Ad Hominem");
+            c.Type.Should().Be("fallacy");
+            c.IllustrationPath.Should().Be("/img/adhominem.png");
+            c.Description.Should().Be("Attacking the person");
+        }
+
+        /// <summary>
+        /// GetId() returns Id — the key for the image generator's output dictionary.
+        /// </summary>
+        [Fact]
+        public void TestFallacyCard_LoadFromContent_GetIdReturnsId()
+        {
+            var csv = Header + "\n" + FullRow + "\n";
+
+            var cards = TestFallacyCard.LoadFromContent(csv);
+
+            cards.Should().ContainSingle();
+            cards[0].GetId().Should().Be("card-1");
+        }
+
+        /// <summary>
+        /// A required column absent from the header must throw HeaderValidationException — all 5
+        /// TestFallacyCard columns are non-Optional, so the strict default applies. This is the
+        /// contract that prevents silent data loss: a column drift fails loud, not silent.
+        /// </summary>
+        [Fact]
+        public void TestFallacyCard_LoadFromContent_RequiredColumnAbsent_Throws()
+        {
+            // Drop "Description" (a required column) from the header.
+            var csv = "Id,Title,Type,IllustrationPath\n" + FullRow + "\n";
+
+            var act = () => TestFallacyCard.LoadFromContent(csv);
+
+            act.Should().Throw<HeaderValidationException>(
+                "Description is a non-Optional column; its absence must fail loud, not silently null the property");
+        }
+
+        /// <summary>
+        /// A short data row (fewer cells than the header) does NOT throw — MissingFieldFound is a
+        /// log callback in LoadFromContent, so a ragged row yields null for the missing fields
+        /// instead of throwing. This mirrors the CsvBaseStrictContractTests short-row contract.
+        /// </summary>
+        [Fact]
+        public void TestFallacyCard_LoadFromContent_ShortRow_DoesNotThrow()
+        {
+            // Header has 5 columns; the row supplies only the first 3.
+            var csv = Header + "\n" + "card-1,Ad Hominem,fallacy\n";
+
+            var act = () => TestFallacyCard.LoadFromContent(csv);
+
+            act.Should().NotThrow();
+            var cards = TestFallacyCard.LoadFromContent(csv);
+            cards.Should().ContainSingle();
+            cards[0].Id.Should().Be("card-1");
+            cards[0].Title.Should().Be("Ad Hominem");
+            cards[0].Description.Should().BeEmpty(
+                "the short row leaves Description unset — CsvHelper yields string.Empty for the missing " +
+                "field (MissingFieldFound logs, does not throw). Not null: the string default is \"\"");
+        }
+
+        /// <summary>
+        /// Multiple rows load in order.
+        /// </summary>
+        [Fact]
+        public void TestFallacyCard_LoadFromContent_MultipleRows_LoadInOrder()
+        {
+            var csv =
+                Header + "\n" +
+                "card-1,Ad Hominem,fallacy,/img/1.png,Desc 1\n" +
+                "card-2,Straw Man,fallacy,/img/2.png,Desc 2\n";
+
+            var cards = TestFallacyCard.LoadFromContent(csv);
+
+            cards.Should().HaveCount(2);
+            cards[0].Id.Should().Be("card-1");
+            cards[1].Id.Should().Be("card-2");
+        }
+    }
+}


### PR DESCRIPTION
## What

Add `TestFallacyCardClassMapRegressionTests` — **5 contract tests** that **close the ClassMap matrix at 100%**. **Additive only, no production code change.** Full suite **434/0/5**.

This is the ai-01 **SECONDAIRE** dispatch (`msg-20260620T094434-yj9f75`: "TestFallacyCard ClassMap — dernier gap de la matrice ClassMap, ferme la matrice à 100%").

## Why

`TestFallacyCard` was the **last entity ClassMap without a dedicated regression suite**. The ClassMap matrix is now complete:

| Entity | Coverage |
|---|---|
| Fallacy | `FallacyClassMapRegressionTests` (#485) |
| Rule / ArgumentVirtue / Scenario | `EntityClassMapRegressionTests` (#476) |
| Virtue | `VirtueClassMapRegressionTests` (#559) |
| DnnUiString | `DnnUiStringClassMapRegressionTests` |
| **TestFallacyCard** | **this PR** ✅ |

`TestFallacyCard` is the simplified fallacy entity for visual-test card generation. Its ClassMap declares **5 columns ALL required** (non-`.Optional()`): `Id`, `Title`, `Type`, `IllustrationPath`, `Description`. A header-name drift = silent null properties = empty visual-test cards.

## The 5 tests

| Test | What it pins |
|---|---|
| `MapsAllColumns` | all 5 required columns map to their properties |
| `GetIdReturnsId` | `GetId()` returns `Id` — the image-generator output-dictionary key |
| `RequiredColumnAbsent_Throws` | a required column drift fails LOUD (`HeaderValidationException`), not silent null — the data-loss-prevention contract |
| `ShortRow_DoesNotThrow` | a ragged row yields `string.Empty` for missing fields (`MissingFieldFound` is a log callback, not throw) — mirrors `CsvBaseStrictContractTests` |
| `MultipleRows_LoadInOrder` | multi-row load preserves order |

## Verification

- **New tests**: 5/5 pass.
- **Full suite**: **434 passed / 0 failed / 5 skipped** — no regression (baseline 429 + 5 new).
- Build: 0 errors.
- No production code touched — pure additive coverage.

## Related

- Dispatched by: ai-01 SECONDAIRE (`msg-20260620T094434-yj9f75`).
- Closes the ClassMap matrix (companion to #485 Fallacy, #476 Rule/ArgumentVirtue/Scenario, #559 Virtue).
- DoD: additive tests only — mergeable without a content gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
