### PR TITLE
test(pdf): #204 pin GetLocalizedFileName contract + document replace-all edge (10 tests)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/LocalizedFileNameContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/LocalizedFileNameContractTests.cs
@@ -1,0 +1,144 @@
+using Argumentum.AssetConverter;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
+{
+    /// <summary>
+    /// Contract pin for <see cref="CardSetLocalization.GetLocalizedFileName"/> — #204 idle (cont.
+    /// po-2024): the localized-filename transform contract.
+    ///
+    /// When the pipeline localizes a CardSet, it derives the output template filename from the
+    /// default-language one by swapping (or inserting) the language code. That derived filename
+    /// drives which template gets loaded for each language — if it is wrong, the wrong template (or
+    /// none) is loaded, silently producing cards in the wrong language or no cards at all.
+    ///
+    /// <see cref="CardSetLocalization.GetLocalizedFileName"/> is a pure, deterministic string
+    /// transform (no I/O) with three branches and several subtle edge cases (substring matches,
+    /// multiple occurrences, multi-dot filenames) that had ZERO unit coverage. These tests pin the
+    /// contract additively so a refactor cannot silently change which template a language resolves to.
+    /// </summary>
+    public class LocalizedFileNameContractTests
+    {
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (1) EMPTY / NULL — passed through untouched (guard clause).
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void EmptyOrNull_ReturnedAsIs(string fileName)
+        {
+            // The first guard returns the input verbatim, so no language substitution is attempted.
+            CardSetLocalization.GetLocalizedFileName(fileName, "fr", "en")
+                .Should().Be(fileName, "an empty/null filename cannot be localized and is returned as-is.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (2) CONTAINS _{defaultLanguage} — replaced (the happy path for standard templates).
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ContainsDefaultLanguageToken_ReplacedWithTarget()
+        {
+            // Standard template: Argumentum_Fallacies_fr.json → ..._en.json
+            CardSetLocalization.GetLocalizedFileName("Argumentum_Fallacies_fr.json", "fr", "en")
+                .Should().Be("Argumentum_Fallacies_en.json",
+                    "when the filename carries the default-language token, it is swapped for the target.");
+        }
+
+        [Fact]
+        public void ContainsDefaultLanguageToken_PreservesPathAndExtension()
+        {
+            // A path with subdirectories: the token is replaced in place, the rest of the path is kept.
+            CardSetLocalization.GetLocalizedFileName(@"locales\cards_fr.json", "fr", "pt")
+                .Should().Be(@"locales\cards_pt.json");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (3) SUBSTRING MATCH — the token must be preceded by '_'. A bare substring of the language
+        //     code elsewhere in the name is NOT matched and falls through to the insertion branch.
+        //     Pins the Contains($"_{defaultLanguage}") guard so a regression to a plain language-code
+        //     Contains (which would misfire on "french.json") is caught.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void LanguageCodeWithoutUnderscore_NotMatched_InsertedBeforeExtension()
+        {
+            // "french.json" CONTAINS "fr" but NOT "_fr" → falls through to the insertion branch.
+            CardSetLocalization.GetLocalizedFileName("french.json", "fr", "en")
+                .Should().Be("french_en.json",
+                    "the match requires a leading underscore, so 'french' is not mistaken for the 'fr' token.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (4) MULTIPLE OCCURRENCES — string.Replace replaces ALL matches, not just the language-tag
+        //     one. A filename that legitimately contains the token twice (e.g. a templated name)
+        //     gets both swapped. This is THE fragile bit: a future "replace only the last segment"
+        //     refactor would change behavior. Pinned as-is.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void MultipleTokenOccurrences_AllReplaced()
+        {
+            // my_fr_cards_fr.json → my_en_cards_en.json (BOTH occurrences replaced, not just the last).
+            CardSetLocalization.GetLocalizedFileName("my_fr_cards_fr.json", "fr", "en")
+                .Should().Be("my_en_cards_en.json",
+                    "the implementation uses string.Replace which swaps every occurrence; a filename with " +
+                    "two tokens has both replaced. Documenting the contract — a surgical 'last-only' fix " +
+                    "would belong in a separate behavior-change PR.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (5) NO TOKEN, HAS EXTENSION — the target code is inserted before the extension.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void NoToken_WithExtension_TargetInsertedBeforeExtension()
+        {
+            // cards.json (no language token) → cards_en.json
+            CardSetLocalization.GetLocalizedFileName("cards.json", "fr", "en")
+                .Should().Be("cards_en.json");
+        }
+
+        [Fact]
+        public void MultiDotFilename_OnlyLastExtensionTreatedAsExtension()
+        {
+            // Path.GetExtension treats only the LAST dot as the extension: Cards.v2.json →
+            // GetFileNameWithoutExtension = "Cards.v2", extension = ".json" → Cards.v2_en.json.
+            CardSetLocalization.GetLocalizedFileName("Cards.v2.json", "fr", "en")
+                .Should().Be("Cards.v2_en.json",
+                    "only the final segment after the last dot is treated as the extension, so a versioned " +
+                    "name like Cards.v2 keeps its '.v2' infix.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (6) NO TOKEN, NO EXTENSION — the target code is appended.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void NoToken_NoExtension_TargetAppended()
+        {
+            // cards (no dot at all) → cards_en
+            CardSetLocalization.GetLocalizedFileName("cards", "fr", "en")
+                .Should().Be("cards_en");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (7) ROUND-TRIP NEUTRALITY — localizing back to the default language restores the original
+        //     for the happy path. Guards against asymmetric swaps.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void RoundTrip_ToTargetAndBack_RestoresOriginal()
+        {
+            const string original = "Argumentum_Fallacies_fr.json";
+
+            var localized = CardSetLocalization.GetLocalizedFileName(original, "fr", "en");
+            var restored = CardSetLocalization.GetLocalizedFileName(localized, "en", "fr");
+
+            restored.Should().Be(original,
+                "swapping to the target and back should restore the original for the standard token case.");
+        }
+    }
+}


### PR DESCRIPTION
## What

Add 10 contract tests for `CardSetLocalization.GetLocalizedFileName` — the pure string transform that derives each language's template filename from the default-language one. Part of the #204 output-neutral coverage lane (cont. po-2024).

## Why

`GetLocalizedFileName(fileName, defaultLanguage, targetLanguage)` drives which CardPen template gets loaded for each language: the pipeline localizes the default template path by swapping/inserting the language code. A wrong swap silently loads the wrong template (cards in the wrong language, or no cards). It is a pure, deterministic string transform (no I/O) with **three branches and several subtle edge cases** — and it had **zero unit coverage**.

This was the idle fallback of ai-01's dispatch (`msg-...171324`): *"#204 tests du pur GetLocalizedFileName (low-risk, déjà pure, juste tests)."* Selected after the dispatched Primary (#192 trad quality) and Secondary (#29 memory) had **no actionable surgical target** this tick (see investigation below).

## Contract pinned (10 tests)

1. **Empty/null** → returned as-is (guard clause)
2. **Contains `_{defaultLanguage}`** → replaced with target (happy path: `Argumentum_Fallacies_fr.json` → `..._en.json`)
3. **Path preserved** through replacement (`locales\cards_fr.json` → `locales\cards_pt.json`)
4. **Substring guard** — the match requires a leading `_`, so `french.json` (contains `fr` but not `_fr`) is NOT misread → falls through to insertion (`french_en.json`)
5. **Multiple occurrences — ALL replaced** (documented as-is): `my_fr_cards_fr.json` → `my_en_cards_en.json`. The implementation uses `string.Replace` which swaps every occurrence. A future "replace only the last language tag" would change behavior — flagged for a separate behavior-change PR, not fixed here (No-Pendulum).
6. **No token + extension** → inserted before extension (`cards.json` → `cards_en.json`)
7. **Multi-dot filename** — only the last dot is the extension (`Cards.v2.json` → `Cards.v2_en.json`, keeps the `.v2` infix)
8. **No token + no extension** → appended (`cards` → `cards_en`)
9. **Round-trip neutrality** — swap to target then back restores the original (guards asymmetric swaps)

## Investigation context — why #192 and #29 were skipped this tick

Per the dispatch's deep-queue order, I investigated the Primary (#192 trad quality) and Secondary (#29 memory) **before** falling back to this idle task:

- **#192 (Primaire)** — scanned all translation CSVs (Fallacies/Scenarii/Rules/Virtues × EN/RU/PT) for a measurable quality gap. Result: **no surgical target detectable**. The "12 contaminated example_pt cells" surfaced by the initial scan were false positives (proper nouns `Joana d'Arc`/`La Fontaine`, FR↔PT lexical coincidences like `mais`/`est`). Strict scan for impossible-in-PT French elisions (`l'`/`qu'`/`c'est`) → **0 cells**. Exact FR==target copies → **0** everywhere. The #216 contamination bug was correctly fixed; residual quality is polish requiring **native-speaker judgment** (not a grep-able gap) — gated to jsboige/locuteurs per the dispatch.
- **#29 (Secondaire)** — confirmed **#436 (deterministic Magick.NET dispose, P0 memory fix) is MERGED and in place** (`PdfManager.GeneratePdfsFromImages` uses `using var collection`). The P0 fix is delivered; #29 is closable with this proof. A dispose regression test is feasible but fragile to design (MagickImageCollection dispose isn't publicly observable; WeakReference/GC tests are flaky) — deferred rather than rushed.

Falling back to the clean idle task (this PR) rather than forcing a fragile/incorrect fix respects No-Pendulum. Both findings are reported to ai-01 for lane redirection.

## Verification

- `dotnet test --filter LocalizedFileNameContractTests` → **10/10 pass**
- Full suite → **453/0/5** (baseline 443 + 10). 0 regression.
- Build: 0 error (only preexisting nullable warnings).
