### PR TITLE
docs(dnn): #457 correct document-tier structure — verified tag counts + taxonomy overlap

### DIFF
--- a/docs/dnn-localization/457-document-tier-translation-workflow.md
+++ b/docs/dnn-localization/457-document-tier-translation-workflow.md
@@ -17,6 +17,51 @@ From the Phase 1 inventory §3, the document-tier content is **2 standalone FR H
 
 Total: ~37,300 chars of FR prose across 2 files. These are **standalone FR content** — translating them is a document/prose task (like Scenarii narrative fields), **not** a key-value dictionary task (like `ui.*`/`res.*`).
 
+> ### ⚠️ VERIFICATION UPDATE (2026-06-22, po-2024) — the §1/§4 structure figures above are PRE-VERIFICATION ESTIMATES and are INCORRECT
+>
+> The table + §4 selector design were written from the inventory's character-budget estimate, **not** from
+> parsing the files. An actual structural probe (`grep` tag counts + content sampling) on 2026-06-22 by
+> po-2024 (taking over this lane from po-2023) shows the real structure differs materially, which changes
+> both the extraction cost and the value of this lane:
+>
+> **`fallacies.html` (81 KB) — verified tag counts:** `2 <h2>` + `2 <h3>` + `8 <li>` (jQuery-UI tab labels:
+> "Manipulations de l'esprit", "Appel aux émotions"…) + **`56 <h4>`** (fallacy NAMES — "Argument d'autorité",
+> "Appel à la pratique courante", "Raison de la majorité"…) + `114 <p>` (almost entirely boilerplate labels
+> "Code Html à copier:" / "PhpBB Html Replacement:" preceding code blocks, **not** fallacy descriptions) +
+> `55 <textarea>` + `55 <form>` (HTML code samples to copy-paste — **code, not prose, skip**).
+>
+> - **It is a developer integration charte** (how to embed the fallacy infographic PNG into a page/phpBB),
+>   NOT a fallacy glossary. Fallacy *definitions* are not in this file (they live in the infographic + the
+>   taxonomy CSV).
+> - **The 56 `<h4>` fallacy names DUPLICATE the taxonomy CSV** (`Cards/Fallacies/...Taxonomy.csv`, already
+>   translated 8-language). Translating them here = **duplicate work** — they should be **joined from the
+>   taxonomy CSV**, not re-translated. Genuine NEW translatable surface = ~4 section/tab titles (h2/h3/li) +
+>   ~3 boilerplate labels (p) ≈ **7 short strings**.
+>
+> **`MariagePourTous.html` (38 KB) — verified tag counts:** `103 <div>` + `102 <a>` + **`0 <p>`, `0 <h2>`,
+> `0 <h3>`, `1 <li>`**. The §4 assumption ("prose, selectors `p, h2, h3`") is **invalid** — there are no
+> `p`/`h2`/`h3` elements. The prose is **bare text between `<div class="fallacieContainer">` blocks**, and
+> each argument line (e.g. "01. Parce que dans le dico, le mariage c'est l'union légale…") appears
+> **duplicated** — once as bare text, once inside a `fallacieContainer` div — interleaved with dictionary
+> definitions and source citations. Correct extraction needs **text-node walking of `<div class="texte">`**
+> and **dedup** of the bare-text/container pair, not a `p`/`h2`/`h3` selector sweep.
+>
+> **Net effect on the lane (honest assessment):**
+>
+> - `fallacies.html` is **low-value + partly duplicate** (7 new strings; 56 h4 joinable from taxonomy CSV;
+>   role = deprecated-looking dev charte — po-2023 flagged it "almost certainly not in v0.9.0 nav").
+> - `MariagePourTous.html` is **1 essay of uncertain scope** with a **non-trivial bare-text dedup**
+>   extraction (no clean selectors).
+> - Combined with the **unanswered scope gate** (§8 Q3: are these 2 pages even served in v0.9.0?), building
+>   the §4 extractor + spending gpt-5.5 translation budget now risks duplicate/possibly-deprecated work.
+>
+> **Recommendation (po-2024, surfaced to ai-01):** **defer the §4 extractor build and any translation**
+> until jsboige resolves §8 Q3 (live-nav scope). If `fallacies.html` is confirmed out-of-scope (likely),
+> only `MariagePourTous.html` remains — a single essay, where a bespoke segment pass is proportionate.
+> The §4 selector design below must be corrected against the verified structure before any build. **This
+> lane is NOT a blocker for v0.9.0** (string tier A/B is complete; fallacy bodies are already 8-lang via
+> the taxonomy CSV); it is a nice-to-have pending a scope decision.
+
 **Out of scope of this doc (covered elsewhere):**
 - String tier (`ui.*`/`res.*`) → [tools/dnn_i18n/README.md](../../tools/dnn_i18n/README.md) + DatasetUpdater config #487.
 - Fallacies Explorer / Rules Explorer → already CSV-driven via 2sxc queries (taxonomy CSVs already localized 8-lang).


### PR DESCRIPTION
## What

Correct the document-tier structure figures in `457-document-tier-translation-workflow.md` — the §1 table and §4 selector design were pre-verification estimates that don't match the actual files.

Extends **#457 Phase 1** (po-2024 taking over the lane from po-2023).

## Why

The workflow doc (merged #557) specified extraction selectors (`p, h2, h3` for MariagePourTous; `h2, h3, li` for fallacies) **without parsing the files**. A structural probe (grep tag counts + content sampling) shows both assumptions are wrong, and surfaces a key finding: **the 56 `<h4>` fallacy names in `fallacies.html` duplicate the taxonomy CSV (already 8-language translated)** — translating them would be duplicate work.

## Verified findings

| File | Doc assumed | Actual (verified) |
|------|-------------|-------------------|
| `fallacies.html` | 2 h2 + 2 h3 + 10 li, "integration charte with worked fallacy examples" | 2 h2 + 2 h3 + **8 li** (tab labels) + **56 h4** (fallacy NAMES — duplicate of taxonomy CSV) + 114 p (boilerplate "Code Html à copier:" labels, NOT descriptions) + 55 textarea (code samples, skip). **Developer integration charte, not a glossary.** Genuine NEW surface ≈ 7 strings. |
| `MariagePourTous.html` | "prose, selectors p/h2/h3" | **0 p / 0 h2 / 0 h3** — assumption **INVALID**. Bare text between `<div class="fallacieContainer">`, duplicated. Needs text-node walk + dedup. |

## Recommendation (surfaced to ai-01)

**Defer the §4 extractor build + gpt-5.5 translation** until jsboige resolves §8 Q3 (are these 2 pages served in v0.9.0?). The lane is **low-value + partly duplicate + scope-uncertain**, and is **NOT a v0.9.0 blocker** (string tier A/B complete via #490; fallacy bodies already 8-lang via the taxonomy CSV).

The verification block is inserted as a `> ⚠️ VERIFICATION UPDATE` after §1 — preserves po-2023's original as history, consistent with the repo's superseded-doc convention (see `README.md` §3).

## Verification

- Doc-only change (no code, no tests, no prod mutation, no DNN/DB touch).
- markdownlint: 0 warnings (fixed the 2 inline-`+`/blank-line warnings the insert initially tripped).

## Context

Cluster: ai-01 + po-2024 (po-2023 lost). ai-01 dispatched #457 Phase 1 (extract + translate DNN content). Verify-before-code showed the repo-slice (A/B string-tier) is already complete (#490), so this tick audited content-type C (the 2 HTML pages) — the only remaining repo-extractable slice. The audit revealed C is low-value/partly-duplicate/scope-uncertain → extractor **deferred** (No-Pendulum: don't churn a low-value extractor + duplicate translation on possibly-deprecated content).

Separately this tick: **Freeplane 1.12.x installed** (`LOCALAPPDATA\Programs\Freeplane\freeplane.exe`, AMEND mandate) — unblocks the next lanes (#568 headless export, TRACK 1 mindmap regen).
