### PR TITLE
docs(mindmap): #568 document Freeplane 1.13.2 probe + disconnected-session factor

### DIFF
--- a/docs/investigations/2026-06-21-mindmap-reliability-without-rdp.md
+++ b/docs/investigations/2026-06-21-mindmap-reliability-without-rdp.md
@@ -161,6 +161,27 @@ Freeplane **refuse d'ouvrir** le `.mm` au format FreeMind du pipeline : *« Le f
 
 Le fallback XSLT (`TryXsltSvgConversion`) existe en code mort. [PR #157](https://github.com/ArgumentumGames/Argumentum/pull/157) l'avait ajouté ; **[PR #184](https://github.com/ArgumentumGames/Argumentum/pull/184) l'a délibérément retiré** (« placeholder », fidélité inférieure aux SVG Batik FreeMind). Décision jsboige confirmée : *« Je ne pense pas que tu puisses faire aussi bien en XSLT que ce que FreeMind fait »*. **Ne pas re-câbler le XSLT** sans GO explicite.
 
+### 3.6 Re-probe 2026-06-22 (po-2024, Freeplane 1.13.2 + session déconnectée)
+
+Reprise du de-risk §3.2 sur **Freeplane 1.13.2** (latest ; po-2023 avait 1.12.x), installé cette session sous `%LOCALAPPDATA%\Programs\Freeplane\` (mandate AMEND 2026-06-22 : *installer les outils manquants plutôt que HOLD*).
+
+**Setup déployé — persistant, prêt pour un prochain run (step 3 du §3.4 partiellement fait) :**
+
+- `auto.properties` (6 booléens §3.2) + `export_to_svg.groovy` posés dans `%APPDATA%\Freeplane\{1.12.x,1.13.x}\`.
+- Probe : `freeplane.exe -S -R"<groovy>" fallacy_map.mm` (sample `.mm` FreeMind minimal, `<map version="1.0.1">`).
+
+**Résultat : INCONCLUSIF.**
+
+| Test | Résultat |
+|------|----------|
+| `freeplane.exe -S -R<groovy>` (GUI, session « Déco ») | ❌ aucun marqueur `.export_done` après 90 s (process encore en vie) |
+| Logs / sortie script | vides (console interne Freeplane, cf. §3.2 ; aucun `.log`) |
+| `freeplaneConsole.exe -N` (headless) | ❌ **hang** — ne termine pas, sortie vide après 12 s (confirme §3.2 « headless casse le rendu ») |
+
+**Lecture (ne surdéclare pas).** Ce probe n'isole **pas** si le bloqueur §3.3 (rejet du format FreeMind) tient sur 1.13.2 — le script n'a pas pu être confirmé exécuté. Il soulève en revanche un **nouveau facteur environnemental** : la session était **« Déco » (RDP déconnectée, SessionId 2)**. Or §3.1 affirme *« RDP peut être déconnectée/inactive, aucun bureau actif requis »*. L'échec sur session *déconnectée* vs le succès §3.2 de po-2023 (session vraisemblablement *connectée*) suggère que `c.export()` peut exiger une session **connectée** (bureau vivant), pas seulement *existante*. Affinement à confirmer : **« déconnecté » ≠ « connecté-inactif »**.
+
+**Conclusion pour [#568](https://github.com/ArgumentumGames/Argumentum/issues/568).** Le path `c.export()` reste **hard/exigeant en environnement** ; la sérialisation native Freeplane (§3.4 step 1) reste le vrai travail, multi-tick + QA visuelle ai-01/jsboige (moteur ≠ Batik). N'a **pas** rétrogradé vers XSLT (§3.5 : interdit). Prochaines tentatives : re-tester sur une session **connectée** (isoler §3.3 vs facteur session) avant d'investir dans la sérialisation native.
+
 ---
 
 ## 4. Références


### PR DESCRIPTION
## What

Append a **section 3.6 verification update** to [`docs/investigations/2026-06-21-mindmap-reliability-without-rdp.md`](docs/investigations/2026-06-21-mindmap-reliability-without-rdp.md) (po-2023's #568 investigation), recording a 2026-06-22 follow-up probe by po-2024 on **Freeplane 1.13.2** (latest; po-2023 tested 1.12.x).

Tracks **[#568](https://github.com/ArgumentumGames/Argumentum/issues/568)** (Freeplane headless `c.export()` export — remove the FreeMind SendKeys / active-foreground dependency).

## Why

po-2023's section 3.2 de-risk was on 1.12.x. Before investing in the real work (native Freeplane serialization, section 3.4 step 1 — multi-tick + visual QA), I re-ran the `c.export()` probe on the current latest build (1.13.2) to confirm the blocker still holds. The probe was **inconclusive** but surfaced a genuinely new environmental factor the doc didn't have.

## Setup deployed (persistent — benefits a future run)

- Freeplane **1.13.2** installed (`%LOCALAPPDATA%\Programs\Freeplane\`, AMEND mandate: install missing tools rather than HOLD).
- `auto.properties` (6 permission booleans) + `export_to_svg.groovy` written to `%APPDATA%\Freeplane\{1.12.x,1.13.x}\` — **section 3.4 step 3 now partially done**.

## Findings

| Test | Result |
|------|--------|
| `freeplane.exe -S -R<groovy>` (GUI, session "Déco") | ❌ no `.export_done` marker after 90s (process still alive); logs empty |
| `freeplaneConsole.exe -N` (headless) | ❌ **hang** (confirms section 3.2: headless breaks render) |

**Inconclusive on the core blocker.** The probe does **not** isolate whether section 3.3 (Freeplane rejects FreeMind-format `.mm`) still holds on 1.13.2 — the script could not be confirmed executed (output hidden in Freeplane's internal console).

**New environmental factor (the real contribution).** Section 3.1 claims *"RDP can be disconnected/inactive, no active desktop needed"*. My probe failed on a **disconnected** ("Déco") session, while po-2023's section 3.2 success was likely on a **connected** session. This suggests `c.export()` may require a **connected** (live) desktop, not merely an *existing* one — i.e. **"disconnected" ≠ "connected-inactive"**. That refines the #568 viability claim and is worth confirming before the native-serialization investment.

## Conclusion for #568

The `c.export()` path remains **hard / env-demanding**; native Freeplane serialization (section 3.4 step 1) is still the real work (multi-tick + ai-01/jsboige visual QA — engine ≠ Batik). Did **not** regress to XSLT (section 3.5: forbidden, = revert of #184). **Next attempt**: re-test on a **connected** session to isolate section 3.3 vs the session factor before investing in native serialization.

## Verification

- Doc-only change (no code, no tests, no prod mutation).
- Table style matches po-2023's existing section 3.2 table in the same file (no markdownlint config / not CI-enforced — MD060 IDE warning is cosmetic and pre-existing in the document's style).

## Context

Cluster: ai-01 + po-2024 (po-2023 lost). This is verify-before-code / No-Pendulum: rather than fabricate a serializer PR on an unconfirmed premise (section 3.3 un-isolated, env flaky), document the genuine de-risk result so the next agent on #568 has the 1.13.2 data point + the session factor + the deployed permissions. Same verification-update pattern as PR #576 (#457 document-tier audit).
