### PR TITLE
build: eliminate all CS compiler warnings (zero-warning build for v0.9.0)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/FallacyCardTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/FallacyCardTests.cs
@@ -58,7 +58,7 @@ namespace Argumentum.AssetConverter.VisualTests
             _output.WriteLine(JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }));
             _output.WriteLine("--------------------------------------");
 
-            string imageFile = null;
+            string? imageFile = null;
             try
             {
                 // 2. Exécution "in-process"

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
@@ -1,4 +1,5 @@
-﻿using Spectre.Console;
+﻿#nullable enable annotations
+using Spectre.Console;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/ImageHelper.cs
@@ -173,7 +173,7 @@ namespace Argumentum.AssetConverter
             image.Alpha(AlphaOption.Remove);
             image.Settings.BackgroundColor = MagickColors.White;
             //image.TransformColorSpace(ColorProfile.SRGB, ColorProfile.USWebCoatedSWOP);
-            image.TransformColorSpace( ColorProfile.USWebCoatedSWOP, ColorTransformMode.Quantum);
+            image.TransformColorSpace( ColorProfiles.USWebCoatedSWOP, ColorTransformMode.Quantum);
 
             image.ColorSpace = ColorSpace.CMYK;
             image.Settings.ColorSpace = ColorSpace.CMYK;

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/FallacyMindMapDocumentConfig.cs
@@ -22,7 +22,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Threading;
-using System.Xml.Xsl;
 using Color = System.Drawing.Color;
 using Argumentum.AssetConverter.Entities;
 

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/CardGridComponent.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/CardGridComponent.cs
@@ -19,6 +19,16 @@ namespace Argumentum.AssetConverter
 
         public void Compose(IContainer container)
         {
+            // QuestPDF deprecated Grid in 2022.11 in favour of Table, but this project deliberately
+            // pins QuestPDF at 2022.12.12 (thread-safety — see CLAUDE.md stable-versions table) and is
+            // NOT upgrading it for the v0.9.0 release. Grid stays: a faithful Table migration is not
+            // possible here without a layout regression. Grid(N) means "N fixed-width columns regardless
+            // of item count" and stores N as a cheap layout parameter, so it tolerates the large/degenerate
+            // column counts that ComputePageGeometry can yield for edge configs (e.g. tiny card sizes).
+            // Materialising N explicit Table.RelativeColumn() definitions instead allocates N column
+            // objects and OOMs on those same inputs (regression caught by PdfAssemblerTests). The obsolete
+            // warning is therefore suppressed with justification rather than "fixed" by a risky rewrite.
+#pragma warning disable CS0618 // QuestPDF Grid deprecated; pinned version + no faithful Table equivalent
             container.Grid(grid =>
             {
                 grid.Columns(_columns);
@@ -36,6 +46,7 @@ namespace Argumentum.AssetConverter
                     }
                 }
             });
+#pragma warning restore CS0618
         }
     }
 }

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/PdfManager.cs
@@ -19,10 +19,6 @@ namespace Argumentum.AssetConverter
         {
         }
 
-        private const float InchToCentimetre = 2.54f;
-        private const float InchToPoints = 72;
-        private float MmToPointsFactor = 0.1f / InchToCentimetre * InchToPoints;
-
         internal void GenerateFacesOnly(string baseName, List<CardImages> cardImages, bool overwriteExistingDocs)
         {
             var targetFiles = new List<(string fileName, Func<MagickImageCollection> documentImages)>();


### PR DESCRIPTION
## Contexte

Décision jsboige (interactif, 2026-06-23) : « les 4 warnings risqués laissés intacts — **On corrige tout** ». Le build solution exposait en réalité **6 sites de warnings CS distincts** (au-delà des 4 cités). Cette PR vise un **build zéro-warning CS** comme gate de la release v0.9.0. Seul reste `NU1903` (CVE AutoMapper 14.0.0), traité dans la lane de bump de dépendance (po-2024).

## Changements (6 sites)

| Warning | Fichier | Résolution |
|---------|---------|------------|
| **CS0618** QuestPDF `Grid` obsolète | `WebBasedGenerator/CardGridComponent.cs` | **Suppression `#pragma` documentée** — PAS de migration |
| **CS0618** `ColorProfile.USWebCoatedSWOP` obsolète | `ImageHelper.cs` | Renommé `ColorProfiles.USWebCoatedSWOP` (même profil) |
| **CS8632** annotation nullable hors contexte `#nullable` | `DatasetUpdater/DatasetUpdaterConfig.cs` | `#nullable enable annotations` |
| **CS0414** champ mort `PdfManager.MmToPointsFactor` (+ consts `InchTo*` orphelins) | `WebBasedGenerator/PdfManager.cs` | Supprimés |
| **CS0105** `using System.Xml.Xsl` dupliqué | `Mindmapper/FallacyMindMapDocumentConfig.cs` | Doublon retiré |
| **CS8600** ×2 `imageFile` | `VisualTests/FallacyCardTests.cs` | Déclaré `string?` |

## Pourquoi `Grid` est suppressed et non migré vers `Table`

QuestPDF déprécie `Grid` (depuis 2022.11) au profit de `Table`, **mais ce projet pin volontairement QuestPDF à 2022.12.12** (thread-safety — cf `CLAUDE.md`) et **ne l'upgrade PAS pour v0.9.0**. Une tentative de migration `Grid`→`Table` a causé une **régression** (`OutOfMemoryException` dans `PdfAssemblerTests`) : `Grid(N)` = « N colonnes fixes indépendamment du nombre d'items », stockant `N` comme simple paramètre et tolérant les comptes dégénérés que `ComputePageGeometry` peut produire ; matérialiser `N` `RelativeColumn()` explicites OOM sur ces entrées. Conformément à **No-Pendulum**, on soustrait (suppress + justifie) plutôt que réécrire du layout éprouvé dans une zone fragile.

## Validation

- ✅ Build solution : **0 warning CS** (seul `NU1903` AutoMapper subsiste, hors scope)
- ✅ Tests unitaires : **533 passed / 0 failed / 5 skipped** (baseline préservée)
- ✅ Contrats PDF re-vérifiés après revert du `Grid` : `PdfAssemblyTests` + `PrintAndPlay*` = 23/23

## Hors scope (signalés séparément)

- `NU1903` AutoMapper CVE → lane po-2024
- `MSB3073`/SGEN (`Microsoft.XmlSerializer.Generator`) = warning outillage MSBuild préexistant, non lié au code

🤖 Generated with [Claude Code](https://claude.com/claude-code)