### PR TITLE
docs(taxonomy): #600 link census reproducibility — independent re-run byte-identical

### DIFF
--- a/docs/taxonomy/192-link-coverage-research.md
+++ b/docs/taxonomy/192-link-coverage-research.md
@@ -93,6 +93,8 @@ The §5 ceilings were theoretical. This section **measures** the real resolvable
 
 Script: [`192-link-coverage-langlinks-probe.py`](192-link-coverage-langlinks-probe.py) — read-only, no API key, ~0.3 s throttle, descriptive User-Agent (MediaWiki 403s the default urllib UA). Census run = 0 errors on 741 (Fallacies) + 88 (Virtues) articles.
 
+**Reproducibility — re-confirmed 2026-06-27 (po-2024, master `c20d5d2c`).** An independent full re-run of both datasets (same probe, `0 fallacies` then `0 virtues`, 741 + 88 articles) returned **byte-identical** figures: Fallacies 2 739 / 4 823 (57 %), Virtues 180 / 322 (56 %), 0 errors, and the same `link_en` categorization (Fallacies 900 Wikipedia · 433 non-Wikipedia · 75 empty; Virtues 185 · 9 · 29). The per-language rows match cell-for-cell. The §5.1 numbers are therefore stable and decision-grade — not a one-run artefact or a mislabeled sample.
+
 ### Fallacies — 1 408 rows
 
 | `link_<lang>` | candidate cells missing | confirmed resolvable | rate |


### PR DESCRIPTION
## Summary

An independent **reproducibility re-run** of the `link_*` langlinks census (#600, merged `32dd809b`), confirming the §5.1 decision-grade figures are stable — not a one-run artefact or mislabeled sample.

> **Context**: dispatch ai-01 2026-06-27 (tertiaire) asked to "replace the ~57% estimate with a named number via a full census." Reading the merged #600 doc revealed the **named number was already on master** — §5.1 (measured census, 2026-06-25) sits one minute *after* the dispatch was written (which referenced the older §5 theoretical ceiling of 8110). This PR therefore contributes what's genuinely missing: a **second independent run** that pins the figure as reproducibly-confirmed.

## Re-run (2026-06-27, master `c20d5d2c`)

Full probe, both datasets (`0 fallacies` then `0 virtues`), 741 + 88 = 829 unique articles, ~0.3s throttle, 0 API key.

| Dataset | §5.1 (2026-06-25) | Re-run (2026-06-27) | Errors | Match |
|---|---|---|---|---|
| Fallacies | 2739 / 4823 (57%) | 2739 / 4823 (57%) | 0/741 | ✅ byte-identical |
| Virtues | 180 / 322 (56%) | 180 / 322 (56%) | 0/88 | ✅ byte-identical |
| **Combined** | **~2919** | **~2919** | — | ✅ |

`link_en` categorization also matches: Fallacies 900 Wikipedia · 433 non-Wikipedia · 75 empty; Virtues 185 · 9 · 29. Per-language rows match cell-for-cell (ru/pt/es/ar/fa/zh).

## What changed

One paragraph added under §5.1 — a "Reproducibility — re-confirmed 2026-06-27" note stating the figures are stable and decision-grade. No table/code changes; the data is the data.

## Why this matters

The 2919 figure feeds jsboige's WE priority decision (how bounded the post-release link-fill effort is). A single-run measurement is a claim; a re-run that returns identical numbers is a **reproducibly-confirmed** claim — the same epistemic bar the characterization test (PR #604) sets for the Virtues FR-frozen behaviour.

## Scope

- ✅ **0 write under `Cards/`** (read-only docs, release freeze respected)
- ✅ Base `c20d5d2c`, 1 file, +2 lines
- Dispatch ai-01 2026-06-27, tertiaire (#600 census link_* complet)
- Pre-existing MD060 markdown-lint table-style warnings in the file are out of scope (cosmetic, on tables I did not touch)

Relates to #600. Does not change its conclusion — confirms it.
