### PR TITLE
feat(ontology): #499 Phase 2 — Virtue ClassMap + OWL generator (mono-corpus, aif:goodTenorOf)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/VirtueOwlGenerationContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/VirtueOwlGenerationContractTests.cs
@@ -1,0 +1,90 @@
+using Argumentum.AssetConverter.Ontology;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Ontology
+{
+    /// <summary>
+    /// Contract pins for #499 Phase 2 — the Virtues OWL generator (<see cref="VirtueOwlGeneratorConfig"/>
+    /// / <see cref="VirtueOwlDocumentConfig"/>). Part 2 mirrors the Fallacies OWL pass but emits
+    /// argumentum_virtues.owl, and links each Virtue concept to its Walton argumentation scheme via a
+    /// custom <c>aif:goodTenorOf</c> object property (the Virtue AIF_skosMappingType holds the FR-prose
+    /// critical question, not a skos:*Match token, so the Fallacies switch cannot fire). Cross-corpus
+    /// Virtue↔Fallacy links (crossLink_Opposes PK→URI) are deferred to Phase 3.
+    ///
+    /// These tests pin the pure, deterministic contract additively (no I/O, no pipeline run):
+    /// the IRI transform, the generator defaults, and the <c>aif:goodTenorOf</c> URI construction.
+    /// </summary>
+    public class VirtueOwlGenerationContractTests
+    {
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (1) GetId — the Virtue concept IRI fragment derives from TitleEn via the SAME transform as
+        //     the Fallacies pass (Humanizer Camelize + strip apostrophes/hyphens/commas). Pinning it
+        //     separately guards against drift between the two generator configs.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("Arguments vertueux", "argumentsVertueux")]
+        [InlineData("Rigorous language", "rigorousLanguage")]
+        public void GetId_MirrorsFallaciesIriTransform(string input, string expected)
+        {
+            VirtueOwlDocumentConfig.GetId(input).Should().Be(expected,
+                "the Virtue concept IRI fragment must use the same Camelize + strip transform as OwlDocumentConfig.GetId.");
+        }
+
+        [Fact]
+        public void GetId_StripsApostrophesHyphensCommas()
+        {
+            // Mirrors the proven OwlDocumentConfig.GetId contract (byte-identical transform), asserted
+            // on the exact same input strings so a divergence between the two configs is caught.
+            // Camelize preserves punctuation; the trailing Replace chain strips apostrophes/hyphens/commas;
+            // accented characters are preserved (Humanizer does not ASCII-fold).
+            VirtueOwlDocumentConfig.GetId("A-B").Should().Be("aB", "hyphens are stripped.");
+            VirtueOwlDocumentConfig.GetId("A, B").Should().Be("aB", "commas are stripped.");
+            VirtueOwlDocumentConfig.GetId("Appel à l'autorité").Should().Be("appelÀLautorité",
+                "apostrophes stripped, accents preserved, segment starts uppercased by Camelize.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (2) Generator defaults — lock the mono-corpus Virtues ontology identity so a config reset
+        //     never silently repoints the document name / namespace / dataset.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void DefaultConfig_EmitsVirtuesOntologyIdentity()
+        {
+            var config = new VirtueOwlGeneratorConfig();
+
+            config.DocumentConfigs.Should().ContainSingle();
+            var doc = config.DocumentConfigs[0];
+
+            doc.DocumentName.Should().Be("argumentum_virtues.owl");
+            doc.DataSet.Should().Be(KnownDataSets.VirtuesTaxonomy,
+                "the Virtues OWL pass must feed off the Virtues taxonomy dataset, not the Fallacies one.");
+            doc.OntologyNamespace.Should().Be("https://www.argumentum.games/argumentum_virtues.owl#");
+            doc.ExternalReferenceOntologyNamespaceURI.Should().StartWith("http://www.arg.dundee.ac.uk/aif#",
+                "the AIF namespace must be the Dundee AIF ontology so aif:goodTenorOf resolves externally.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (3) aif:goodTenorOf URI — the custom object property linking a Virtue to the Walton scheme
+        //     it is the good tenor of. Phase 2 carries the critical-question prose as rdfs:comment;
+        //     this predicate is the structured link. Pin the URI so Phase 3 cross-corpus can reuse it.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void GoodTenorOf_Predicate_ResolvesInAifNamespace()
+        {
+            var doc = new VirtueOwlDocumentConfig
+            {
+                ExternalReferenceOntologyNamespaceURI = "http://www.arg.dundee.ac.uk/aif#"
+            };
+
+            // Mirrors the URI assembled in VirtueOwlDocumentConfig.CreateVirtueOwlDocument.
+            var goodTenorOfUri = $"{doc.ExternalReferenceOntologyNamespaceURI}goodTenorOf";
+
+            goodTenorOfUri.Should().Be("http://www.arg.dundee.ac.uk/aif#goodTenorOf",
+                "aif:goodTenorOf must live in the AIF namespace (already used by the Fallacies pass), not a new namespace.");
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/VirtueClassMapRegressionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/VirtueClassMapRegressionTests.cs
@@ -159,5 +159,73 @@ namespace Argumentum.AssetConverter.Tests.Parsing
             act.Should().Throw<HeaderValidationException>(
                 "title_fr is a non-Optional column; its absence must fail loud, not silently null the property");
         }
+
+        /// <summary>
+        /// #499 Phase 1 — the 12 relational/AIF columns appended to the Virtues prod CSV map to their
+        /// properties when present. The representative row mirrors prod pk=71 (the "Valid results"
+        /// Virtue, Math-accuracy family): crossLink_Opposes is the semicolon list of prevented Fallacy
+        /// PKs, AIF_skosDirectRef the Walton scheme label, AIF_skosMappingType the FR-prose critical
+        /// question (RFC4180-quoted in prod because it contains a comma). The 9 structural-empty
+        /// columns stay null — a Virtue's only cross-taxon link is "Opposes" its prevented family.
+        /// </summary>
+        [Fact]
+        public void Virtue_LoadFromContent_Maps499RelationalAndAifColumns()
+        {
+            var newCols =
+                "crossLink_PredatesOn,crossLink_Denounces,crossLink_Leverages,crossLink_Allows," +
+                "crossLink_Opposes,crossLink_Inverts,crossLink_Mirrors,crossLink_IsRelatedTo," +
+                "AIF_skosDirectRef,AIF_skosExceptionRef,AIF_skosOther,AIF_skosMappingType";
+            // Representative pk=71 row: 3 of 12 populated, 9 empty by design. The FR-prose
+            // AIF_skosMappingType is quoted because it contains a comma (RFC4180, as written in prod).
+            var newRow =
+                ",,,," +                         // PredatesOn, Denounces, Leverages, Allows (empty)
+                "681;690" +                      // crossLink_Opposes (prevented Fallacy PKs)
+                ",,,," +                         // Inverts, Mirrors, IsRelatedTo (empty)
+                "Argument from Sign" +           // AIF_skosDirectRef (Walton scheme label)
+                ",,," +                          // AIF_skosExceptionRef, AIF_skosOther (empty)
+                "\"Les résultats sont-ils correctement calculés, reproductibles et cohérents ?\""; // AIF_skosMappingType
+
+            var csv = VirtueRequiredHeader + "," + newCols + "\n" + VirtueRequiredRow + "," + newRow + "\n";
+
+            var virtues = Virtue.LoadFromContent(csv);
+
+            virtues.Should().ContainSingle();
+            var v = virtues[0];
+            v.CrossLinkOpposes.Should().Be("681;690");
+            v.AIFSkosDirectRef.Should().Be("Argument from Sign");
+            v.AIFSkosMappingType.Should().Be("Les résultats sont-ils correctement calculés, reproductibles et cohérents ?");
+            // 9 structural empties — empty string by design (cell present but empty in prod; the 7
+            // other relation types are Fallacy↔Fallacy internal semantics, AIF Exception/Other are
+            // Fallacy attributes). CsvHelper maps an empty cell to "", not null.
+            v.CrossLinkPredatesOn.Should().BeEmpty();
+            v.CrossLinkDenounces.Should().BeEmpty();
+            v.CrossLinkLeverages.Should().BeEmpty();
+            v.CrossLinkAllows.Should().BeEmpty();
+            v.CrossLinkInverts.Should().BeEmpty();
+            v.CrossLinkMirrors.Should().BeEmpty();
+            v.CrossLinkIsRelatedTo.Should().BeEmpty();
+            v.AIFSkosExceptionRef.Should().BeEmpty();
+            v.AIFSkosOther.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The 12 #499 columns are all .Optional() — a header set without them (a pre-#499 CSV, or a
+        /// FR-only harvest header) must load without throwing. Losing an .Optional() flag would make
+        /// HeaderValidated throw when the harvest loads a header missing the relational block.
+        /// </summary>
+        [Fact]
+        public void Virtue_LoadFromContent_499ColumnsAbsent_DoesNotThrow()
+        {
+            // VirtueRequiredHeader has none of the 12 #499 relational/AIF columns.
+            var csv = VirtueRequiredHeader + "\n" + VirtueRequiredRow + "\n";
+
+            var act = () => Virtue.LoadFromContent(csv);
+
+            act.Should().NotThrow();
+            var virtues = Virtue.LoadFromContent(csv);
+            virtues.Should().ContainSingle();
+            virtues[0].CrossLinkOpposes.Should().BeNull("crossLink_Opposes is Optional and absent → null, not throw");
+            virtues[0].AIFSkosMappingType.Should().BeNull();
+        }
     }
 }

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -284,6 +284,8 @@ namespace Argumentum.AssetConverter
 
 public OwlGeneratorConfig OwlGeneratorConfig { get; set; } = new OwlGeneratorConfig();
 
+public VirtueOwlGeneratorConfig VirtueOwlGeneratorConfig { get; set; } = new VirtueOwlGeneratorConfig();
+
 public TaxonomyValidatorConfig TaxonomyValidatorConfig { get; set; } = new TaxonomyValidatorConfig();
 
 public OwlValidatorConfig OwlValidatorConfig { get; set; } = new OwlValidatorConfig();
@@ -512,10 +514,12 @@ public string DocumentsDirectoryName { get; set; } = @"Documents\";
 				if (AsynchronousPipeline)
 				{
 					tasks.Add(Task.Run(() => OwlGeneratorConfig.Apply(this)));
+					tasks.Add(Task.Run(() => VirtueOwlGeneratorConfig.Apply(this)));
 				}
 				else
 				{
 					await OwlGeneratorConfig.Apply(this);
+					await VirtueOwlGeneratorConfig.Apply(this);
 				}
 			}
 

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Virtue.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Virtue.cs
@@ -66,6 +66,23 @@ namespace Argumentum.AssetConverter.Entities
         public string DescriptionEs { get; set; }
         public string RemarkEs { get; set; }
         public string LinkEs { get; set; }
+
+        // #499 Phase 1 — 12 relational/AIF columns appended to the Virtues prod CSV (66→78).
+        // crossLink_Opposes is the only one populated (the prevented Fallacy-family PK list);
+        // the other 7 relation types + AIF Exception/Other are structurally empty by design.
+        public string CrossLinkPredatesOn { get; set; }
+        public string CrossLinkDenounces { get; set; }
+        public string CrossLinkLeverages { get; set; }
+        public string CrossLinkAllows { get; set; }
+        public string CrossLinkOpposes { get; set; }
+        public string CrossLinkInverts { get; set; }
+        public string CrossLinkMirrors { get; set; }
+        public string CrossLinkIsRelatedTo { get; set; }
+
+        public string AIFSkosDirectRef { get; set; }
+        public string AIFSkosExceptionRef { get; set; }
+        public string AIFSkosOther { get; set; }
+        public string AIFSkosMappingType { get; set; }
     }
 
     public sealed class VirtueClassMap : ClassMap<Virtue>
@@ -122,6 +139,21 @@ namespace Argumentum.AssetConverter.Entities
             Map(m => m.DescriptionEs).Name("description_es").Optional();
             Map(m => m.RemarkEs).Name("remark_es").Optional();
             Map(m => m.LinkEs).Name("link_es").Optional();
+
+            // #499 Phase 1 — 12 relational/AIF columns. All Optional(): 9 are structurally
+            // empty by design; 3 are populated for the 222 real Virtue nodes (pk=0 root empty).
+            Map(m => m.CrossLinkPredatesOn).Name("crossLink_PredatesOn").Optional();
+            Map(m => m.CrossLinkDenounces).Name("crossLink_Denounces").Optional();
+            Map(m => m.CrossLinkLeverages).Name("crossLink_Leverages").Optional();
+            Map(m => m.CrossLinkAllows).Name("crossLink_Allows").Optional();
+            Map(m => m.CrossLinkOpposes).Name("crossLink_Opposes").Optional();
+            Map(m => m.CrossLinkInverts).Name("crossLink_Inverts").Optional();
+            Map(m => m.CrossLinkMirrors).Name("crossLink_Mirrors").Optional();
+            Map(m => m.CrossLinkIsRelatedTo).Name("crossLink_IsRelatedTo").Optional();
+            Map(m => m.AIFSkosDirectRef).Name("AIF_skosDirectRef").Optional();
+            Map(m => m.AIFSkosExceptionRef).Name("AIF_skosExceptionRef").Optional();
+            Map(m => m.AIFSkosOther).Name("AIF_skosOther").Optional();
+            Map(m => m.AIFSkosMappingType).Name("AIF_skosMappingType").Optional();
         }
     }
 }

--- a/Generation/Converters/Argumentum.AssetConverter/Ontology/VirtueOwlGeneratorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Ontology/VirtueOwlGeneratorConfig.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Argumentum.AssetConverter.Entities;
+using Argumentum.AssetConverter.Mindmapper;
+using Humanizer;
+using OWLSharp;
+using RDFSharp.Model;
+
+namespace Argumentum.AssetConverter.Ontology
+{
+    /// <summary>
+    /// #499 Phase 2 — OWL/SKOS generator for the Virtues taxonomy (mono-corpus).
+    /// Mirrors <see cref="OwlGeneratorConfig"/> (Fallacies), emitting argumentum_virtues.owl:
+    /// a concept scheme with the 7-family hierarchy (skos:narrower), one concept per Virtue node,
+    /// and a custom AIF link <c>aif:goodTenorOf</c> to the Walton argumentation scheme
+    /// declared in <see cref="Virtue.AIFSkosDirectRef"/> (the critical question prose in
+    /// <see cref="Virtue.AIFSkosMappingType"/> is carried as an rdfs:comment annotation).
+    ///
+    /// Cross-corpus Virtue↔Fallacy links (crossLink_Opposes PK→URI resolution) are deferred to
+    /// Phase 3: resolving Fallacy PKs requires loading the Fallacies corpus (new architecture,
+    /// single-dataset in this pass).
+    /// </summary>
+    public class VirtueOwlGeneratorConfig : ParallelVirtueDocumentCreatorConfigBase<VirtueOwlDocumentConfig>
+	{
+
+		public override string GetLogTitle()
+		{
+			return "Generating Virtues Owl vocabulary";
+		}
+
+		public override string GetLogMessage()
+		{
+			return "In this, an OWL vocabulary generated from the same Virtues dataset that was used for cards pdfs and mindmaps.";
+		}
+
+		public override List<VirtueOwlDocumentConfig> DocumentConfigs { get; set; } = new List<VirtueOwlDocumentConfig>(new[]
+			{
+				new VirtueOwlDocumentConfig()
+				{
+					Enabled = true,
+					DocumentName = "argumentum_virtues.owl",
+					DataSet = KnownDataSets.VirtuesTaxonomy,
+					OntologyNamespace = "https://www.argumentum.games/argumentum_virtues.owl#",
+					ExternalReferenceOntologyNamespaceURI = "http://www.arg.dundee.ac.uk/aif#",
+					ExternalReferenceOntologyUri = "http://www.arg.dundee.ac.uk/wp-content/uploads/AIF.owl",
+					Comment = "Virtuous argumentation taxonomy — the mirror of the fallacies axis (223 nodes, 7 families)",
+					Version = new Version(1,0,0),
+					Creator = "Argumentum",
+
+				}
+			});
+
+	}
+
+    /// <summary>
+    /// Document config driving the Virtues OWL pass. Mirrors <see cref="OwlDocumentConfig"/>
+    /// (Fallacies), adapted to the Virtue entity and the AIF "good tenor of a scheme" semantics.
+    /// </summary>
+    public class VirtueOwlDocumentConfig : VirtueDocumentConfigBase
+    {
+
+	    public static string GetId(string text)
+	    {
+			return text.Camelize().Replace("'","").Replace("-","").Replace(",","");
+	    }
+
+	    public string OntologyNamespace { get; set; } = "";
+
+	    public string ExternalReferenceOntologyNamespaceURI { get; set; } = "";
+
+
+	    public string ExternalReferenceOntologyUri { get; set; } = "";
+
+
+		public string Comment { get; set; } = "";
+
+
+		public string Creator { get; set; } = "";
+
+
+		public Version Version { get; set; } = new Version(1,0,0);
+
+
+		public override async Task GenerateMindMapFile(IList objects, AssetConverterConfig config, string targetDirectory, string language)
+		{
+			var virtueList = objects.Cast<Virtue>().ToList();
+			if (string.IsNullOrEmpty(language))
+				language = config.LocalizationConfig.DefaultLanguage;
+
+			// Définir le répertoire de sortie correct
+			var outputDir = Path.Combine(config.GetBaseTargetDirectory(language), "Ontology");
+			Directory.CreateDirectory(outputDir); // S'assurer que le répertoire existe
+
+			var fileName = Path.Combine(outputDir, DocumentName);
+
+			// On efface l'ancien fichier pour forcer la regénération
+			if (File.Exists(fileName))
+			{
+				File.Delete(fileName);
+			}
+
+			Logger.Log($"Creating Virtues Owl document {DocumentName} in {outputDir}");
+			await CreateVirtueOwlDocument(virtueList, config, language, fileName);
+		}
+
+		private async Task CreateVirtueOwlDocument(IList<Virtue> virtues, AssetConverterConfig config, string language, string fileName)
+	    {
+	        var virtuesByPath = virtues.ToDictionary(v => v.Path, v => v);
+	        Virtue GetParent(Virtue v)
+	        {
+	            if (v.Depth <= 1)
+	                return virtues.First();
+	            var parentPath = v.Path.Substring(0, v.Path.LastIndexOf('.'));
+	            return virtuesByPath[parentPath];
+	        }
+
+	        var ontology = new OwlAdapter(OntologyNamespace);
+
+	        // Metadata init
+	        ontology.Annotate(RDFVocabulary.RDFS.COMMENT, new RDFPlainLiteral(Comment, "en"));
+	        ontology.Annotate(RDFVocabulary.OWL.VERSION_INFO, new RDFPlainLiteral(Version.ToString()));
+	        ontology.Annotate(RDFVocabulary.DC.CREATOR, new RDFPlainLiteral(Creator.ToString()));
+
+	        // AIF object property: a Virtue is the "good tenor of" a Walton argumentation scheme
+	        // (i.e. the correct practice / answer to the scheme's critical questions). The Fallacies
+	        // switch over skos:*Match tokens cannot fire here: the Virtue AIF_skosMappingType column
+	        // holds the FR-prose critical question, not a skos enum token (design adaptation 1).
+	        var aifGoodTenorOfUri = $"{ExternalReferenceOntologyNamespaceURI}goodTenorOf";
+	        var goodTenorOfProperty = new RDFResource(aifGoodTenorOfUri);
+	        ontology.DeclareObjectProperty(goodTenorOfProperty);
+
+	        // Scheme declaration
+	        var schemeName = GetId(virtues.First().TitleEn);
+	        RDFResource mainScheme = new RDFResource($"{OntologyNamespace}{schemeName}Scheme");
+	        ontology.DeclareConceptScheme(mainScheme);
+
+	        var concepts = new Dictionary<Virtue, RDFResource>();
+
+	        foreach (var virtue in virtues)
+	        {
+	            var virtueConcept = this.GetVirtueConcept(virtue, ontology, mainScheme);
+	            concepts[virtue] = virtueConcept;
+
+	            // Hierarchy
+	            var parentVirtue = GetParent(virtue);
+
+	            if (parentVirtue == virtue)
+	            {
+	                ontology.DeclareTopConcept(virtueConcept, mainScheme);
+	            }
+	            else
+	            {
+	                var parentResource = concepts[parentVirtue];
+	                try
+	                {
+	                    ontology.DeclareNarrowerConcepts(parentResource, virtueConcept);
+	                }
+	                catch (Exception e)
+	                {
+	                    Console.WriteLine(e);
+	                }
+	            }
+
+	            // AIF good-tenor link: Virtue → Walton scheme concept(s), prose critical question
+	            // carried as an rdfs:comment annotation. Cross-corpus crossLink_Opposes is Phase 3.
+	            if (!string.IsNullOrEmpty(virtue.AIFSkosDirectRef))
+	            {
+	                var schemeMappings = virtue.AIFSkosDirectRef.Split(',')
+	                    .Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x));
+
+	                foreach (var schemeMapping in schemeMappings)
+	                {
+	                    var schemeUri = $"{ExternalReferenceOntologyNamespaceURI}{schemeMapping}";
+	                    var schemeConcept = new RDFResource(schemeUri);
+	                    ontology.AnnotateConceptWithResource(virtueConcept, goodTenorOfProperty, schemeConcept);
+	                }
+
+	                // The critical-question prose (AIF_skosMappingType) is not a skos token here;
+	                // carry it as a free-text rdfs:comment so it stays consumable and lossless.
+	                if (!string.IsNullOrEmpty(virtue.AIFSkosMappingType))
+	                {
+	                    ontology.AnnotateConcept(virtueConcept, RDFVocabulary.RDFS.COMMENT, new RDFPlainLiteral(virtue.AIFSkosMappingType, "fr"));
+	                }
+	            }
+	        }
+
+	        //Saving
+	        await ontology.ToFileAsync(OWLEnums.OWLFormats.OWL2XML, fileName);
+	        Logger.LogSuccess($"Virtue Owl document {fileName} successfully saved");
+	    }
+
+	    private RDFResource GetVirtueConcept(Virtue targetVirtue,
+	     OwlAdapter ontology, RDFResource mainScheme)
+	    {
+	        var virtueId = GetId(targetVirtue.TitleEn);
+	        var virtueUri = $"{OntologyNamespace}{virtueId}";
+
+	        RDFResource virtueResource = new RDFResource(virtueUri);
+	        ontology.DeclareConcept(virtueResource, mainScheme);
+
+	        ontology.AnnotateConceptPreferredLabel(virtueResource, new RDFPlainLiteral(targetVirtue.TitleFr, "fr"));
+	        ontology.AnnotateConceptPreferredLabel(virtueResource, new RDFPlainLiteral(targetVirtue.TitleEn, "en"));
+
+	        ontology.DocumentConcept(virtueResource, Ontology.SKOSDocumentationTypes.Definition, new RDFPlainLiteral(targetVirtue.DescriptionFr, "fr"));
+	        ontology.DocumentConcept(virtueResource, Ontology.SKOSDocumentationTypes.Definition, new RDFPlainLiteral(targetVirtue.DescriptionEn, "en"));
+
+	        // Virtues carry no example field in the source taxonomy (Virtue.Example == string.Empty).
+
+	        if (!string.IsNullOrEmpty(targetVirtue.LinkEn))
+	        {
+	            ontology.AnnotateConcept(virtueResource, RDFVocabulary.RDFS.SEE_ALSO, new RDFPlainLiteral(targetVirtue.LinkEn, "en"));
+	        }
+	        if (!string.IsNullOrEmpty(targetVirtue.LinkFr))
+	        {
+	            ontology.AnnotateConcept(virtueResource, RDFVocabulary.RDFS.SEE_ALSO, new RDFPlainLiteral(targetVirtue.LinkFr, "fr"));
+	        }
+
+	        return virtueResource;
+	    }
+	}
+}


### PR DESCRIPTION
## #499 Phase 2 — Virtue ClassMap + OWL pass ✅ READY (Part 1 + Part 2)

**Status: READY** — Part 1 (ClassMap) + Part 2 (Virtue OWL generator) both delivered.
Base `6e029a6f` (#590 merged). Dispatch: `msg-20260623T151404-vjbzs9`.

---

### Part 1 — ClassMap ✅ (commit `e0be8911`)

- Mapped the 12 #499 columns onto **`Virtue` / `VirtueClassMap`** — the entity that loads
  the prod CSV (`CsvType = typeof(Virtue)`) and feeds the pipeline. All 12 `.Optional()`.
- Entity-target correction (validated): the dispatch named `ArgumentVirtueClassMap`, but
  `ArgumentVirtue` is only the AutoMapper projection target — **not a CSV loader**. The prod
  Virtues CSV operates on `Virtue`.
- Tests +2 in `VirtueClassMapRegressionTests` (suite 533 → 535).

### Part 2 — Virtue OWL generator ✅ (commit `d5ce3228`)

**Discovery**: `OwlGeneratorConfig` only emitted `argumentum_fallacies.owl` — **no OWL pass
existed for Virtues**. Part 2 therefore **creates the generator from scratch**, mirroring
`OwlGeneratorConfig` / `OwlDocumentConfig` (Fallacies):

- **`VirtueOwlGeneratorConfig` + `VirtueOwlDocumentConfig`** (`Ontology/`, new file) — emits
  `argumentum_virtues.owl`: a concept scheme with the 7-family hierarchy (`skos:narrower`
  via `Path`/`Depth`, same `GetParent` shape), one concept per Virtue node (prefLabel /
  definition FR+EN on `Title*`/`Description*`), and a custom AIF object property.
- **Wired into the pipeline** (`AssetConverterConfig.cs`): new property + invoked in the
  `OwlGenerator` mode block (sync + async), parallel to `OwlGeneratorConfig.Apply`.

#### Design decisions (jsboige interactive 2026-06-24)

1. **AIF predicate = custom `aif:goodTenorOf`** (`DeclareObjectProperty`), **not** a
   `skos:*Match` token. The Virtue `AIF_skosMappingType` column holds the FR-prose critical
   question, not a skos enum, so the Fallacies `switch(AIFSkosMappingType)` cannot fire.
   The prose is carried as an `rdfs:comment` annotation. The AIF namespace already exists
   in the Fallacies pass (`http://www.arg.dundee.ac.uk/aif#`) — **no new namespace**.
2. **Cross-corpus `crossLink_Opposes` (PK→URI) DEFERRED to Phase 3.** Resolving Fallacy PKs
   requires loading the Fallacies corpus (concept URIs derive from `GetId(TextEn)`, not PK) —
   new architecture beyond this single-dataset pass. **This pass is strictly mono-corpus.**

#### Tests +5 (`VirtueOwlGenerationContractTests`)

- `GetId` mirrors the Fallacies IRI transform (byte-identical; asserted on the same proven
  inputs `A-B` / `A, B` / `Appel à l'autorité`).
- Generator defaults lock the ontology identity (`argumentum_virtues.owl` /
  `VirtuesTaxonomy` dataset / namespace / AIF namespace).
- `aif:goodTenorOf` URI construction pinned for Phase 3 reuse.

**Verified**: build 0 errors, 0 new warnings; suite **535 → 540 passed / 0 failed / 5 skipped**.

---

### Honesty note — E2E not yet exercised ⚠️

The generator compiles, is wired, and is covered by **pure contract tests** (transform /
defaults / URI). The **actual end-to-end `.owl` file emission has NOT been run** — that
needs the compute-heavy pipeline (CardPen harvest is not my lane solo). Flagged explicitly:
concept count, hierarchy depth, and `aif:goodTenorOf` triples should be byte-checked against
the 222 populated Virtue nodes on the next coordinated pipeline run. Cross-corpus Phase 3 +
E2E validation are the open tails.

### DoD #499 coverage

- [x] Relational + AIF columns added to the Virtue schema (Phase 1, #590)
- [x] Export consommable documenté — `argumentum_virtues.owl` (this PR, mono-corpus)
- [ ] E2E generation verified (next coordinated pipeline run)
- [ ] Cross-corpus Virtue↔Fallacy links (Phase 3)
- [ ] 1 exemple de consommation EPITA (Phase 3 / consumer side)

🤖 Worker po-2024 · #499 Phase 2 · Part 1 (ClassMap) + Part 2 (OWL gen) delivered · 540/0/5
