### PR TITLE
chore(dnn): #131 migrate 12 RazorComponent templates to Razor14 (source-level, runtime pending)

### DIFF
--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Layout/_Line.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Layout/_Line.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles"})
 
 @{

--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_Large emphasized link.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_Large emphasized link.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @* This adds all link/script tags *@
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles"})

--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of document-links.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of document-links.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @* This adds all link/script tags *@
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles"})

--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of icon-links.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of icon-links.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @* This adds all link/script tags *@
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles,scripts,height"})
@@ -9,7 +9,7 @@
 }
 
 <div class="co-container-outer">
-	<div class="co-container-inner co-navigation co-navigation-@(Dnn.Module.ModuleID) co-navigation-icon co-navigation-text">
+	<div class="co-container-inner co-navigation co-navigation-@(CmsContext.Module.Id) co-navigation-icon co-navigation-text">
     <div class="row">
       @foreach (var link in AsList(Data))
       {

--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of image-links with overlay.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of image-links with overlay.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @* This adds all link/script tags *@
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles,scripts,height"})
@@ -9,7 +9,7 @@
 }
 
 <div class="co-container-outer">
-	<div class="co-container-inner co-navigation co-navigation-@(Dnn.Module.ModuleID) co-navigation-image">
+	<div class="co-container-inner co-navigation co-navigation-@(CmsContext.Module.Id) co-navigation-image">
 		<div class="row">
 			@foreach (var link in AsList(Data))
 			{

--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of image-links.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of image-links.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @* This adds all link/script tags *@
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles,scripts,height"})
@@ -9,7 +9,7 @@
 }
 
 <div class="co-container-outer">
-	<div class="co-container-inner co-navigation co-navigation-@(Dnn.Module.ModuleID) co-navigation-image">
+	<div class="co-container-inner co-navigation co-navigation-@(CmsContext.Module.Id) co-navigation-image">
 		<div class="row">
 			@foreach (var link in AsList(Data))
 			{

--- a/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of links.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Content/bs3/Link/_List of links.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @* This adds all link/script tags *@
 @RenderPage("../shared/_Assets.cshtml", new { parts = "styles,scripts,height"})
@@ -9,7 +9,7 @@
 }
 
 <div class="co-container-outer">
-	<div class="co-container-inner co-navigation co-navigation-@(Dnn.Module.ModuleID) co-navigation-text">
+	<div class="co-container-inner co-navigation co-navigation-@(CmsContext.Module.Id) co-navigation-text">
     <div class="row">
       @foreach (var link in AsList(Data))
       {

--- a/DNNPlatform/Portals/1/2sxc/News5/bs3/_Details.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/News5/bs3/_Details.cshtml
@@ -1,4 +1,4 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 
 @Html.Partial("./shared/_Assets.cshtml", new { scripts = true} )
@@ -7,7 +7,7 @@
   var parts = CreateInstance("./shared/_Parts.cshtml");
   var page = GetService<ToSic.Sxc.Web.IPageService>(); // Service to set titles etc. on the page
   var article = AsList(Data).FirstOrDefault();
-  var filteredCategory = Request.QueryString["category"];
+  var filteredCategory = CmsContext.Page.Parameters["category"];
   var categoryParams = Text.Has(filteredCategory)
       ? "category=" + filteredCategory
       : "";

--- a/DNNPlatform/Portals/1/2sxc/News5/bs3/_List Columns without images.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/News5/bs3/_List Columns without images.cshtml
@@ -1,7 +1,7 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @using ToSic.Sxc.Search;
-@using ToSic.Eav.Run;
+@using ToSic.Sxc.Context;
 
 @Html.Partial("shared/_Assets.cshtml")
 
@@ -11,7 +11,7 @@
   var viewConfiguration = Content;
   var articles = AsList(Data["News"]);
   var categories = AsList(App.Data["Category"]);
-  var categoryQueryString = Request.QueryString["category"];
+  var categoryQueryString = CmsContext.Page.Parameters["category"];
   var filteredCategory = AsList(Data["Category"]).FirstOrDefault();
   var pages = AsList(Data["Paging"]).FirstOrDefault();
 }
@@ -46,7 +46,7 @@
   /**
   * Prevent duplicated search results
   */
-  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IContainer moduleInfo, DateTime beginDate) {
+  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IModule moduleInfo, DateTime beginDate) {
     searchInfos.Clear();
   }
 }

--- a/DNNPlatform/Portals/1/2sxc/News5/bs3/_List Columns.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/News5/bs3/_List Columns.cshtml
@@ -1,7 +1,7 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @using ToSic.Sxc.Search;
-@using ToSic.Eav.Run;
+@using ToSic.Sxc.Context;
 
 @Html.Partial("shared/_Assets.cshtml")
 
@@ -11,7 +11,7 @@
   var viewConfiguration = Content;
   var articles = AsList(Data["News"]);
   var categories = AsList(App.Data["Category"]);
-  var categoryQueryString = Request.QueryString["category"];
+  var categoryQueryString = CmsContext.Page.Parameters["category"];
   var filteredCategory = AsList(Data["Category"]).FirstOrDefault();
   var pages = AsList(Data["Paging"]).FirstOrDefault();
 }
@@ -46,7 +46,7 @@
   /**
   * Prevent duplicated search results
   */
-  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IContainer moduleInfo, DateTime beginDate) {
+  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IModule moduleInfo, DateTime beginDate) {
     searchInfos.Clear();
   }
 }

--- a/DNNPlatform/Portals/1/2sxc/News5/bs3/_List archive.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/News5/bs3/_List archive.cshtml
@@ -1,7 +1,7 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @using ToSic.Sxc.Search;
-@using ToSic.Eav.Run;
+@using ToSic.Sxc.Context;
 
 @Html.Partial("shared/_Assets.cshtml")
 
@@ -11,7 +11,7 @@
   var viewConfiguration = Content;
   var articles = AsList(Data["News"]);
   var categories = AsList(App.Data["Category"]);
-  var categoryQueryString = Request.QueryString["category"];
+  var categoryQueryString = CmsContext.Page.Parameters["category"];
   var filteredCategory = AsList(Data["Category"]).FirstOrDefault();
   var pages = AsList(Data["Paging"]).FirstOrDefault();
 }
@@ -46,7 +46,7 @@
   /**
   * Prevent duplicated search results
   */
-  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IContainer moduleInfo, DateTime beginDate) {
+  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IModule moduleInfo, DateTime beginDate) {
     searchInfos.Clear();
   }
 }

--- a/DNNPlatform/Portals/1/2sxc/News5/bs3/_List.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/News5/bs3/_List.cshtml
@@ -1,7 +1,7 @@
-@inherits ToSic.Sxc.Dnn.RazorComponent
+@inherits Custom.Hybrid.Razor14
 @using ToSic.Razor.Blade;
 @using ToSic.Sxc.Search;
-@using ToSic.Eav.Run;
+@using ToSic.Sxc.Context;
 
 @Html.Partial("shared/_Assets.cshtml")
 
@@ -11,7 +11,7 @@
   var viewConfiguration = Content;
   var articles = AsList(Data["News"]);
   var categories = AsList(App.Data["Category"]);
-  var categoryQueryString = Request.QueryString["category"];
+  var categoryQueryString = CmsContext.Page.Parameters["category"];
   var filteredCategory = AsList(Data["Category"]).FirstOrDefault();
   var pages = AsList(Data["Paging"]).FirstOrDefault();
 }
@@ -50,7 +50,7 @@
   /// <param name="moduleInfo"></param>
   /// <param name="beginDate"></param>
 
-  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IContainer moduleInfo, DateTime beginDate) {
+  public override void CustomizeSearch(Dictionary<string, List<ISearchItem>> searchInfos, IModule moduleInfo, DateTime beginDate) {
     var parts = CreateInstance("shared/_Parts.cshtml");
     foreach (var si in searchInfos["SearchIndex"]) {
       var article = AsDynamic(si.Entity);


### PR DESCRIPTION
## Summary

Source-level migration of the **12 deprecated `ToSic.Sxc.Dnn.RazorComponent` templates** (the Dnn-specific base, **removed in 2sxc 21 LTS**) to the modern Dnn-agnostic `Custom.Hybrid.Razor14` base. This is the **last remaining 2sxc breaking-risk** identified in the DNN 10.3.2 + 2sxc 21 upgrade arc (#458 / #131).

> **Note: this is a SOURCE-LEVEL migration only.** Runtime validation is **PENDING on the sandbox** (see §Validation). These `.cshtml` files are interpreted by 2sxc at runtime in DNN — they are **not** compiled by `dotnet build`, so they cannot be validated locally by the .NET pipeline. The PR is opened for sandbox runtime validation, per the ai-01 dispatch (2026-06-25 14:05).

Dispatched by ai-01 (coordinator). Worker: po-2023.

## Scope (12 files — all under `DNNPlatform/`)

**News5/bs3 (5):**
- `_Details.cshtml`
- `_List.cshtml`
- `_List archive.cshtml`
- `_List Columns.cshtml`
- `_List Columns without images.cshtml`

**Content/bs3 (7):**
- `Layout/_Line.cshtml`
- `Link/_Large emphasized link.cshtml`
- `Link/_List of document-links.cshtml`
- `Link/_List of icon-links.cshtml`
- `Link/_List of image-links with overlay.cshtml`
- `Link/_List of image-links.cshtml`
- `Link/_List of links.cshtml`

**0 files under `Cards/`** (release freeze respected — master stays `bef3bc6c`).

## API migrations (semantics preserved, 2sxc 21-compatible)

| Legacy (RazorComponent) | Modern (Razor14) | Count | Where |
|---|---|---|---|
| `@inherits ToSic.Sxc.Dnn.RazorComponent` | `@inherits Custom.Hybrid.Razor14` | 12× | all |
| `Request.QueryString["category"]` | `CmsContext.Page.Parameters["category"]` | 5× | News5 |
| `Dnn.Module.ModuleID` | `CmsContext.Module.Id` | 4× | Content/Link |
| `@using ToSic.Eav.Run;` | `@using ToSic.Sxc.Context;` | 4× | News5 `_List*` |
| `CustomizeSearch(... IContainer moduleInfo ...)` | `CustomizeSearch(... IModule moduleInfo ...)` | 4× | News5 `_List*` |

The `CustomizeSearch` signature is aligned with the repo's **already-modern** `News5/DnnSearch/SearchMapper.cs` (`Custom.Hybrid.Code12, ICustomizeSearch`, `IModule`). Each of the 4 `_List*` overrides preserves its own logic (`_List.cshtml` = stream cleanup + per-entity querystring; the 3 others = `searchInfos.Clear()` to prevent duplicate results) — none were removed or merged into `SearchMapper`, to avoid changing behavior without runtime tests.

## APIs preserved (still valid in Razor14 — confirmed)

`App.Data`, `AsList`, `AsDynamic`, `Content`, `CreateInstance`, `GetService`, `Edit.TagToolbar` / `Edit.Enabled`, `Text.Has`, `Tags.*` (`Tags.Nl2Br`, `Tags.Strip`), `@RenderPage`, `@Html.Partial`, `@Html.Raw`, `CmsContext.View.Identifier` (already modern in `_Line.cshtml`).

Out-of-scope shared dependencies left untouched (per dispatch perimeter):
- `News5/bs3/shared/_Parts.cshtml` — already `Custom.Hybrid.Razor12` (2sxc 21 supports Razor12).
- `Content/bs3/Link/_LinkHelper.cshtml` — helper with no `@inherits`, not in the 12-template list.

## ⚠️ Runtime validation PENDING on sandbox

These points cannot be verified by `dotnet build` (2sxc interprets `.cshtml` at runtime). To validate on the DNN sandbox post-2sxc-21-upgrade:

1. **`CustomizeSearch` override signature (IModule)** in the 4 News5 `_List*` — confirm `Custom.Hybrid.Razor14` still exposes the `virtual` override. **If 2sxc 21 dropped template-level overrides in favor of the `ICustomizeSearch` interface**, fall back to the existing `News5/DnnSearch/SearchMapper.cs` pattern (move the per-template logic into `SearchMapper` or a per-view `SearchMapper`).
2. **`CmsContext.Page.Parameters["category"]` null-behavior** — verify it returns `null` when the parameter is absent (downstream `Text.Has(...)` handles null). If it throws on missing key, wrap with `.ContainsKey("category")`.
3. **`_LinkHelper.cshtml:30`** uses `Dnn.Portal.PortalAlias.HTTPAlias` (legacy). **NOT migrated here** (outside the 12-template scope, no `@inherits`). It **may break** when instantiated from a Razor14 template → **candidate follow-up PR** if the sandbox reveals it.

## Diff hygiene

29 insertions / 29 deletions (no line-ending noise — repo has no `.gitattributes` + `core.autocrlf=false`; files were re-normalized to match each original's line ending).

## Related

- Closes nothing yet (runtime validation pending).
- Refs #131, #458, #593 (DNN upgrade assessment audit).
- Smoke-test checklist: `docs/dnn-localization/131-step2-smoke-test-checklist.md`.

🤖 Worker po-2023 · dispatched by ai-01 · runtime validation pending on sandbox
