### PR TITLE
docs(publication): #135 news article v0.9.0 brouillon (FR+EN, gated publish)

### DIFF
--- a/docs/publication/README.en.md
+++ b/docs/publication/README.en.md
@@ -24,6 +24,11 @@ Any substantive update to an FR document must be mirrored in the EN counterpart 
 
 The rules ("booklet") ship as **Rules cards** in the Tarot deck (and the Print&Play A4) — there is no separate document. See the "Game rules" section of [cards-catalog.en.md](cards-catalog.en.md).
 
+### 3. Release announcement article
+
+- **[news-article-v0.9.0.en.md](news-article-v0.9.0.en.md)** — EN mirror draft of the v0.9.0 release announcement (DNN News5 module); publication gated on #134/#131/#132 (issue #135).
+- **[news-article-v0.9.0.fr.md](news-article-v0.9.0.fr.md)** — French canonical.
+
 ## Conventions
 
 - Documents take the ISO language code as suffix: `*.fr.md`, `*.en.md`.

--- a/docs/publication/README.fr.md
+++ b/docs/publication/README.fr.md
@@ -24,6 +24,11 @@ Toute mise à jour matérielle d'un document FR doit être répliquée dans le m
 
 Les règles (« livret ») sont livrées sous forme de **cartes Rules** dans le deck Tarot (et le Print&Play A4) — il n'existe pas de document séparé. Voir la section « Règles du jeu » de [cards-catalog.fr.md](cards-catalog.fr.md).
 
+### 3. Article d'annonce de release
+
+- **[news-article-v0.9.0.fr.md](news-article-v0.9.0.fr.md)** — brouillon FR canonique de l'article d'annonce v0.9.0 (module News5 DNN) ; publication gated #134/#131/#132 (issue #135).
+- **[news-article-v0.9.0.en.md](news-article-v0.9.0.en.md)** — miroir anglais.
+
 ## Conventions
 
 - Les documents prennent le code de langue ISO en suffixe : `*.fr.md`, `*.en.md`.

--- a/docs/publication/news-article-v0.9.0.en.md
+++ b/docs/publication/news-article-v0.9.0.en.md
@@ -1,0 +1,147 @@
+# Announcement article — Argumentum v0.9.0 (EN mirror draft)
+
+> **Status: DRAFT (#135 prep).** Public-facing announcement article for the v0.9.0 release, to be
+> published on the DNN portal **News5** module. **English mirror** of the FR canonical
+> ([news-article-v0.9.0.fr.md](news-article-v0.9.0.fr.md)). The DNN portal serves FR as primary; EN
+> is the bilingual mirror per `docs/publication/` convention.
+> **Publication is GATED** on #134 (GitHub Release tag), #132 (prod deployment) and #131 (DNN 10.3.2
+> live) — see "Publish checklist" below. This file prepares the copy; it publishes nothing.
+>
+> **Source of truth:** [RELEASE-NOTES-v0.9.0.md](../../RELEASE-NOTES-v0.9.0.md),
+> [docs/release-dossier/README.md](../release-dossier/README.md),
+> [cards-catalog.en.md](cards-catalog.en.md). Every figure is verified there as of 2026-06-29;
+> `[PLACEHOLDER]` fields are filled at tag time.
+
+---
+
+## SEO / CMS metadata (fill at publish)
+
+| Field | Value |
+|-------|-------|
+| **SEO title** (`<title>`) | Argumentum v0.9.0 — the fallacy card game, now in 8 languages |
+| **Meta description** (<160 char.) | Argumentum v0.9.0: 8 languages, 4 new game variants, updated mind maps and ontology. Free Print & Play materials to download. |
+| **URL slug** | `argumentum-v0-9-0-8-languages` |
+| **og:image** | `[PLACEHOLDER — A0 EN thumbnail or 4-variants mosaic, ~1200×630]` |
+| **twitter:card** | `summary_large_image` |
+| **og:locale** | `en_US` (FR canonical: `fr_FR`) |
+| **Publish date** | `[PLACEHOLDER — day of the v0.9.0 tag]` |
+| **CMS author** | Argumentum Games |
+
+> **Sitemap:** add the canonical URL to the DNN sitemap at publish; declare `hreflang` alternates
+> for translated variants (FR/RU/PT/ES/AR/FA/ZH) once they exist.
+
+---
+
+## Article body (EN)
+
+### Argumentum v0.9.0 — the fallacy card game, now in 8 languages
+
+**Argumentum**, the educational card game that teaches you to spot logical fallacies and build
+rigorous arguments, releases version **0.9.0**. Its most ambitious update to date expands language
+coverage from 4 to **8 languages**, adds **four new game variants**, and refreshes the cards, mind
+maps and taxonomy ontology.
+
+The full set of materials — printable cards, mind maps and ontology — is available as a free
+download under an open license.
+
+#### 🌍 Eight languages, one corpus
+
+Argumentum is now generated end-to-end in **8 languages**: French (source language), English,
+Russian, Portuguese, Spanish, Arabic, Persian and Chinese. Every piece of game data — the **1408
+nodes** of the fallacy taxonomy, the **223 nodes** of argumentation virtues, the **167 game
+scenarios** and the rules — is 100% translated into each of these languages, including non-Latin
+scripts (Cyrillic, Arabic, Persian, Chinese).
+
+| Language | Script | |
+|----------|--------|---|
+| Français | Latin | source language |
+| English · Português · Español | Latin | |
+| Русский | Cyrillic | |
+| العربية · فارسی | RTL (right-to-left) | |
+| 中文 | CJK | |
+
+#### 🃏 Four new game variants
+
+The **Rules** deck gains four brand-new game modes that freshen up play sessions:
+
+- **Bingo mixologie argumentative**
+- **Dernier Beau Parleur**
+- **Moulin à Baratin**
+- **Parlote Coinchée**
+
+Each variant ships as a rule card inside the Tarot deck (and the Print & Play A4 booklet).
+
+#### 📚 Enriched taxonomy, mind maps and ontology
+
+The fallacy taxonomy has been consolidated: the 7 FR family roots were reviewed cell by cell, and
+translation consistency is now deterministic (no machine-translation artefacts, correct scripts for
+non-Latin languages). The **argumentation virtues** and the **167 scenarios** (previously 54%
+translated) now reach 100% coverage.
+
+**Mind maps** (Fallacies + Virtues) were regenerated as FreeMind SVG, and the **OWL ontology**
+(with SKOS alignments and AIF references) documents the formal structure of the taxonomy — a
+foundation for computational-argumentation research.
+
+#### 🖨 Print & Play
+
+All materials are available as **A4 Print & Play**: duplex printing on heavy paper (160–250 g/m²),
+cut, and play. Two booklets:
+
+- `TarotCards_Print&Play_A4` — Rules + Memo + Fallacies
+- `PokerCards_Print&Play_A4` — Scenarios
+
+#### 📦 Downloads
+
+Packages are hosted on the [GitHub Releases page](https://github.com/ArgumentumGames/Argumentum/releases)
+`[PLACEHOLDER — link to the v0.9.0 release once tagged]`.
+
+| Package | Contents | Languages |
+|---------|----------|-----------|
+| **Full** | All materials (Tarot, Poker, Print & Play, FallaciesWeb A0/A4, Thumbnails) | all 8 |
+| **Print & Play** | Print & Play A4 PDFs only (home printing, duplex) | all 8 |
+| **Per language** | Complete materials for one language | pick one |
+| **Mind maps** | Fallacies + Virtues SVG | `[PLACEHOLDER — 4 or 8 languages per MindMap scope decision]` |
+| **Ontology** | `argumentum.owl` + documentation | FR |
+
+Per-format detail (Tarot, Poker, Print & Play, FallaciesWeb A0/A4/Thumbnails) and printing
+instructions: see the [card catalog](cards-catalog.en.md) and the
+[release dossier downloads snippet](../release-dossier/README.md#5-readme-download-section-snippet-ready-to-paste--issue-134-asks-for-it).
+
+> **64 PDFs in total** = 8 languages × 8 document types, parity verified.
+
+#### 💬 Join the community
+
+`[PLACEHOLDER — community link / Discord / GitHub Discussions per decision]`
+
+---
+
+## Publish checklist (gates #134 / #132 / #131)
+
+Tick at tag time — **do not publish until all are green**:
+
+- [ ] **#134** — Tag `v0.9.0` set + GitHub Release created (assets uploaded).
+- [ ] **#131** — DNN **10.3.2 + 2sxc 21** live in production (release coupling validated by jsboige).
+- [ ] **#132** — Full prod deployment (runbook Phase 5).
+- [ ] Replace every `[PLACEHOLDER]`: v0.9.0 release URL, date, og:image, MindMap scope (4 or 8), community link.
+- [ ] Upload the `og:image` to DNN media and reference its final URL.
+- [ ] Create the post in the **News5** module (DNN), paste the EN body, set slug + meta.
+- [ ] Add the canonical URL to the DNN sitemap; declare `hreflang` alternates for translated variants.
+- [ ] **Final visual verdict** = jsboige / ai-01 (worker signals, does not declare PASS).
+- [ ] Update the site **Downloads** page with v0.9.0 links (issue #135 §Downloads).
+
+## Translations
+
+Per `docs/publication/` convention (FR canonical + EN mirror in the same PR), this English mirror
+accompanies the canonical French file: [news-article-v0.9.0.fr.md](news-article-v0.9.0.fr.md).
+
+The **6 other languages** (RU/PT/ES/AR/FA/ZH) follow at publish time via the `DatasetUpdater`
+pipeline (same discipline as #192 native-ratification: translate then human-validate non-Latin
+scripts, especially RTL/CJK). Planned post-tag, non-blocking for FR+EN publication.
+
+## Sources
+
+- [RELEASE-NOTES-v0.9.0.md](../../RELEASE-NOTES-v0.9.0.md) — canonical figures (8 languages, 64 PDFs, 4 variants, ~9834 images, 5.3 MB OWL).
+- [docs/release-dossier/README.md](../release-dossier/README.md) — validation dossier + README downloads snippet (§5) + gate checklist (§4).
+- [cards-catalog.en.md](cards-catalog.en.md) — formats and physical dimensions.
+- Issue [#135](https://github.com/ArgumentumGames/Argumentum/issues/135) — brief (original body stale: "4 languages"; live scope = 8).
+- Dependency issues: #134 (release), #131 (DNN), #132 (deploy).

--- a/docs/publication/news-article-v0.9.0.fr.md
+++ b/docs/publication/news-article-v0.9.0.fr.md
@@ -1,0 +1,147 @@
+# Article d'annonce — Argumentum v0.9.0 (brouillon FR canonique)
+
+> **Statut : BROUILLON (prep #135).** Article public-facing d'annonce de la release v0.9.0, à publier
+> sur le module **News5** du portail DNN. Version FR canonique (le portail sert le FR en primaire).
+> **La publication est GATED** sur #134 (tag GitHub Release), #132 (déploiement prod) et #131 (DNN
+> 10.3.2 live) — voir « Checklist de publication » en bas. Ce fichier est la préparation du texte ;
+> il ne publie rien.
+>
+> **Source de vérité :** [RELEASE-NOTES-v0.9.0.md](../../RELEASE-NOTES-v0.9.0.md) (technique),
+> [docs/release-dossier/README.md](../release-dossier/README.md) (dossier + snippet downloads §5),
+> [cards-catalog.fr.md](cards-catalog.fr.md) (formats). Cet article est le **volet public** — il
+> vulgarise, ne duplique pas le technique. Tout chiffre cité est vérifié dans ces sources au
+> 2026-06-29 ; les champs `[PLACEHOLDER]` sont à remplir au moment du tag.
+
+---
+
+## Méta-données SEO / CMS (à remplir au publish)
+
+| Champ | Valeur |
+|-------|--------|
+| **Titre SEO** (`<title>`) | Argumentum v0.9.0 — le jeu de cartes sur les sophismes, désormais en 8 langues |
+| **Meta description** (<160 car.) | Argumentum v0.9.0 : 8 langues, 4 nouvelles variantes de jeu, mind maps et ontologie mises à jour. Matériel Print & Play gratuit à télécharger. |
+| **Slug URL** | `argumentum-v0-9-0-8-langues` |
+| **og:image** | `[PLACEHOLDER — vignette A0 FR ou mosaïque 4 variantes, ~1200×630]` |
+| **twitter:card** | `summary_large_image` |
+| **og:locale** | `fr_FR` (variantes `en_US`, `ru_RU`, `pt_PT`, `es_ES`, `ar_AR`, `fa_IR`, `zh_CN` aux miroirs traduits) |
+| **Date de publication** | `[PLACEHOLDER — jour du tag v0.9.0]` |
+| **Auteur CMS** | Argumentum Games |
+
+> **Sitemap :** ajouter l'URL canonique au sitemap DNN au publish. Les variantes traduites (EN/RU/PT/
+> ES/AR/FA/ZH) devront avoir leurs `hreflang` alternates déclarés (voir « Traductions » en bas).
+
+---
+
+## Corps de l'article (FR)
+
+### Argumentum v0.9.0 — le jeu de cartes sur les sophismes, désormais en 8 langues
+
+**Argumentum**, le jeu de cartes pédagogique qui apprend à repérer les sophismes et à défendre des
+arguments rigoureux, sort en version **0.9.0**. Cette mise à jour la plus ambitieuse à ce jour
+étend la couverture linguistique de 4 à **8 langues**, ajoute **quatre nouvelles variantes de jeu**,
+et met à jour les cartes, les cartes mentales et l'ontologie de la taxonomie.
+
+Le matériel complet — cartes à imprimer, cartes mentales et ontologie — est disponible en téléchargement
+gratuit sous licence ouverte.
+
+#### 🌍 Huit langues, un seul matériel
+
+Argumentum est désormais généré intégralement en **8 langues** : français (langue source), anglais,
+russe, portugais, espagnol, arabe, persan et chinois. Toutes les données du jeu — les **1408 nœuds**
+de la taxonomie des sophismes, les **223 nœuds** des vertus argumentatives, les **167 scénarios** de
+jeu et les règles — sont traduites à 100 % dans chacune de ces langues, y compris les scripts
+non latins (cyrillique, arabe, persan, chinois).
+
+| Langue | Script | |
+|--------|--------|---|
+| Français | Latin | langue source |
+| English · Português · Español | Latin | |
+| Русский | Cyrillique | |
+| العربية · فارسی | RTL (droite-à-gauche) | |
+| 中文 | CJK | |
+
+#### 🃏 Quatre nouvelles variantes de jeu
+
+Le deck **Règles** s'enrichit de quatre modes de jeu inédits qui renouvellent les parties :
+
+- **Bingo mixologie argumentative**
+- **Dernier Beau Parleur**
+- **Moulin à Baratin**
+- **Parlote Coinchée**
+
+Chaque variante est livrée comme carte-règle dans le deck Tarot (et le livret Print & Play A4).
+
+#### 📚 Taxonomie enrichie, cartes mentales et ontologie
+
+La taxonomie des sophismes a été consolidée : les 7 racines de familles FR ont été révisées
+cellule par cellule, et la cohérence des traductions est désormais déterministe (aucun artefact de
+traduction automatique, scripts corrects pour les langues non latines). Les **vertus argumentatives**
+et les **167 scénarios** (précédemment traduits à 54 %) sont désormais couverts à 100 %.
+
+Les **cartes mentales** (Fallacies + Virtues) ont été régénérées au format SVG FreeMind, et
+l'**ontologie OWL** (avec alignements SKOS et références AIF) documente la structure formelle de la
+taxonomie — un socle pour la recherche en argumentation computationnelle.
+
+#### 🖨 Print & Play
+
+Tout le matériel est disponible en **Print & Play A4** : impression recto-verso sur papier épais
+(160–250 g/m²), découpe, et jouer. Deux livrets :
+
+- `TarotCards_Print&Play_A4` — Règles + Mémo + Fallacies
+- `PokerCards_Print&Play_A4` — Scénarios
+
+#### 📦 Téléchargements
+
+Les paquets sont hébergés sur la page [Releases GitHub](https://github.com/ArgumentumGames/Argumentum/releases)
+`[PLACEHOLDER — lien vers la release v0.9.0 une fois taguée]`.
+
+| Paquet | Contenu | Langues |
+|--------|---------|---------|
+| **Complet** | Tout le matériel (Tarot, Poker, Print & Play, FallaciesWeb A0/A4, Thumbnails) | les 8 |
+| **Print & Play** | PDFs Print & Play A4 uniquement (impression maison, recto-verso) | les 8 |
+| **Par langue** | Matériel complet pour une langue | au choix |
+| **Cartes mentales** | SVG Fallacies + Virtues | `[PLACEHOLDER — 4 ou 8 langues selon décision scope MindMap]` |
+| **Ontologie** | `argumentum.owl` + documentation | FR |
+
+Détail par format (Tarot, Poker, Print & Play, FallaciesWeb A0/A4/Thumbnails) et instructions
+d'impression : voir le [catalogue des cartes](cards-catalog.fr.md) et le
+[snippet downloads du dossier release](../release-dossier/README.md#5-readme-download-section-snippet-ready-to-paste--issue-134-asks-for-it).
+
+> **64 PDFs au total** = 8 langues × 8 types de documents, parité vérifiée.
+
+#### 💬 Rejoindre la communauté
+
+`[PLACEHOLDER — lien communauté / Discord / GitHub Discussions selon décision]`
+
+---
+
+## Checklist de publication (gates #134 / #132 / #131)
+
+À cocher au moment du tag — **ne pas publier tant que tout n'est pas vert** :
+
+- [ ] **#134** — Tag `v0.9.0` posé + GitHub Release créée (assets uploadés).
+- [ ] **#131** — DNN **10.3.2 + 2sxc 21** live en production (couplage release validé par jsboige).
+- [ ] **#132** — Déploiement prod complet (runbook Phase 5).
+- [ ] Remplacer tous les `[PLACEHOLDER]` : URL release v0.9.0, date, og:image, scope MindMap (4 ou 8), lien communauté.
+- [ ] Charger l'`og:image` dans le media DNN et référencer son URL finale.
+- [ ] Créer le post dans le module **News5** (DNN), coller le corps FR, régler slug + méta.
+- [ ] Ajouter l'URL canonique au sitemap DNN ; déclarer les `hreflang` aux variantes traduites.
+- [ ] **Verdict visuel final** = jsboige / ai-01 (le worker signale, ne déclare pas PASS).
+- [ ] Mettre à jour la page **Téléchargements** du site avec les liens v0.9.0 (issue #135 §Downloads).
+
+## Traductions (miroirs)
+
+Conformément à la convention `docs/publication/` (FR canonique + miroir EN dans le même PR), un
+**miroir anglais** accompagne ce fichier : [news-article-v0.9.0.en.md](news-article-v0.9.0.en.md).
+
+Les **6 autres langues** (RU/PT/ES/AR/FA/ZH) suivront au publish via le pipeline `DatasetUpdater`
+(même discipline que la native-ratification #192 : traduction puis validation humaine des scripts
+non latins, en particulier RTL/CJK). À planifier post-tag, non bloquant pour la publication FR+EN.
+
+## Sources
+
+- [RELEASE-NOTES-v0.9.0.md](../../RELEASE-NOTES-v0.9.0.md) — chiffres canoniques (8 langues, 64 PDFs, 4 variantes, ~9834 images, OWL 5.3 Mo).
+- [docs/release-dossier/README.md](../release-dossier/README.md) — dossier de validation + snippet README downloads (§5) + gate checklist (§4).
+- [cards-catalog.fr.md](cards-catalog.fr.md) — formats et dimensions physiques.
+- Issue [#135](https://github.com/ArgumentumGames/Argumentum/issues/135) — cahier des charges ( corps d'origine stale : « 4 langues » ; scope réel = 8).
+- Issues de dépendance : #134 (release), #131 (DNN), #132 (deploy).


### PR DESCRIPTION
## Summary

**Idle #135** (endorsed by ai-01 deep-queue idle fallback). Net-new **public-facing announcement article** for the v0.9.0 release — the text prep for the DNN **News5** module. **Publish action stays GATED** on #134 (tag) + #131 (DNN 10.3.2 live) + #132 (deploy); this PR is copy preparation, it publishes nothing.

Issue #135's body is **stale** ("4 languages FR/EN/RU/PT") — the live release scope is **8 languages** (decision #4, merged via #359/#360/#361). This draft reflects the **current** scope, verified against the codebase.

## What it delivers

Two net-new files under `docs/publication/` (FR canonical + EN mirror, per the dir's bilingual convention):

- **`news-article-v0.9.0.fr.md`** — FR canonical (DNN serves FR primary)
- **`news-article-v0.9.0.en.md`** — EN mirror

Plus a one-line inventory entry added to `README.fr.md` + `README.en.md` (doc #3) for discoverability.

## Grounded (no figure invented — all verified 2026-06-29)

| Claim | Source |
|-------|--------|
| 8 languages (fr/en/ru/pt/es/ar/fa/zh) | `AssetConverterConfig.cs` localization map (config-verified) |
| 1408 fallacy nodes + 223 virtues + 167 scenarios, 100% translated | CLAUDE.md recovery status + RELEASE-NOTES-v0.9.0.md |
| 4 new game variants (Bingo mixologie argumentative, Dernier Beau Parleur, Moulin à Baratin, Parlote Coinchée) | `Cards/Rules/Argumentum Rules - Cards.csv` (grep-verified) |
| 64 PDFs (8 langs × 8 types), OWL 5.3 MB SKOS+AIF, ~9834 images | RELEASE-NOTES-v0.9.0.md |
| Downloads taxonomy (Full / Print&Play / Per-language / MindMaps / Ontology) | extends release-dossier README §5 snippet |

## Structure (per file)

1. **DRAFT header** — gating (#134/#131/#132) + source-of-truth links.
2. **SEO/CMS metadata block** — title, meta description, slug, og:image, twitter:card, og:locale, hreflang note, sitemap.
3. **Article body** — 8 languages · 4 game variants · enriched taxonomy + mind maps + ontology · Print & Play · downloads · community CTA.
4. **Publish checklist** — the gates to tick at tag time.
5. **Translations** — EN mirror done; 6 other langs via `DatasetUpdater` post-tag (non-blocking, same discipline as #192 native-ratification).

## Explicit placeholders (filled at tag time)

Every release-specific field is a `[PLACEHOLDER]`: v0.9.0 release URL, publish date, og:image asset, MindMap scope (4 vs 8 — jsboige gate), community link. None asserted prematurely.

## Safety / scope

- ✅ **0 write `Cards/`**, **0 AssetConverter code change** (pre-tag safe).
- ✅ `docs/publication/` only — no consumer file edited (README inventory add excepted, which is the doc index itself).
- ✅ Base `ba8e4a6c`, docs-only → CLEAN expected.

## Next (post-release, gated)

At tag time: replace placeholders → upload og:image → create News5 post (DNN) → update site Downloads page with v0.9.0 links → declare hreflang alternates for translated variants → **visual verdict = jsboige/ai-01** (worker signals, does not declare PASS).

Relates to #135, #134, #131, #132.
