### PR TITLE
test(ontology): #204 pin OwlDocumentConfig.GetId IRI-fragment transform (10 tests)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlGetIdPureContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlGetIdPureContractTests.cs
@@ -1,0 +1,130 @@
+using Argumentum.AssetConverter.Ontology;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Ontology
+{
+    /// <summary>
+    /// Contract pin for <see cref="OwlDocumentConfig.GetId"/> — #204 coverage sweep (cont. po-2024):
+    /// the OWL IRI-fragment transform contract.
+    ///
+    /// The OWL generator turns each fallacy's display name into the fragment identifier of its concept
+    /// IRI (e.g. <c>https://www.argumentum.games/...#AdHominem</c>). That transform is
+    /// <see cref="OwlDocumentConfig.GetId"/>: Humanizer <c>Camelize()</c> (PascalCase join) then strip
+    /// apostrophes, hyphens and commas — characters forbidden in IRI fragments. A bug here produces
+    /// duplicate or invalid concept IRIs, which silently corrupts the generated ontology (collision,
+    /// or a fragment that breaks IRI resolution). It is pure &amp; deterministic — no I/O, no config
+    /// state — yet had ZERO isolated coverage (the E2E ontology tests exercise it only indirectly).
+    /// These tests pin the contract additively.
+    /// </summary>
+    public class OwlGetIdPureContractTests
+    {
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (1) Camelize — Humanizer Camelize() produces camelCase (first segment lowercased, subsequent
+        //     segments kept/uppercased-on-first-letter) and joins the words into a single token. The
+        //     exact outputs below were captured from the real Humanizer 2.14.1 transform.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("Ad Hominem", "adHominem")]
+        [InlineData("straw man", "strawMan")]
+        [InlineData("red herring", "redHerring")]
+        [InlineData("Hasty Generalization", "hastyGeneralization")]
+        public void Camelize_JoinsWordsCamelCase_NoSpaces(string input, string expected)
+        {
+            OwlDocumentConfig.GetId(input).Should().Be(expected,
+                "Camelize() joins the words into a single camelCase token, dropping the spaces.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (2) Apostrophes stripped — French elisions (l', d', qu') would otherwise land in the IRI.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Apostrophes_Stripped()
+        {
+            // "L'appel" → Camelize "l'appel" → apostrophe stripped → "lappel".
+            OwlDocumentConfig.GetId("L'appel").Should().Be("lappel",
+                "apostrophes are stripped after Camelize so French elisions don't leak into the IRI fragment.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (3) Hyphens stripped — compound names ("A-B") would create an invalid fragment otherwise.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Hyphens_Stripped()
+        {
+            // "A-B" → Camelize "a-b" → hyphen stripped → "aB".
+            OwlDocumentConfig.GetId("A-B").Should().Be("aB",
+                "hyphens are stripped so compound names produce a valid IRI fragment.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (4) Commas stripped.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Commas_Stripped()
+        {
+            // "A, B" → Camelize "a, b" → comma stripped → "aB".
+            OwlDocumentConfig.GetId("A, B").Should().Be("aB",
+                "commas are stripped so list-style names produce a valid IRI fragment.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (5) End-to-end on a realistic French fallacy name — the canonical use case. NOTE: Humanizer
+        //     Camelize() PRESERVES accented characters (it does not ASCII-fold), so "à" survives and is
+        //     uppercased to "À" at the segment start. This is the OBSERVED contract — the fragment is
+        //     apostrophe/hyphen/comma/space-free but may contain accented letters. Pinned exactly so a
+        //     future Humanizer upgrade (or an added ASCII-fold) that changes accent handling is caught.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void FrenchFallacyName_ProducesFragment_AccentsPreserved()
+        {
+            // "Appel à l'autorité" → Camelize "appel À l'autorité" → apostrophe stripped → "appelÀLautorité".
+            OwlDocumentConfig.GetId("Appel à l'autorité").Should().Be("appelÀLautorité",
+                "Camelize joins the words camelCase, preserves the accented 'à' (uppercased to 'À' at the " +
+                "segment start), and the trailing Replace chain strips only apostrophes/hyphens/commas.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (6) DETERMINISM — same input always yields the same output (pure function).
+        //     Guards against a refactor that introduces state/time/randomness.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Deterministic_SameInput_SameOutput()
+        {
+            const string input = "Hasty Generalization";
+            var first = OwlDocumentConfig.GetId(input);
+            var second = OwlDocumentConfig.GetId(input);
+
+            first.Should().Be(second, "GetId is a pure function — identical inputs produce identical fragments.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (7) NO forbidden characters remain — the generic invariant the OWL generator relies on.
+        //     Regardless of input, the fragment must never contain ', -, or ,.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Result_NeverContainsForbiddenChars()
+        {
+            var inputs = new[]
+            {
+                "Ad Hominem", "L'appel à l'autorité", "A-B, C", "red-herring",
+                "tu, quoque", "Slippery Slope", "post hoc", "Ménage à trois",
+            };
+
+            foreach (var input in inputs)
+            {
+                var id = OwlDocumentConfig.GetId(input);
+                id.Should().NotContain("'", $"fragment for '{input}' must be apostrophe-free");
+                id.Should().NotContain("-", $"fragment for '{input}' must be hyphen-free");
+                id.Should().NotContain(",", $"fragment for '{input}' must be comma-free");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Pin the OWL IRI-fragment transform contract for `OwlDocumentConfig.GetId(string)` — a pure, deterministic helper surfaced by the #204 coverage sweep with **zero isolated coverage**.

## Why

The OWL generator turns each fallacy's display name into the fragment identifier of its concept IRI (e.g. `https://www.argumentum.games/...#AdHominem`). That transform is `GetId`: Humanizer `Camelize()` (camelCase join) then strip apostrophes, hyphens and commas — characters forbidden in IRI fragments. A bug here produces duplicate or invalid concept IRIs, which silently corrupts the generated ontology (collision, or a fragment that breaks IRI resolution). It is pure & deterministic — no I/O, no config state — yet the E2E ontology tests exercise it only indirectly. These tests pin the contract additively.

## Tests added (10)

All exact-match against real Humanizer 2.14.1 output (captured via a standalone probe — see note below):

- **Camelize joins words camelCase** (4 Theory cases): `"Ad Hominem"→"adHominem"`, `"straw man"→"strawMan"`, `"red herring"→"redHerring"`, `"Hasty Generalization"→"hastyGeneralization"`
- **Apostrophes stripped**: `"L'appel"→"lappel"` (French elisions don't leak into the IRI)
- **Hyphens stripped**: `"A-B"→"aB"` (compound names produce a valid fragment)
- **Commas stripped**: `"A, B"→"aB"` (list-style names produce a valid fragment)
- **End-to-end French fallacy name**: `"Appel à l'autorité"→"appelÀLautorité"`
- **Determinism** — pure function, identical inputs → identical fragments
- **Generic invariant** — across 8 inputs (incl. accented + compound), the fragment never contains `'`, `-`, or `,`

## Finding pinned (not fixed)

Humanizer `Camelize()` **preserves accented characters** (it does not ASCII-fold): `"à"` survives and is uppercased to `"À"` at the segment start. This is the **observed contract** — the fragment is apostrophe/hyphen/comma/space-free but may contain accented letters. Pinned exactly so a future Humanizer upgrade (or an added ASCII-fold) that changes accent handling is caught. Accented IRI fragments are technically valid (IRIs allow non-ASCII per RFC 3987); if strict-ASCII URIs were ever required, `GetId` is the place that would change. Acted on separately if at all — this PR is output-neutral, additive tests only (no production code changed).

## Verification

- `dotnet test --filter OwlGetIdPureContractTests` → **10/10 pass**
- Full suite → **479/0/5** (baseline 469 + 10). 0 regression.
- Build: 0 error (only preexisting nullable warnings).

## Probe note

Humanizer `Camelize()` output is non-obvious (camelCase, not PascalCase; accents preserved, not folded). I captured the real outputs from Humanizer 2.14.1 via a standalone console probe before writing the assertions, so the expected values are observed behavior — not assumptions.

Continues the #204 lane per ai-01's dispatch ("enchaîne deep-queue #204 ; pas de stall").
