### PR TITLE
docs(dnn): DNN ops runbooks bundle — sandbox-bootstrap + go-live smoke-test + turnkey checklist

### DIFF
--- a/docs/dnn/go-live-smoke-test.md
+++ b/docs/dnn/go-live-smoke-test.md
@@ -1,0 +1,71 @@
+# DNN 10.3.2 Go-Live — Smoke-Test Checklist
+
+**Date**: 2026-06-26 · **Author**: po-2023 (dispatched by ai-01 v3, secondary track)
+**Status**: Actionable checklist — **complements** the [#132 production deployment runbook](../dnn-localization/132-deployment-runbook.md) (PR #594), does NOT duplicate it. Read-only doc, no code.
+**Purpose**: The #132 runbook covers the upgrade wizard + rollback contract. This doc is the **detailed smoke test** run immediately after the wizard completes (Phase 5, step 5 of #132) before exiting maintenance mode — the gate that says "10.3.2 is live and serving".
+**Related**: #132 (deployment runbook), #131 (upgrade arc), #596 (12 Razor14 templates), #597 (4 social-auth connectors), [UPGRADE-ASSESSMENT.md](UPGRADE-ASSESSMENT.md) §5 (eshop), [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md).
+
+---
+
+## TL;DR
+
+After the DNN 10.3.2 wizard + 2sxc 21 upgrade + 12-template deploy (all detailed in [#132](../dnn-localization/132-deployment-runbook.md) §5/§5.5), run **this checklist** on production before exiting maintenance mode. Three sections: **(A) Platform core**, **(B) Argumentum 2sxc app + 12 Razor14 templates** (#596), **(C) Social auth connectors** (#597) + **eshop path**. Every item is a green/red signal. **All green → exit maintenance. Any red → rollback** (#132 §6).
+
+> **Scope note**: #132 already sequences the upgrade. This doc exists because (1) #132 treats smoke as one line per phase, (2) it predates #596 (Razor14 templates) and #597 (auth connectors) so doesn't smoke-test them, and (3) a focused, URL-level checklist is what an operator runs in the maintenance window. It references #132 rather than repeating it.
+
+## A. Platform core (post-wizard)
+
+| # | Check | How | Green | Red flag |
+|---|-------|-----|-------|----------|
+| A1 | DNN version | `SELECT Major,Minor,Build FROM {db}.{obj}Version` | `10.3.2` | `9.x` (wizard didn't run) |
+| A2 | Homepage loads | `GET /` (anon) | HTTP 200, site skin renders | 500 / yellow-screen / `0x80131040` (binding) |
+| A3 | Admin panel | login as admin → PersonaBar | loads, no JS console errors | `DnnJsInclude` crash = 2sxc cliff not crossed (re-do #132 §5.5.a) |
+| A4 | Language switcher | toggle FR ⇄ en-US | content switches, no 404 | FR-leak into EN (cf. #216 regression class) |
+| A5 | Login (local admin) | DNN native login | succeeds, session cookie set | `aspnet_Membership` schema mismatch |
+| A6 | SEO URLs | a known friendly URL resolves | 200, correct page | SiteUrls.config lost in web.config merge |
+
+## B. Argumentum 2sxc app + 12 Razor14 templates (#596)
+
+> The 12 templates migrated in #596 are file-based Razor, interpreted by 2sxc 21 at runtime. Each must render without a 2sxc yellow-screen.
+
+| # | Template (path under `Portals/1/2sxc/`) | Check | Green | Red flag |
+|---|---|---|---|---|
+| B1 | `Argumentum/_FallacyExplorer_Root.cshtml` | load Fallacy Explorer page | taxonomy renders | (already Razor14 — if red, 2sxc 21 upgrade regressed) |
+| B2 | `Argumentum/_RulesExplorer_*` | Rules list + detail | renders | same |
+| B3 | `Argumentum/_Album List.cshtml` | gallery page | renders | same |
+| B4 | `News5/bs3/_Details.cshtml` | a News5 detail page | renders, `CmsContext.Page.Parameters` resolves | `Request.QueryString` NRE (RazorComponent API missed in migration) |
+| B5 | `News5/bs3/_List.cshtml` + `_List archive` + `_List Columns*` | News5 list pages | render | `IContainer`/`IModule` compile error |
+| B6 | `Content/bs3/Link/_List of *.cshtml` (6) + `_Large emphasized link` | Content Link views | render, `CmsContext.Module.Id` resolves | `Dnn.Module.ModuleID` NRE (legacy API missed) |
+| B7 | `Content/bs3/Layout/_Line.cshtml` | layout partial | renders | — |
+
+**Red on B4-B7** = a RazorComponent→Razor14 API migration was incomplete in #596; capture the 2sxc error, fix the template, redeploy. (These were source-level migrated; runtime binding is what this smoke validates.)
+
+## C. Social auth connectors (#597) + eshop path
+
+> The 4 DNN-native auth connectors (Facebook, Google, LiveConnect=Microsoft, Twitter) are at v9.11.1.0 distributed binaries (per #597). They upgrade **with the DNN core package**. Validate each OAuth flow still initiates.
+
+| # | Connector | Check | Green | Red flag |
+|---|-----------|-------|-------|----------|
+| C1 | Facebook | click "Login with Facebook" | redirects to FB OAuth consent | redirect-loop / 401 (client secret / callback URL) |
+| C2 | Google | "Login with Google" | redirects to Google OAuth | same |
+| C3 | LiveConnect (Microsoft) | "Login with Microsoft" | redirects to MS OAuth | API deprecation (legacy Live API) |
+| C4 | Twitter | "Login with Twitter" | redirects to Twitter OAuth | same |
+| C5 | OpenStore admin | `/DesktopModules/NBright/...` admin | loads on .NET 4.8 (no `DnnJsInclude` crash) | IIS crash = 2sxc cliff (#132 §5.5) |
+| C6 | Stripe checkout path | add item → checkout | OS_Stripe + Stripe.net path loads | RazorEngine/CVE surface (pre-#445 removal) |
+
+> **#597 caveat**: these connectors have known community-reported fragility ("do not work in DNN CE") — a red here may be pre-existing misconfig, **not** a regression from the 10.3.2 upgrade. Compare against the **pre-upgrade** baseline (snapshot in #132 Phase 0) to distinguish regression from pre-existing.
+
+## Sign-off gate
+
+```
+[ ] Section A: all green (A1-A6)
+[ ] Section B: all 12 templates render (B1-B7)
+[ ] Section C: C5 (OpenStore) + C6 (Stripe) green; C1-C4 either green OR confirmed pre-existing (vs Phase-0 baseline)
+[ ] Rollback anchor (#132 Phase-5 re-backup) verified: RESTORE VERIFYONLY green
+→ If all green: exit maintenance mode. Record versions (DNN 10.3.2, 2sxc 21.07, OpenStore) in deploy log.
+→ If any RED that is a regression: do NOT exit maintenance → execute #132 §6 rollback.
+```
+
+## Runtime validation note (#596 un-gate)
+
+Sections B4-B7 are the **same checks** that un-gate the #596 merge when run on the **sandbox** (see [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md) §5). The sandbox run produces the OK/KO report on #596; this go-live run confirms them on production post-upgrade. po-2023 signals factual OK/KO; the PASS verdict is ai-01/jsboige's.

--- a/docs/dnn/go-live-turnkey-checklist.md
+++ b/docs/dnn/go-live-turnkey-checklist.md
@@ -1,0 +1,81 @@
+# DNN 10.3.2 Go-Live — Turnkey Session Checklist (jsboige's RDP window)
+
+**Date**: 2026-06-26 · **Author**: po-2023 (dispatched by ai-01, secondary track — release COUPLÉE au site, jsboige input 26/06)
+**Status**: **Turnkey navigator.** Organizes the entire #131 arc by **what an RDP session is needed for**, not by technical phase (the [dnn-localization README](../dnn-localization/README.md) already does phase-order). The shortest path from "open RDP" to "site live on 10.3.2". Read-only doc, no code.
+**Purpose**: jsboige coupled v0.9.0 to the DNN go-live (#131/#132). Most of the arc is already done by agents without touching the runtime; a bounded set **requires jsboige's interactive RDP/sandbox session**. This is the checklist that says — when you open that window, here is the exact turnkey sequence and nothing redundant.
+**Related**: [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md), [go-live-smoke-test.md](go-live-smoke-test.md), [../dnn-localization/README.md](../dnn-localization/README.md) (arc index), #596 (Razor14), #597 (auth), #131/#132.
+
+---
+
+## TL;DR — the RDP-time split
+
+```
+[A] DONE by agents (no RDP) ────── verify only (no runtime action)
+[B] REQUIRES jsboige RDP session ─ the runtime work, turnkey sequence below
+```
+
+| Block | What | Needs RDP? | Status |
+|-------|------|------------|--------|
+| Templates Razor14 migration (#596) | 12 templates source-level migrated | ❌ no (repo) | ✅ done — runtime verify only (B3) |
+| CVE + target docs (#593) | 9.13.x closes 0 CVE; target = 10.3.2 | ❌ no | ✅ done |
+| Full doc arc + checklists | README index, sandbox smoke (#131-step2), prod smoke (#603), deployment (#132) | ❌ no | ✅ done |
+| **Sandbox `bin/` repair** | 5 .NET-9 contaminants → net48 re-deploy | ✅ **RDP** | ⛔ characterized, recipe ready (B1) |
+| Sandbox upgrade 9.11.1→10.3.2 + 2sxc 15.02→21.07 | wizard + cliff cross | ✅ **RDP** | ⛔ gated (B2) |
+| Browser-verify 12 templates (#596 runtime un-gate) | assign + screenshot | ✅ **RDP** | ⛔ gated (B3) |
+| Prod go-live 10.3.2 | wizard on prod + Phase-5 smoke | ✅ **RDP (prod)** | ⛔ gated (B4) |
+
+## [A] Already done without RDP (agent-delivered — verify only, no action)
+
+These landed via PRs while `master` stayed frozen at `bef3bc6c`:
+
+- **#596** — 12 RazorComponent→Razor14 templates migrated at source level (`Portals/1/2sxc/News5/`, `Content/`). Runtime binding is what B3 verifies; the source migration is complete.
+- **#593** (`131-cve-correction-and-target-refinement.md`) — CVE reconciliation: 9.13.x closes **0** of the 2 relevant CVEs; floor = 10.1.2; actée target = **10.3.2 + 2sxc 21**.
+- **#597** (`506-social-auth-connectors-inventory.md`) — Facebook/Google/Microsoft/Twitter connector inventory + secret-rotation procedure. Repo-grounded; live console checks fold into B4.
+- **#603** — [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md) (the `bin/` repair recipe) + [go-live-smoke-test.md](go-live-smoke-test.md) (prod smoke checklist).
+- **#132** (`132-deployment-runbook.md`, #594) — 6-phase production go-live + rollback contract. Retargeted to 10.3.2.
+- **#131-step2-smoke-test-checklist.md** — consolidated, tickable sandbox smoke gate (9 sections, cliff-specific checks).
+- **Arc navigation** — [../dnn-localization/README.md](../dnn-localization/README.md) sequences the 15-doc arc in execution order.
+
+## [B] Requires jsboige's RDP session — turnkey sequence
+
+> Run in order. Each step references the authoritative doc (don't re-derive here). The whole of [B] is one focused session if B1 goes smoothly.
+
+### B1 — Sandbox `bin/` repair (FIRST — blocks ALL DNN boot) ⛔
+
+This is the characterized blocker from the 2026-06-25 boot attempt ([#596 `issuecomment-4804068740`](https://github.com/ArgumentumGames/Argumentum/pull/596#issuecomment-4804068740)). The sandbox **cannot start** until the `bin/` SDK contamination is cleaned. **Recipe is turnkey**: [sandbox-bootstrap-runbook.md §3](sandbox-bootstrap-runbook.md).
+
+1. Copy `System.Buffers`/`System.Memory` from `bin/Imageflow/` (clean 4.0.3.0/4.0.1.1).
+2. Fetch the **5 .NET-9 contaminants** at **6.0.x** NuGet (`lib/net462`, last net48 line): `System.Collections.Immutable`, `System.Text.Json`, `System.IO.Pipelines`, `System.Diagnostics.DiagnosticSource`, `System.Text.Encodings.Web`.
+3. Align binding redirects `newVersion` → 6.0.0.0.
+4. Edit `web.config` locally (LocalDB conn string + throwaway machineKey — **never commit**, revert after).
+5. Boot IIS Express `:8090` via `/config:` + named "DNN Argumentum" site. Expect HTTP 200 (not `0x80131040`).
+
+### B2 — Sandbox upgrade + smoke gate
+
+Per [../dnn-localization/131-2sxc-migration-plan.md](../dnn-localization/131-2sxc-migration-plan.md) (2sxc-first) then [../dnn-localization/131-step1-sandbox-upgrade-runbook.md](../dnn-localization/131-step1-sandbox-upgrade-runbook.md):
+
+1. **2sxc 15.02 → 21.07 LTS** first (carries the `DnnJsInclude` cliff workaround — mandatory on the 10.3.2 path).
+2. **DNN 9.11.1 → 10.3.2** upgrade wizard.
+3. Run [../dnn-localization/131-step2-smoke-test-checklist.md](../dnn-localization/131-step2-smoke-test-checklist.md) — all green (esp. §3 `DnnJsInclude` crash, §4 stock 2sxc apps).
+
+### B3 — Browser-verify 12 Razor14 templates (#596 runtime un-gate)
+
+Per [sandbox-bootstrap-runbook.md §5](sandbox-bootstrap-runbook.md): assign each migrated template to a 2sxc App module, browser-navigate, screenshot. **OK/KO per template**. KO = capture the 2sxc yellow-screen, fix, redeploy. Red on B4-B7 of [go-live-smoke-test.md](go-live-smoke-test.md) = incomplete RazorComponent→Razor14 API migration.
+
+> po-2023 signals the OK/KO report; the visual PASS verdict is ai-01/jsboige's.
+
+### B4 — Production go-live
+
+Per [../dnn-localization/132-deployment-runbook.md](../dnn-localization/132-deployment-runbook.md) Phase 5: prod wizard on prod-restored data → [go-live-smoke-test.md](go-live-smoke-test.md) (A platform core + B 12 templates + C auth/eshop) → sign-off gate → exit maintenance. Any regression-red → #132 §6 rollback.
+
+## Reference map (which doc for what)
+
+| You need | Open |
+|----------|------|
+| The `bin/` repair recipe | [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md) §3 |
+| Sandbox smoke gate (tickable) | [../dnn-localization/131-step2-smoke-test-checklist.md](../dnn-localization/131-step2-smoke-test-checklist.md) |
+| Prod smoke (post-wizard) | [go-live-smoke-test.md](go-live-smoke-test.md) |
+| Full prod go-live + rollback | [../dnn-localization/132-deployment-runbook.md](../dnn-localization/132-deployment-runbook.md) |
+| The whole arc in phase order | [../dnn-localization/README.md](../dnn-localization/README.md) |
+| Target decision + cliff rationale | [../dnn-localization/131-target-revision-10.3.2-full-upgrade.md](../dnn-localization/131-target-revision-10.3.2-full-upgrade.md) |
+| Auth connectors (#597) | [../dnn-localization/506-social-auth-connectors-inventory.md](../dnn-localization/506-social-auth-connectors-inventory.md) |

--- a/docs/dnn/go-live-turnkey-checklist.md
+++ b/docs/dnn/go-live-turnkey-checklist.md
@@ -42,7 +42,7 @@ These landed via PRs while `master` stayed frozen at `bef3bc6c`:
 
 ### B1 — Sandbox `bin/` repair (FIRST — blocks ALL DNN boot) ⛔
 
-This is the characterized blocker from the 2026-06-25 boot attempt ([#596 `issuecomment-4804068740`](https://github.com/ArgumentumGames/Argumentum/pull/596#issuecomment-4804068740)). The sandbox **cannot start** until the `bin/` SDK contamination is cleaned. **Recipe is turnkey**: [sandbox-bootstrap-runbook.md §3](sandbox-bootstrap-runbook.md).
+This is the characterized blocker from the 2026-06-25 boot attempt ([#596 `issuecomment-4804068740`](https://github.com/ArgumentumGames/Argumentum/pull/596#issuecomment-4804068740)). The sandbox **cannot start** until the `bin/` SDK contamination is cleaned. **Recipe is turnkey** ([sandbox-bootstrap-runbook.md §3](sandbox-bootstrap-runbook.md)) — or run it as a script: [`repair-bin-net48.ps1`](repair-bin-net48.ps1) (dry-run by default, `-Apply` to execute: backs up `bin\`, copies the 2 local DLLs, fetches the 5 NuGet 6.0.0, drops them in). Manual run in this RDP session only; `bin/` is git-tracked, revert after.
 
 1. Copy `System.Buffers`/`System.Memory` from `bin/Imageflow/` (clean 4.0.3.0/4.0.1.1).
 2. Fetch the **5 .NET-9 contaminants** at **6.0.x** NuGet (`lib/net462`, last net48 line): `System.Collections.Immutable`, `System.Text.Json`, `System.IO.Pipelines`, `System.Diagnostics.DiagnosticSource`, `System.Text.Encodings.Web`.

--- a/docs/dnn/repair-bin-net48.ps1
+++ b/docs/dnn/repair-bin-net48.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+  DNN sandbox bin/ repair — replace .NET 9 SDK contaminants with net48-compatible versions.
+
+  Step B1 of docs/dnn/go-live-turnkey-checklist.md. Run interactively in jsboige's
+  RDP/sandbox session (the only place the runtime blocker can be cleared).
+
+.DESCRIPTION
+  The 2026-06-25 boot attempt (PR #596 issuecomment-4804068740) characterized: bin/ root
+  carries .NET 9 SDK contract assemblies (asmVer 9.0.0.0) that EF Core 2.1.1 / DNN net48
+  cannot bind -> HTTP 500 0x80131040 cascade. This script is the bounded recipe from
+  sandbox-bootstrap-runbook.md §3, made executable in one command.
+
+  -DryRun is the DEFAULT: prints the plan + current->target version map, changes nothing.
+  Pass -Apply to execute. Backs up bin/ to bin.contaminated.bak before any change.
+
+  bin/ is git-tracked. NEVER commit the result — revert after validation:
+    git checkout -- DNNPlatform/bin DNNPlatform/web.config
+
+.PARAMETER BinRoot
+  Path to DNNPlatform/bin. Default D:\Dev\Argumentum\DNNPlatform\bin.
+
+.PARAMETER Apply
+  Execute the repair (backup + copy + download + extract). Without it: dry-run plan only.
+
+.EXAMPLE
+  .\repair-bin-net48.ps1                    # dry-run: see the plan
+  .\repair-bin-net48.ps1 -Apply             # execute the bin/ repair
+#>
+param(
+  [string]$BinRoot = 'D:\Dev\Argumentum\DNNPlatform\bin',
+  [switch]$Apply
+)
+$ErrorActionPreference = 'Stop'
+$DryRun = -not $Apply
+$mode = if ($DryRun) { 'DRY-RUN (no changes — pass -Apply to execute)' } else { 'APPLY' }
+
+# 5 .NET 9 contaminants -> fetch 6.0.0 NuGet (last line shipping a net4x lib/ folder,
+# predates the .NET 8+ TFM-only cliff; satisfies EF Core 2.1.1 + DNN binding redirects).
+$nugets = @(
+  @{ Id='System.Collections.Immutable';      Asm='6.0.0.0' }
+  @{ Id='System.Text.Json';                  Asm='6.0.0.0' }
+  @{ Id='System.IO.Pipelines';               Asm='6.0.0.0' }
+  @{ Id='System.Diagnostics.DiagnosticSource'; Asm='6.0.0.0' }
+  @{ Id='System.Text.Encodings.Web';         Asm='6.0.0.0' }
+)
+$nugetVer = '6.0.0'
+
+# 2 .NET 6 markers -> local clean source already in bin/Imageflow/ (correct older versions).
+$local = @(
+  @{ Id='System.Buffers'; Target='4.0.3.0'; Src='Imageflow\System.Buffers.dll' }
+  @{ Id='System.Memory';  Target='4.0.1.1'; Src='Imageflow\System.Memory.dll' }
+)
+
+function Get-AsmVer([string]$dllPath) {
+  if (-not (Test-Path $dllPath)) { return '(missing)' }
+  try { return [System.Reflection.AssemblyName]::GetAssemblyName($dllPath).Version.ToString() }
+  catch { return '(unreadable)' }
+}
+
+Write-Host "=== DNN bin/ repair ($mode) ===" -ForegroundColor Cyan
+Write-Host "BinRoot: $BinRoot`n"
+
+Write-Host "--- Current contaminant versions (current -> target) ---" -ForegroundColor Yellow
+foreach ($n in $nugets) {
+  $p = Join-Path $BinRoot "$($n.Id).dll"
+  $cur = Get-AsmVer $p
+  Write-Host ("  {0,-42} {1,-14} -> {2}  (NuGet $nugetVer)" -f $n.Id, $cur, $n.Asm)
+}
+foreach ($n in $local) {
+  $p = Join-Path $BinRoot "$($n.Id).dll"
+  $cur = Get-AsmVer $p
+  Write-Host ("  {0,-42} {1,-14} -> {2}  (from {3})" -f $n.Id, $cur, $n.Target, $n.Src)
+}
+
+if ($DryRun) {
+  Write-Host "`n[DRY-RUN] Would:" -ForegroundColor Magenta
+  Write-Host "  1. Backup bin\ -> bin.contaminated.bak (if not present)"
+  Write-Host "  2. Copy 2 clean DLLs from bin\Imageflow\ (Buffers 4.0.3.0, Memory 4.0.1.1)"
+  Write-Host "  3. Download + extract 5 NuGet $nugetVer from nuget.org v3-flatcontainer (lib/net4x)"
+  Write-Host "  4. Drop the 5 net48 DLLs into bin\"
+  Write-Host "`n[DRY-RUN] web.config binding-redirect alignment is NOT auto-applied" -ForegroundColor Magenta
+  Write-Host "  (see sandbox-bootstrap-runbook.md section 3.3 for the newVersion map)."
+  Write-Host "  After -Apply: align newVersion -> 6.0.0.0 for the 5 + 4.0.3.0/4.0.1.1 for the 2."
+  Write-Host "`n[DRY-RUN] Pass -Apply to execute the bin/ repair."
+  return
+}
+
+# --- APPLY ---
+if (-not (Test-Path $BinRoot)) { throw "BinRoot not found: $BinRoot" }
+
+$bak = "$BinRoot.contaminated.bak"
+if (-not (Test-Path $bak)) {
+  Write-Host "`nBacking up bin\ -> $bak" -ForegroundColor Green
+  Copy-Item $BinRoot $bak -Recurse
+} else {
+  Write-Host "`nBackup $bak already exists — skipping backup." -ForegroundColor DarkGray
+}
+
+# 1. Local copies (Buffers + Memory from bin/Imageflow/)
+foreach ($n in $local) {
+  $src = Join-Path $BinRoot $n.Src
+  $dst = Join-Path $BinRoot "$($n.Id).dll"
+  if (-not (Test-Path $src)) { throw "Clean source not found: $src" }
+  Copy-Item $src $dst -Force
+  Write-Host ("  Copied {0} -> {1}.dll (asm {2})" -f $n.Src, $n.Id, (Get-AsmVer $dst)) -ForegroundColor Green
+}
+
+# 2. NuGet fetch + extract (pick the highest net4x TFM folder, fallback netstandard2.0)
+$tmp = Join-Path $env:TEMP "dnn-binrepair"
+if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+foreach ($n in $nugets) {
+  $idLower = $n.Id.ToLower()
+  $url = "https://api.nuget.org/v3-flatcontainer/$idLower/$nugetVer/$idLower.$nugetVer.nupkg"
+  $pkg = Join-Path $tmp "$idLower.$nugetVer.zip"
+  Write-Host "`n  Downloading $n.Id $nugetVer ..." -ForegroundColor Cyan
+  try {
+    Invoke-WebRequest $url -OutFile $pkg -UseBasicParsing
+  } catch { throw "Download failed for $n.Id : $_" }
+
+  $extract = Join-Path $tmp $n.Id
+  Expand-Archive $pkg -DestinationPath $extract -Force
+
+  # Prefer the highest .NET Framework folder (net462 > net461 > net46), else netstandard2.0
+  $tfmDir = Get-ChildItem -Path "$extract\lib" -Directory -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match '^net4' } |
+    Sort-Object Name -Descending |
+    Select-Object -First 1
+  if (-not $tfmDir) {
+    $tfmDir = Get-Item "$extract\lib\netstandard2.0" -ErrorAction SilentlyContinue
+  }
+  if (-not $tfmDir) { throw "No net4x/netstandard2.0 lib folder in $n.Id $nugetVer nupkg" }
+
+  $dll = Join-Path $tfmDir.FullName "$($n.Id).dll"
+  if (-not (Test-Path $dll)) { throw "$($n.Id).dll not found in $($tfmDir.Name)" }
+
+  Copy-Item $dll (Join-Path $BinRoot "$($n.Id).dll") -Force
+  Write-Host ("    Installed {0} from {1} -> asm {2}" -f $n.Id, $tfmDir.Name, (Get-AsmVer (Join-Path $BinRoot "$($n.Id).dll"))) -ForegroundColor Green
+}
+Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host "`n=== bin/ repair DONE ===" -ForegroundColor Cyan
+Write-Host "Verify (asmVer should be 6.0.0.0 for the 5 NuGet, 4.0.3.0/4.0.1.1 for the 2):"
+foreach ($n in $nugets + $local) {
+  $target = if ($n.Asm) { $n.Asm } else { $n.Target }
+  $p = Join-Path $BinRoot "$($n.Id).dll"
+  Write-Host ("  {0,-42} {1}  (target {2})" -f $n.Id, (Get-AsmVer $p), $target)
+}
+Write-Host "`nNEXT (see go-live-turnkey-checklist.md B1, sandbox-bootstrap-runbook.md section 3.3/3.4):" -ForegroundColor Yellow
+Write-Host "  - Align web.config binding redirects newVersion -> 6.0.0.0 (5) + 4.0.3.0/4.0.1.1 (2)"
+Write-Host "  - Edit web.config local: LocalDB conn string + throwaway machineKey (never commit)"
+Write-Host "  - Boot: iisexpress /config:applicationhost.config /site:'"'"'DNN Argumentum'"'"'"
+Write-Host "  - Expect HTTP 200 (not 0x80131040). Probe: Invoke-WebRequest http://localhost:8090/ -SkipHttpErrorCheck"
+Write-Host "`nREVERT after validation (bin/ + web.config are git-tracked):" -ForegroundColor Yellow
+Write-Host "  git checkout -- DNNPlatform\bin DNNPlatform\web.config"

--- a/docs/dnn/sandbox-bootstrap-runbook.md
+++ b/docs/dnn/sandbox-bootstrap-runbook.md
@@ -1,0 +1,152 @@
+# DNN Sandbox Bootstrap Runbook — DNN 9.11.1 + 2sxc 21 (.NET Framework 4.8)
+
+**Date**: 2026-06-26 · **Author**: po-2023 (dispatched by ai-01 v3, idle track)
+**Status**: Reproducible ops runbook (capitalizes the 2026-06-25 boot-attempt characterization). Read-only doc, no code.
+**Purpose**: Bootstrap a local DNN 9.11.1 + 2sxc 21.07 sandbox for runtime validation (e.g. the 12 Razor14 templates of #596) without touching production.
+**Related**: #131 (DNN upgrade arc), #596 (Razor14 migration, runtime-pending), [UPGRADE-ASSESSMENT.md](UPGRADE-ASSESSMENT.md) §1 (verified bin/ state), [feedback-dnn-iis-express](../../) (IIS Express `/config:` gotcha).
+
+---
+
+## TL;DR
+
+The sandbox **boot infrastructure is proven** on po-2023 (LocalDB + IIS Express + DB present). DNN itself **cannot start** due to a **pre-existing `bin/` SDK-assembly contamination**: ~5 contract assemblies shipped at `.NET 9` versions (asmVer `9.0.0.0`) into a site that runs **EF Core 2.1.1** (netstandard2.0) on **.NET Framework 4.8**. EF Core 2.1.1 cannot bind `.NET 9` assemblies → HTTP 500 cascade. The fix is a **bounded clean `bin/` re-deploy** (replace ~8 net48-compatible assemblies) — an ops task, **not a config tweak**. This runbook gives the exact recipe.
+
+> ⚠️ **Local-only edits.** `DNNPlatform/bin/` and `web.config` are **git-tracked**. All edits in this runbook are **local, reverted after** — never commit a machineKey, connection string, or `bin/` binary.
+
+---
+
+## 1. Verified current state (po-2023, 2026-06-25)
+
+| Component | State | Source |
+|---|---|---|
+| **LocalDB `MSSQLLocalDB`** | ✅ present, starts clean | `sqllocaldb start MSSQLLocalDB` |
+| **DB `ArgumentumGames`** | ✅ real DNN 9.11.1 (163 tables, `Version`=9.11.1, full `aspnet_*`) | `sqlcmd` |
+| **IIS Express** | ✅ x64 + x86 present | `C:\Program Files\IIS Express\` |
+| **IIS site "DNN Argumentum"** | ✅ pre-configured (`:8090`, Clr4IntegratedAppPool v4.0, physicalPath `DNNPlatform`) | `Documents/IISExpress/config/applicationhost.config` |
+| **.NET Framework 4.8 runtime** | ✅ present | `Windows/Microsoft.NET/Framework64/v4.0.30319/` |
+| **`DNNPlatform/bin/`** | ❌ **CONTAMINATED** — see §2 | git-tracked |
+| **`web.config`** | ❌ placeholders (`Data Source=REPLACE`, `machineKey=REPLACE`) | git-tracked |
+
+## 2. The blocker — `bin/` SDK-assembly contamination (characterized)
+
+DNN returns **HTTP 500**, FR-locale title:
+> *« Impossible de charger le fichier ou l'assembly '<System.X>' … La définition trouvée du manifeste de l'assembly ne correspond pas à la référence de l'assembly. (Exception de HRESULT : 0x80131040) »*
+
+The failing assembly **advances with each binding-redirect patch** = a cascade, not a single fix.
+
+### Root cause (verified 2026-06-26)
+
+**EF Core = 2.1.1.0** (`Microsoft.EntityFrameworkCore*.dll`, netstandard2.0 — old, NOT .NET 9). But `bin/` root contains contract assemblies at **.NET 9 SDK versions** that EF Core 2.1.1 / DNN net48 **cannot bind**:
+
+| Assembly (physical `bin/`) | asmVer | fileVer (= SDK marker) | EF Core 2.1.1 needs |
+|---|---|---|---|
+| `System.Collections.Immutable` | **9.0.0.0** | 9.0.24.52809 | ~1.5/5.0/6.0 |
+| `System.Text.Json` | **9.0.0.0** | 9.0.24.52809 | ~4.7/6.0 |
+| `System.IO.Pipelines` | **9.0.0.0** | 9.0.24.52809 | ~4.x/6.0 |
+| `System.Diagnostics.DiagnosticSource` | **9.0.0.11** | 9.0.1125.51716 | ~4.x/6.0 |
+| `System.Text.Encodings.Web` | **9.0.0.0** | 9.0.24.52809 | ~4.7/6.0 |
+| `System.Buffers` | 4.0.4.0 | **4.600.24.56208** (.NET 6 SDK) | 4.0.3.0 |
+| `System.Memory` | 4.0.1.2 | 4.6.31308.01 | 4.0.1.1 |
+| `System.Numerics.Vectors` | 4.1.4.0 | 4.6.26515.06 | 4.1.3.0/4.1.4.0 |
+| `System.Runtime.CompilerServices.Unsafe` | 6.0.0.0 | 6.0.21.52210 | 4.0.4.1/4.5.x |
+| `System.Threading.Tasks.Extensions` | 4.2.0.1 | 4.6.28619.01 | 4.2.0/4.5.x |
+
+The fileVersions `4.600.x` / `9.0.x` are **.NET 6/9 SDK forwarder/contract assemblies** — dropped by a global-tool / SDK NuGet restore polluting `bin/`. A DNN 9.11.1 site on .NET Framework 4.8 cannot bind them.
+
+### Partial clean source exists — but insufficient
+
+`bin/Imageflow/` carries the **correct** older versions for 2 of these (the `codeBase`-commented redirects pointed here):
+
+| `bin/Imageflow/` assembly | asmVer (correct) |
+|---|---|
+| `System.Buffers.dll` | **4.0.3.0** ✅ |
+| `System.Memory.dll` | **4.0.1.1** ✅ |
+| `Microsoft.Extensions.*` (7 dlls) | netstandard2.0 ✅ |
+
+**But none of the 5 `.NET 9` contaminants has a clean local source** in the repo. Resolving them requires fetching net48-compatible NuGet packages (see §3).
+
+## 3. Clean `bin/` re-deploy recipe (the remaining ops work)
+
+> This is a **bounded, reproducible ops task** (~1 focused tick). It is NOT whack-a-mole redirect patching — the versions are known.
+
+### 3.1 Replace from the local clean source (free)
+
+```powershell
+# Backup first (local — never commit bin/)
+Copy-Item DNNPlatform\bin DNNPlatform\bin.contaminated.bak -Recurse
+# Buffers + Memory: use the correct bin/Imageflow/ versions
+Copy-Item DNNPlatform\bin\Imageflow\System.Buffers.dll DNNPlatform\bin\System.Buffers.dll -Force
+Copy-Item DNNPlatform\bin\Imageflow\System.Memory.dll DNNPlatform\bin\System.Memory.dll -Force
+```
+
+### 3.2 Fetch the 5 .NET 9 contaminants at net48-compatible versions (6.0.x)
+
+Pull these NuGet packages and extract the `lib/net462` (or `lib/netstandard2.0`) assemblies into `DNNPlatform/bin/`:
+
+| Package | Version | Provides |
+|---|---|---|
+| `System.Collections.Immutable` | **6.0.0** | `System.Collections.Immutable.dll` (asm 6.0.0.0) |
+| `System.Text.Json` | **6.0.0** | `System.Text.Json.dll` (asm 6.0.0.0) |
+| `System.IO.Pipelines` | **6.0.0** | `System.IO.Pipelines.dll` (asm 6.0.0.0) |
+| `System.Diagnostics.DiagnosticSource` | **6.0.0** | `System.Diagnostics.DiagnosticSource.dll` (asm 6.0.0.0) |
+| `System.Text.Encodings.Web` | **6.0.0** | `System.Text.Encodings.Web.dll` (asm 6.0.0.0) |
+
+Why 6.0: last line shipping `lib/net462` (net48-compatible), predates the `.NET 8+ TFM-only` cliff. These satisfy EF Core 2.1.1 + the DNN binding redirects.
+
+> Verify after extraction: `Get-Item bin\System.Collections.Immutable.dll` → asmVer `6.0.0.0` (not 9.0.0.0).
+
+### 3.3 Align the binding redirects (web.config, local edit)
+
+The active (uncommented) redirects at `web.config` lines ~446/454/596/600 use `oldVersion="0.0.0.0-32767...newVersion=<X>"`. Set `newVersion` to the **6.0.0.0** (or the matching physical asmVer) for the 5 replaced assemblies + `System.Buffers`→`4.0.3.0`, `System.Memory`→`4.0.1.1`. The existing `0.0.0.0-32767` oldVersion range already covers any requestor version.
+
+### 3.4 Boot + probe
+
+```powershell
+sqllocaldb start MSSQLLocalDB
+# web.config local edits (see §4)
+& "C:\Program Files\IIS Express\iisexpress.exe" /config:"...\applicationhost.config" /site:"DNN Argumentum"
+# probe (PS7 SkipHttpErrorCheck captures 500 bodies):
+Invoke-WebRequest http://localhost:8090/ -UseBasicParsing -SkipHttpErrorCheck
+```
+
+Expectation: HTTP 200 with DNN home page (not the `0x80131040` FileLoadException). If a **new** assembly mismatch surfaces, repeat §3.2-3.3 for it (bounded set).
+
+## 4. web.config local edits (revert after — never commit)
+
+```xml
+<!-- connectionString: line ~40 -->
+<add name="SiteSqlServer"
+     connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=ArgumentumGames;Integrated Security=True;"
+     providerName="System.Data.SqlClient" />
+
+<!-- machineKey: line ~151 — THROWAWAY DEV key (prod machineKey is GDrive-authoritative) -->
+<!-- Generate: [byte[]] (1..32 | %{ Get-Random -Max 256 }) → hex64 for decryption (AES-256) -->
+<machineKey validationKey="<throwaway-64+hex>" decryptionKey="<throwaway-64hex-AES>"
+            decryption="AES" validation="HMACSHA256" />
+```
+
+**Revert**: `git checkout -- DNNPlatform/web.config` (and `DNNPlatform/bin` from the backup or `git checkout`) after the validation session. Verify `git status` shows only `?? tmp/`.
+
+## 5. Runtime validation (the DoD for #596)
+
+Once DNN boots (§3-4), to validate the 12 Razor14 templates:
+
+1. **Assign** each migrated template (`Portals/1/2sxc/{News5/bs3, Content/bs3/{Link,Layout}}/`) to a 2sxc App module on a DNN page in `ArgumentumGames` (DB rows control page/module wiring — verify which pages exist).
+2. **Browser-navigate** each page → screenshot the render.
+3. **Record OK/KO** per template. KO = capture the 2sxc runtime error (yellow-screen).
+4. Post the OK/KO report on #596 → that **un-gates the merge**.
+
+> po-2023 signals the runtime report (factual OK/KO); the visual PASS verdict is ai-01/jsboige's.
+
+---
+
+## 6. Known gotchas (applied)
+
+- **IIS Express `/path:` is broken** on this machine (404s silently) — **must** use `/config:` + the named "DNN Argumentum" site. ([feedback-dnn-iis-express])
+- **Do NOT whack-a-mole** binding redirects without replacing the physical assemblies — patching `System.Buffers`→4.0.4.0 just advanced the cascade to `System.Collections.Immutable`. Replace the DLLs (§3.2), then align redirects (§3.3).
+- **One `dotnet run` / IIS site at a time** for any MindMap-related work (unrelated here, but the machine shares the desktop).
+- `bin/` + `web.config` are **git-tracked** — local edits show in `git status`; revert before any commit/PR.
+
+## 7. Why not just patch redirects?
+
+Tested 2026-06-25: patching the `System.Buffers` redirect `4.0.3.0`→`4.0.4.0` advanced the error to `System.Collections.Immutable` (the next contaminated assembly). With ~5 `.NET 9` assemblies all mismatched, redirect-patching is an indefinite chase, and even if it bound, the `.NET 9` assemblies are ABI-incompatible with EF Core 2.1.1 / Imageflow compiled against older versions → runtime errors after binding. **The DLLs must be replaced, not just redirected.**


### PR DESCRIPTION
Two **net-new** ops docs in `docs/dnn/`, both **complements** to the existing [#132 deployment runbook](../blob/master/docs/dnn-localization/132-deployment-runbook.md) (PR #594) — **no duplication**.

## What's here

### `docs/dnn/sandbox-bootstrap-runbook.md` (idle track)
Capitalizes the 2026-06-25 `bin/` SDK-contamination characterization (PR #596 `issuecomment-4804068740`):
- Verified boot infra: LocalDB `MSSQLLocalDB` + IIS Express `:8090` "DNN Argumentum" site + DB `ArgumentumGames` (DNN 9.11.1, 163 tables)
- The blocker: `bin/` root carries **.NET 9 SDK contract assemblies** (`System.Collections.Immutable` 9.0.0.0, `System.Text.Json` 9.0.0.0, `System.IO.Pipelines` 9.0.0.0, `System.Diagnostics.DiagnosticSource` 9.0.0.11, `System.Text.Encodings.Web` 9.0.0.0) that EF Core **2.1.1.0** (netstandard2.0) on .NET Framework 4.8 **cannot bind** → HTTP 500 `0x80131040` cascade.
- Bounded fix recipe: replace `System.Buffers`/`System.Memory` from `bin/Imageflow/` (clean 4.0.3.0/4.0.1.1), fetch the 5 `.NET 9` contaminants at **6.0.x** NuGet (`lib/net462`, last net48-compatible line), align binding redirects.
- §6 gotchas: IIS Express `/path:` broken → `/config:`; do NOT whack-a-mole redirects (cascade); `bin/`+`web.config` git-tracked → local edits reverted.

This is the **remaining ops work to un-gate #596** runtime validation (ai-01 dispatch v3, timeboxed no-yak-shave → documented as reproducible runbook).

### `docs/dnn/go-live-smoke-test.md` (secondary track)
Detailed **URL-level smoke-test checklist** run in the maintenance window, immediately after the #132 Phase-5 wizard completes (before exiting maintenance mode). Why this exists and doesn't duplicate #132:
- #132 treats smoke as 1-liners per phase.
- #132 **predates** #596 (12 Razor14 templates) and #597 (4 social-auth connectors) → doesn't smoke-test them.
- This doc gives the operator a concrete green/red signal table.

Three sections:
- **(A) Platform core** — version `SELECT`, homepage 200, PersonaBar, language switcher (FR⇄en, #216-leak class), admin login, SEO URLs.
- **(B) Argumentum 2sxc app + 12 Razor14 templates** (#596) — FallacyExplorer, RulesExplorer, Album, News5 bs3 (Details/List/Layout), Content bs3 (Link views). Red on B4-B7 = incomplete RazorComponent→Razor14 API migration.
- **(C) Social auth connectors** (#597) + eshop — Facebook/Google/LiveConnect/Twitter OAuth initiation, OpenStore admin, Stripe checkout. #597 caveat: pre-existing fragility → compare vs #132 Phase-0 baseline.

Sign-off gate references #132 §6 rollback contract.

## Scope / safety
- **Read-only docs, no code.** 0 `Cards/` changes — master stays `bef3bc6c` for the v0.9.0 release.
- Cross-references (not duplicates) the #132 runbook, UPGRADE-ASSESSMENT §5 (eshop), and the sandbox-bootstrap runbook (B4-B7 = #596 un-gate checks).
- po-2023 signals factual OK/KO on runtime runs; the PASS verdict is ai-01/jsboige's.

Related: #131 (DNN upgrade arc), #596 (runtime-pending), #597 (auth connectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)