### PR TITLE
build: close NU1903 (AutoMapper CVE) while staying on the last free MIT version

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
+++ b/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
@@ -39,7 +39,18 @@
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="xunit.extensibility.core" Version="2.8.1" />
   </ItemGroup>
- 
+
+  <!-- NU1903: AutoMapper 14.0.0 carries GHSA-rvv3-g6hj-g44x (DoS via uncontrolled recursion). We stay on
+       14.0.0 — the LAST free MIT version; 15.0.0+ is the commercial dual-licensed line — to keep this OSS
+       repo MIT-pure (decision jsboige 2026-06-23). The vuln is NOT reachable here: the only AutoMapper
+       Profile is a flat, acyclic map (Entities/MappingProfile.cs) with an explicit MaxDepth(1) guard, so
+       the vulnerable recursion path is never taken. No free patched version exists (14.x gets no fix), so
+       this single advisory is suppressed with justification rather than "fixed" by adopting a commercial
+       dependency. Targeted suppression (this advisory only), not a blanket NoWarn. -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Data\Target\" />
     <Folder Include="Published\v1.3\" />

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/MappingProfile.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/MappingProfile.cs
@@ -24,6 +24,13 @@ public class MappingProfile : Profile
 			.ForMember(dest => dest.FamilleCamelCase, opt => opt.MapFrom(src => src.FamilyFrCamelcase))
 			.ForMember(dest => dest.Carte, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.Card) ? (int?)null : int.Parse(src.Card)))
 			.ForMember(dest => dest.DecimalPath, opt => opt.MapFrom(src =>  Decimal.Parse(src.DecimalPathPadded).ToString(CultureInfo.InvariantCulture)))
-			.ReverseMap();
+			// Belt-and-suspenders for GHSA-rvv3-g6hj-g44x (DoS via uncontrolled recursion). This map is
+			// flat and acyclic — only scalar ForMember projections — so the vulnerable recursion path is
+			// never taken on AutoMapper 14.0.0 (the last free MIT version). MaxDepth(1) makes that bound
+			// explicit on both directions, mirroring the vendor's MaxDepth-default fix, so the NU1903
+			// audit suppression in the .csproj is defensible rather than blind.
+			.MaxDepth(1)
+			.ReverseMap()
+			.MaxDepth(1);
 	}
 }


### PR DESCRIPTION
## Contexte

Suite à la décision jsboige (interactif, 2026-06-23) sur `NU1903` (AutoMapper `14.0.0`, GHSA-rvv3-g6hj-g44x / CVE-2026-32933, DoS par récursion non bornée, sévérité 7.5).

**Recherche (vérifiée)** : il n'existe **aucune version free patchée**. Le fix n'est livré que sur **15.1.1 / 16.1.1**, qui appartiennent à la **ligne commerciale dual-licence** d'AutoMapper (le passage commercial est à **v15.0** ; `14.x` ne reçoit aucun patch — confirmé par le mainteneur). **`14.0.0` EST déjà la dernière version libre MIT** — il n'y a pas de bump free possible.

**Décision jsboige** : « on reste en MIT pur, mais migre vers la dernière version libre ». → On est déjà sur la dernière version libre (`14.0.0`) ; on **garde le repo MIT-pur** et on **clôt NU1903 par justification**, sans adopter une dépendance commerciale.

## Pourquoi le vuln n'est pas atteignable ici

Le seul `Profile` AutoMapper est une map **plate et acyclique** : `CreateMap<ArgumentVirtue, Fallacy>()` avec uniquement des `ForMember` scalaires + `ReverseMap()` (cf `Entities/MappingProfile.cs`). Le chemin de récursion vulnérable n'est **jamais emprunté**.

## Changements

- **`MappingProfile.cs`** : `MaxDepth(1)` explicite dans les deux sens — reproduit le fix vendeur (MaxDepth par défaut), borne explicite (ceinture-bretelles, **output-neutral** sur une map plate).
- **`.csproj`** : `<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />` — suppression **ciblée sur CE seul advisory** (pas un `NoWarn` global), commentée avec le rationale complet.

## Validation

- ✅ Build solution : **zéro warning CS ET NU** (NU1903 clos)
- ✅ Tests : **533 passed / 0 failed / 5 skipped** (`MaxDepth(1)` vérifié output-neutral — mapping inchangé)

Avec #587 (warnings CS) + cette PR, le build est **intégralement zéro-warning** pour la release v0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)