### PR TITLE
fix(pipeline): #613 harvest resilient to per-set failures (no more abort-all on one timeout)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
@@ -82,6 +82,11 @@ public class HarvestManager : IAsyncDisposable
 
 		var funcBrowser = new Func<Task<IBrowser>>(GetBrowserAsync);
 
+		// Issue #613: collect per-set failures so one set timing out (e.g. a large set under high
+		// parallelism) does not abort the whole multi-language harvest. All reachable sets are
+		// attempted and persisted; a single aggregate error is raised at the end if any failed.
+		var failedSets = new ConcurrentBag<(string cardSet, string language, string error)>();
+
 		var parallelOptionsCardset = new ParallelOptions { MaxDegreeOfParallelism = Config.EnableParallelism? Config.MaxDegreeOfParallelismCardpen : 1 };
 		await Parallel.ForEachAsync(targetCardSets, parallelOptionsCardset, async (configCardSet, token) =>
 		{
@@ -89,9 +94,29 @@ public class HarvestManager : IAsyncDisposable
 			var parallelOptionsCardsetLanguage = new ParallelOptions { MaxDegreeOfParallelism = Config.EnableParallelism?  Config.MaxDegreeOfParallelismCardpenTranslations : 1 };
 			await Parallel.ForEachAsync(targetLanguages, parallelOptionsCardsetLanguage, async (currentLanguage, newToken) =>
 			{
-				await ProcessLocalizedHarvest(configCardSet, currentLanguage, harvestDictionary, funcBrowser);
+				try
+				{
+					await ProcessLocalizedHarvest(configCardSet, currentLanguage, harvestDictionary, funcBrowser);
+				}
+				catch (Exception ex) when (Config.ContinueOnHarvestSetFailure)
+				{
+					// Persist the failure and keep harvesting the other sets (issue #613).
+					failedSets.Add((configCardSet.Name, currentLanguage, ex.Message));
+					Logger.Log($"[HARVEST-FAILURE] Card set '{configCardSet.Name}' / '{currentLanguage}' failed and was skipped: {ex.Message}", MessageType.Problem);
+				}
 			});
 		});
+
+		if (!failedSets.IsEmpty)
+		{
+			var summary = string.Join("; ", failedSets.Select(f => $"{f.cardSet}/{f.language}"));
+			Logger.Log($"[HARVEST-PARTIAL] {failedSets.Count} card set(s) failed to harvest and were skipped: {summary}. " +
+				"All successful harvests were persisted to disk — re-run to collect the missing sets (the cache skips the good ones). " +
+				"If large sets time out, set EnableParallelism=false or lower MaxDegreeOfParallelismCardpen (issue #613).", MessageType.Problem);
+			throw new ApplicationException(
+				$"Harvest completed with {failedSets.Count} failed card set(s): {summary}. " +
+				"Successful harvests were persisted; re-run to collect the missing sets (issue #613).");
+		}
 
 		return harvestDictionary;
 	}

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
@@ -34,6 +34,16 @@ namespace Argumentum.AssetConverter
 
 		public int MaxDegreeOfParallelismCardpenTranslations { get; set; } = 2;
 
+		/// <summary>
+		/// Issue #613: when true (default), a card set whose harvest fails (e.g. a large set
+		/// timing out under high parallelism) is logged and skipped so the remaining sets still
+		/// harvest and persist to disk; a single aggregate error is raised at the end of the run
+		/// listing every failed set. A re-run then skips the good harvests (cache) and only
+		/// re-collects the missing ones. When false, the first failure aborts the whole harvest
+		/// (legacy behavior).
+		/// </summary>
+		public bool ContinueOnHarvestSetFailure { get; set; } = true;
+
 		public int MaxDegreeOfParallelismImages { get; set; } = 3;
 
 		public int MaxDegreeOfParallelismImageTranslations { get; set; } = 2;


### PR DESCRIPTION
## Quoi
Corrige #613 : lors de la régén Release 8-lang (2026-06-29), **un seul card set qui timeout** (grand set — Virtues 113 / Scenarii 174 / Fallacies 1408 — sous le `MaxDegreeOfParallelism` que l'optimizer monte à 6) **abortait TOUT le pipeline** (`throw` propagé hors du `Parallel.ForEachAsync` imbriqué), perdant tous les sets pas encore traités.

## Comment
`HarvestImages` :
1. **tente chaque set atteignable** et **persiste sur disque** tous les harvests réussis (`File.Create` post-success → re-run skip via cache) ;
2. collecte les échecs par set ;
3. s'il y a des échecs : log `[HARVEST-PARTIAL]` (MessageType.Problem) listant tous les sets ratés + lève **une seule** `ApplicationException` agrégée **à la fin** (pas au premier échec) → une régén partielle n'est **jamais silencieuse**, et un re-run ne récolte que les manquants.

Garde-fou No-Pendulum : ni abort-tout-au-premier (trop fragile), ni swallow-silencieux (trop permissif) → continue + échec terminal bruyant.

Gated par le nouveau flag `WebBasedGeneratorConfig.ContinueOnHarvestSetFailure` (**défaut true**) ; `false` = comportement legacy (abort au premier échec).

## Scope
- `HarvestManager.cs` (+27/-1) : guard `when (Config.ContinueOnHarvestSetFailure)` au call-site + summary/throw final.
- `WebBasedGeneratorConfig.cs` (+10) : flag + doc.
- **0 write `Cards/`, 0 JSON** (config JSON = régénérée depuis C#).

## Validation
- Build Debug : **0 erreur**.
- Tests unitaires : **549 réussis / 0 échec / 5 ignorés** (≥ baseline 540).
- Validation régén complète : en cours via la passe **serial** de po-2023 (workaround Option C). Le fix rend la passe **parallèle** résiliente pour les prochaines régén.

Ref #458 (TRACK 1 — matériel 8 langues). Diagnostic root cause : po-2023.

🤖 Coordinator ai-01 (lane pipeline-fix)