### PR TITLE
build(entities): suppress CS0108 member-hiding warnings with new keyword

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Entities/ArgumentVirtue.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/ArgumentVirtue.cs
@@ -4,7 +4,7 @@ namespace Argumentum.AssetConverter.Entities;
 
 public class ArgumentVirtue : CsvBase<ArgumentVirtue, ArgumentVirtueClassMap>, ICsvBase
 {
-	public string GetId()
+	public new string GetId()
 	{
 		return Pk;
 	}

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Fallacy.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Fallacy.cs
@@ -7,7 +7,7 @@ namespace Argumentum.AssetConverter.Entities
 {
 	public class Fallacy : CsvBase<Fallacy, FallacyClassMap>, IMindMapItem, ICsvBase
 	{
-		public string GetId()
+		public new string GetId()
 		{
 			return Id;
 		}
@@ -20,7 +20,7 @@ namespace Argumentum.AssetConverter.Entities
 	       public string Description => DescFr;
 	       public string Example => ExampleFr;
 	       public string Link => LinkFrFallback;
-	          public string Id { get; set; }
+	          public new string Id { get; set; }
 
 	       public string LinkFrFallback => string.IsNullOrEmpty(LinkFr) ? LinkEn : LinkFr;
 

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Scenario.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Scenario.cs
@@ -4,7 +4,7 @@ namespace Argumentum.AssetConverter.Entities
 {
     public class Scenario : CsvBase<Scenario, ScenarioClassMap>, ICsvBase
     {
-        public string GetId()
+        public new string GetId()
         {
             return path ?? string.Empty;
         }

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/TestFallacyCard.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/TestFallacyCard.cs
@@ -10,7 +10,7 @@ namespace Argumentum.AssetConverter.Entities
         /// <summary>
         /// Identifiant unique de la carte
         /// </summary>
-        public string Id { get; set; }
+        public new string Id { get; set; }
 
         /// <summary>
         /// Titre de la fallacy
@@ -36,7 +36,7 @@ namespace Argumentum.AssetConverter.Entities
         /// Retourne l'identifiant unique pour la génération d'images
         /// </summary>
         /// <returns>L'identifiant de la carte</returns>
-        public string GetId()
+        public new string GetId()
         {
             return Id;
         }


### PR DESCRIPTION
## What

**Non-gated tech-debt cleanup**: suppress the **6 CS0108 member-hiding compiler warnings** in the CSV entity classes by adding the `new` modifier. Behavior-neutral, textbook fix.

Dispatched as po-2024's **secondary** (ai-01, post-merge #579/#580: *"dette technique non-gated — pioche réelle"*). My prior two ticks had assessed the non-gated debt as "thin" **without building the project**; this tick's build surfaced **22 warnings**, correcting that assessment.

## Why — `new` is correct and behavior-neutral

`CsvBase<T,TMap>.Id` and `CsvBase.GetId()` are **non-virtual** (verified at `CsvBase.cs:14,21`). The entities (Fallacy, Scenario, ArgumentVirtue, TestFallacyCard) redeclare `Id`/`GetId()` to map their own ID source — intentional hiding, not a bug. Without `new`, the compiler emits CS0108 on every build.

Adding `new`:
- **Documents** the intentional hiding (compiler's own recommendation).
- **Zero behavior change** — hiding is compile-time-bound identically before/after; the members still satisfy `ICsvBase.GetId()`.
- Is **`new`, not `override`** (base is non-virtual; `override` would be a compile error).

| Entity | Member | Maps to |
|---|---|---|
| Fallacy | `GetId()`, `Id` | `Id` |
| Scenario | `GetId()` | `path` |
| ArgumentVirtue | `GetId()` | `Pk` |
| TestFallacyCard | `Id`, `GetId()` | `Id` |

## Verification

- Full `--no-incremental` Debug build: **CS0108 6 → 0**; all other warning categories **unchanged** (no accidental suppression); **0 errors**.
- Tests: **533 passed / 0 failed / 5 skipped** (baseline unchanged).
- `git diff`: 4 files, 6 ins / 6 del — every hunk is exactly `public string X` → `public new string X`, indentation preserved.

## ⚠️ Other AssetConverter warnings — deliberately NOT touched (gated / regression-risky)

Surfaced by the same build scan; each is left for jsboige/ai-01 because it is gated or carries regression risk:

| Warning | Location | Why not auto-fixed |
|---|---|---|
| **CS0618** ×4 | `ImageHelper` (`ColorProfile.`→`ColorProfiles.`), `CardGridComponent` (QuestPDF `Grid`→`Table`) | **Color area** (ai-01 gated ColorExtensions-adjacent) + **QuestPDF pinned at 2022.12.12** deliberately; `Grid`→`Table` risks PDF-layout regression (CLAUDE.md flags PDF layout as fragile). |
| **CS8632** ×2 | `DatasetUpdaterConfig` (`string?` w/o `#nullable`) | Enabling `#nullable` cascades (CS8618 on uninitialized non-nullable props); removing `?` loses the author's optional-provider intent. Either fix is fiddly/lossy for 1 warning. |
| **CS0414** ×2 | `PdfManager.MmToPointsFactor` (unused field) + 1 more | **Dead-code** — ai-01 gated "dead-code [ASK]". PdfManager is PDF-area (fragile). |
| **CS0105** ×2 | `FallacyMindMapDocumentConfig` (duplicate `using System.Xml.Xsl`) | **XSLT-adjacent** — #184 deliberately removed the XSLT fallback; touching the Mindmapper XSLT file risks the gated XSLT decision. |
| **NU1903** | AutoMapper 14.0.0 (GHSA-rvv3-g6hj-g44x, high) | Dependency bump — AutoMapper backs the DatasetUpdater entity mapping; version change risks mapping regression. Flag for jsboige. |

## Context

Cluster: ai-01 + po-2023 (#568 in flight) + po-2024. No-Pendulum: I'd claimed "debt thin" for two ticks without building; this tick's build proved that wrong (22 warnings). Fixed the safe, coherent, non-gated subset (6 CS0108) and inventoried the rest for the humans rather than touching gated/risky code.

🤖 Worker po-2024 · non-gated debt cleanup · CS0108 6→0 (`new` keyword, behavior-neutral) · 533 tests pass · 4 gated/risky warning categories inventoried for jsboige
