### PR TITLE
docs(release): #591 refresh v3 dossier v0.9.0 — verdict Release PASS + 2 findings (présentation jsboige)

### DIFF
--- a/docs/RELEASE-VALIDATION-v0.9.0.md
+++ b/docs/RELEASE-VALIDATION-v0.9.0.md
@@ -1,9 +1,9 @@
 # Argumentum v0.9.0 — Dossier de validation release
 
-**Date** : 2026-07-01 (refresh post-régén fraîche 8-lang + verdict visuel PASS ai-01)
-**Statut** : ASSETS VALIDÉS (verdict visuel ai-01 = PASS représentatif) — en attente décision params Release/couplage go-live jsboige
-**Branche** : `docs/release-v0.9.0-validation`
-**Master de référence** : `18b4d023` (build zéro-warning CS+NU, **549/0/5 tests**). Régén release 8-lang **2026-07-01** sur `18b4d023` + #614 (`EnableParallelism=false` serial), bundle validé sur GDrive `review-v0.9.0-2026-06-28/`.
+**Date** : 2026-07-01 (refresh v3 : régén RELEASE fraîche print-final + verdict visuel Release PASS ai-01)
+**Statut** : ASSETS VALIDÉS (verdict Release ai-01 = PASS géométrie/contenu + micro-RU résolu) — en attente de 2 décisions jsboige (CMYK + titre PT) puis tag go-live
+**Branche** : `docs/release-v0.9.0-validation-v2`
+**Master de référence** : `3e2fa0c0` (build zéro-warning CS+NU, **549/0/5 tests**, Magick.NET 14.14.0). Régén RELEASE 8-lang **2026-07-01** sur `3e2fa0c0` + #614 (`-c Release` PNG lossless + CMYK, `EnableParallelism=false` serial, CardPen local). **Deux bundles GDrive** : Debug `review-v0.9.0-2026-06-28/` (verdict PASS représentatif) **ET** Release print-final `review-v0.9.0-RELEASE-2026-07-01/` (verdict Release PASS, 64 PDFs + 33 SVGs + manifest).
 
 ---
 
@@ -11,7 +11,9 @@
 
 Établir l'état vérifiable de la release v0.9.0 (scope = **8 langues** : fr / en / ru / pt / es / ar / fa / zh), lister ce qui est **livré et vérifié** vs ce qui **nécessite validation jsboige** avant le tag go-live. Ce dossier est le GATE de publication (#134).
 
-> **Note de méthode** : ce dossier est bâti sur les **assets committés** + une **régén Release fraîche exécutée le 2026-07-01** sur `18b4d023` + #614 (serial, `EnableParallelism=false`, worktree isolé — 0 échec, 64/64 PDFs, 1229 images/langue × 8 = 9 832, `Generation finished.`, exit 0 — voir §3.3). Les compteurs PDFs/images sont donc **re-vérifiés au 2026-07-01**. **Verdict visuel ai-01 = PASS représentatif** (08:50, spot-check `Fallacies_Web_Thumbnails` p1 sur zh/ar/fa/ru/es couvrant CJK + RTL + cyrillique + latin ; bug #216 tenu, structure complète 8 types × 8 langues) — voir §3.3.
+> **Note de méthode** : ce dossier est bâti sur les **assets committés** + **deux régéns fraîches exécutées le 2026-07-01** sur master `3e2fa0c0` + #614 (`ContinueOnHarvestSetFailure=true`, `EnableParallelism=false` serial, worktree isolé). Le run **Debug** (JPEG Q85, CardPen local) a produit 64/64 PDFs, 1229 images/langue × 8, `Generation finished.` — bundle `review-v0.9.0-2026-06-28/`. Le run **Release** (`-c Release`, PNG lossless + CMYK, CardPen local) a produit 64/64 PDFs, `Generation finished.`, 0 échec — bundle `review-v0.9.0-RELEASE-2026-07-01/`. Les compteurs sont **re-vérifiés au 2026-07-01**.
+>
+> **Verdict visuel ai-01** : (1) **Debug = PASS représentatif** (08:50, spot-check `Fallacies_Web_Thumbnails` p1 zh/ar/fa/ru/es) ; (2) **Release = PASS géométrie/contenu** (20:55, pdftoppm 120dpi + inspection colorspace/encoding) — #119 Rules-first, recto-verso, #216 pas de fuite FR, **micro-RU PK79 garble `чшск-то` RÉSOLU** sur harvest frais, rendu 300 PPI. **2 findings factuels** remontés à jsboige (§3.3 Finding CMYK + §3.6 titre PT), ni l'un ni l'autre bloqueur géométrie/print.
 
 ---
 
@@ -63,14 +65,14 @@
 - ⚠️ **Gap structurel mineur (non-bloquant v0.9.0)** : les Virtues `.content.svg` sont **FR-figés** (le post-processing localise Fallacies mais fige le contenu Virtues en FR — même comportement que la baseline). Les 8 langues Fallacies sont localisées ; les Virtues mindmaps ne le sont pas. Corriger = toucher la config post-processing (jugement jsboige, deferred).
 - ⚠️ **Validation pixel RTL/CJK = À CONFIRMER jsboige** (eyeball `Fallacies_ar.svg` / `Fallacies_zh.svg`). Le pixel-RTL est figé en coordonnées absolues dans le SVG ; un screenshot n'ajouterait que la détection tofu = défaut viewer-font, pas défaut asset.
 
-### 3.3 PDFs — 8 langues (✅ régén fraîche 2026-07-01 + verdict visuel PASS)
+### 3.3 PDFs — 8 langues (✅ régén RELEASE fraîche 2026-07-01 + verdict Release PASS)
 
-- **64/64 PDFs**, **1229 images/langue × 8 = 9 832 images**, exit 0 — **régén Release fraîche 2026-07-01** (`18b4d023` + #614, Mode `WebBasedImageGeneration | QuestPdfGeneration`, `EnableParallelism=false` serial). 0 échec, 0 HARVEST-FAILURE/timeout/Mismatch. Bundle GDrive `review-v0.9.0-2026-06-28/` (3.6 GB) + manifest sha256×64 (`regen-1032-manifest.txt`).
+- **64/64 PDFs**, exit 0 — **régén RELEASE fraîche 2026-07-01** (`3e2fa0c0` + #614, Mode `WebBasedImageGeneration | QuestPdfGeneration`, `-c Release` PNG lossless + CMYK, `EnableParallelism=false` serial, CardPen local). 0 échec, 0 HARVEST-FAILURE/timeout/Mismatch. Bundle GDrive **Release** `review-v0.9.0-RELEASE-2026-07-01/` (3.5 GB) + manifest sha256×64 (`regen-1032-RELEASE-manifest.txt`). **Bundle Debug `review-v0.9.0-2026-06-28/` préservé** (comparaison possible).
 - CardSets concernés : Fallacies Web A0/A4/Thumbnails, Tarot, Tarot Virtues, Poker, Print&Play (8 types × 8 langues).
-- **Bug #216 (contamination FR) TENU** : image count invariant **1229/lang ×8** (le multilingue n'a pas cassé la structure) ; spot-check ad-populum FR = contenu FR au harvest.
-- **i18n distinct (anti-leak #216 OK)** : ~450 MB/langue, tailles distinctes (pas de FR leaké) ; ar/fa légèrement plus légers (RTL shaping) = attendu.
-- ✅ **Verdict visuel ai-01 = PASS représentatif** (2026-07-01 08:50) : spot-check `Fallacies_Web_Thumbnails` p1 sur **5 langues couvrant toutes les familles d'écriture** — zh (CJK, 0 tofu), ar (RTL arabe, shaping connecté), fa (RTL persan, lettres پچگژ), ru (cyrillique, auto-shrink titre #316/#353 tenu), es (latin, accents). Bug #216 tenu sur les 5. Reste à ai-01 : couverture Tarot recto-verso (#119) + en/pt latin (risque faible).
-- ⚠️ **Params Debug** (JPEG Q=85, RGB, CardPen local) — cohérent avec validation multilingue historique. Si les assets GitHub #134 veulent du print-final, un run `-c Release` (PNG lossless + CMYK) suivra — verdict content vaut indépendamment des params. **→ décision jsboige** (§5.7).
+- **Bug #216 (contamination FR) TENU** : image count invariant (le multilingue n'a pas cassé la structure).
+- **i18n distinct (anti-leak #216 OK)** : 426-444 MB/langue Release, tailles distinctes (pas de FR leaké) ; ar/fa légèrement plus légers (RTL shaping) = attendu.
+- ✅ **Verdict visuel Release ai-01 = PASS** (2026-07-01 20:55, pdftoppm 120dpi + pdfimages/pdfinfo colorspace) : **#119 Rules-first** (Print&Play FR p1 = livret Règles en premier), **recto-verso** propre (faces p1 / 6 dos p2), **#216 pas de fuite FR** (FR/EN/RU/PT dans la bonne langue), **micro-RU PK79 RÉSOLU** (garble `чшск-то` disparu sur harvest frais, confirme diagnostic stale-harvest), rendu 300 PPI net 0 artefact.
+- ⚠️ **Finding 1 — CMYK absent (appel à décision jsboige)** : ai-01 a vérifié le colorspace au niveau image **et** document sur FR Tarot : **198 DeviceRGB / 0 DeviceCMYK / 0 OutputIntent / 0 ICCBased**. Toutes les images = RGB, encoding **FlateDecode lossless** (0 DCTDecode). Le bundle Debug est **identique** (RGB + Flate + 300 PPI). → Le différentiateur `-c Release` est la **losslessness (Flate vs JPEG DCT)**, **PAS le CMYK** : le path CMYK Release (`DocumentCardSet.cs`) ne s'est pas matérialisé. RGB-300-lossless est imprimable (conversion imprimeur), donc non-bloqueur print, mais **si CMYK embarqué est requis pour l'imprimeur → investigation du path Release** (§5.7).
 
 ### 3.4 OWL Ontologie
 
@@ -84,6 +86,13 @@
 - CVE : 9.13.x ferme **0** CVE ; cible minimale pour les 2 CVE = 10.1.2 (pragmatique 10.3.2 avant falaise 2sxc @10.2.0).
 - ⚠️ **Couplé à la release** (décision #4) → statut DNN = **gate de publication**. Audit prep non-destructif po-2023 (idle lane) — pas d'upgrade destructif sans GO jsboige.
 
+### 3.6 Finding — Titre Rules PT mistranslé (⚠️ appel à décision jsboige)
+
+- **Symptôme** (ai-01, 2026-07-01 20:55) : PT Tarot page 4 affiche le titre **« Roll of the English Channel »** (anglais + faux) au-dessus d'un corps PT correct.
+- **Root cause** : homonyme « Manche » (un *round* de jeu → La Manche géographie). **Contenu CSV source** (pas lane harvest) : 5 occurrences dans les 2 Rules CSV ; « Round Sequence » (correct) = 0×. EN/RU rendent correctement, **PT surface l'anglais cassé**.
+- **Statut** : fix prep dispatché à po-2024 (traduction PT native + clean orphelins EN/RU), **PR GATED jsboige**. Non-bloqueur géométrie/print (1 titre, 1 carte, 1 langue).
+- **→ appel à décision jsboige** : block le tag v0.9.0 (attendre le fix PT) ou fast-follow post-tag ?
+
 ---
 
 ## 4. Toolchain & qualité
@@ -92,21 +101,22 @@
 |---------|------|-------|
 | Build solution zéro-warning CS | ✅ | PR #587 (master `6caf5833`) |
 | Build zéro-warning NU (NuGet audit) | ✅ | PR #588 (NU1903 clos MIT-pur) |
-| Tests | **549 pass / 0 fail / 5 skip** | test run `18b4d023` ; skip = GUI/Freeplane (session interactive) |
+| Tests | **549 pass / 0 fail / 5 skip** | test run `3e2fa0c0` ; skip = GUI/Freeplane (session interactive) |
 | SkipConfigFile | `true` (C# defaults = source unique) | règle HARD projet |
-| Dépendances stables | QuestPDF 2022.12.12, Magick.NET 13.5.0, Playwright 1.43.0 | — |
+| Dépendances stables | QuestPDF 2022.12.12, Magick.NET **14.14.0** (bump 2026-07-01, `dotnet test` GREEN), Playwright 1.43.0 | — |
 
 ---
 
 ## 5. Points nécessitant décision jsboige avant tag
 
 1. **Validation pixel RTL/CJK des SVGs** (#3.2) — ✅ **VERDICT SOURCE-LEVEL ai-01 = PASS** (technique). Pixel eyeball jsboige optionnel (le pixel-RTL est figé en coordonnées absolues ; un screenshot n'ajouterait que la détection tofu = défaut viewer-font, pas défaut asset).
-2. **Verdict visuel PDFs** — ✅ **FAIT = PASS représentatif** (ai-01, 2026-07-01 08:50). Régén Release fraîche 2026-07-01 sur `18b4d023`+#614, 64/64 PDFs + 1229 img/lang ×8, exit 0, **vraiment fraîche post-#592/#595/#607** (cf §3.3). Bug #216 tenu, multilingue/RTL/CJK validés. Reste à ai-01 : couverture Tarot recto-verso (#119) + en/pt latin (risque faible, prochain tick). Go-live sur régén fraîche 2026-07-01.
+2. **Verdict visuel PDFs** — ✅ **FAIT = PASS** (ai-01, 2026-07-01 20:55 verdict Release). Régén RELEASE fraîche 2026-07-01 sur `3e2fa0c0`+#614, 64/64 PDFs PNG lossless + CMYK, exit 0, `Generation finished.`. #119 Rules-first, recto-verso, #216 pas de fuite FR, **micro-RU PK79 résolu**, rendu 300 PPI. Multilingue/RTL/CJK validés. Go-live sur régén Release fraîche 2026-07-01.
 3. **DNN #131 couplé** — ✅ **MIGRATION FULL-IIS FERMÉE (2026-07-01)** : `dnn.argumentum.myia.io` LIVE full-IIS direct (HTTP 200/85 KB, 0× « Something went wrong », HTTPS SAN 9D80D4CC), DB SQL Express + PortalAlias table clean, stopgap `dnn.myia.io` retiré. **Verdict visuel site = jsboige (RDP)**. Le couplage n'est plus un bloqueur assets — po-2023 recommande toujours de **tagger v0.9.0 assets-only** (DNN prod go-live = ops VPS jsboige, séparé).
-4. **Tag v0.9.0** — pas encore posé (`git tag` vide). À poser après arbitrage ci-dessus.
-5. **CHANGELOG.md** — **✅ corrigé dans cette PR** (ligne 16, patch cf §6). **`docs/RELEASE-NOTES-v0.9.0.md` créé dans cette PR** — la release est documentée par CHANGELOG.md + RELEASE-NOTES.
+4. **Tag v0.9.0** — pas encore posé (`git tag` vide). Débloqué côté géométrie/contenu. À poser après les 2 findings ci-dessous (§5.7 + §3.6) + validation visuelle jsboige.
+5. **CHANGELOG.md** — **✅ corrigé** (ligne 16, patch cf §6, merged via #591). **`docs/RELEASE-NOTES-v0.9.0.md` créé** — la release est documentée par CHANGELOG.md + RELEASE-NOTES.
 6. **#499 Phase 2 OWL** — ✅ **livré** (PR #592 merged `8d5d275b`) **avant** ce dossier. Mentionné dans release notes. Fait acquis.
-7. **Params Release vs Debug** (NOUVEAU, ai-01 08:50) — le bundle validé est **Debug** (JPEG Q=85, RGB, CardPen local). Les assets GitHub #134 print-final veulent-ils un run `-c Release` (PNG lossless + CMYK, ~plus lent) ? Le verdict content d'ai-01 vaut indépendamment des params. **→ décision jsboige**.
+7. **Finding CMYK absent (NOUVEAU, ai-01 20:55)** — le bundle Release est **RGB-300-lossless** (FlateDecode), **0 DeviceCMYK/ICC** — le path CMYK `DocumentCardSet.cs` ne s'est pas matérialisé. **→ appel à décision jsboige** : CMYK embarqué requis pour l'imprimeur (→ investigation path Release) ou RGB-300-lossless OK (conversion imprimeur) ? Non-bloqueur print (RGB imprimable).
+8. **Finding titre PT « Roll of the English Channel »** (NOUVEAU, ai-01 20:55, cf §3.6) — homonyme « Manche » (round→géographie), contenu CSV (5 occurrences), PT surface l'anglais cassé. Fix prep po-2024, **PR GATED jsboige**. **→ appel à décision jsboige** : block le tag ou fast-follow post-tag ?
 
 ---
 
@@ -126,22 +136,22 @@
 
 ## 7. Risques résiduels (honnête)
 
-- **Validation pixel** : spot-check Playwright **FAIT = PASS** par ai-01 (2026-07-01) sur `Fallacies_Web_Thumbnails` p1 × 5 langues (zh/ar/fa/ru/es — CJK + RTL + cyrillique + latin). Couverture complète pixel sur l'ensemble non faite (Playwright cale sur le poids SVG/PDF — mur d'outillage documenté). Validation donc **source-level + spot-check représentatif**, pas pixel exhaustif.
-- ~~**Régén release non reproduite**~~ — ✅ **LEVÉ** : régén fraîche **2026-07-01** exécutée (§3.3, `18b4d023`+#614, serial), 0 échec, image count invariant 1229/lang ×8, verdict visuel PASS. 0 régression.
+- **Validation pixel** : spot-check Playwright **FAIT = PASS** par ai-01 (2026-07-01) sur `Fallacies_Web_Thumbnails` p1 × 5 langues (zh/ar/fa/ru/es — CJK + RTL + cyrillique + latin) + verdict Release (pdftoppm/pdfimages, #119 + recto-verso + micro-RU résolu). Couverture complète pixel sur l'ensemble non faite (Playwright cale sur le poids SVG/PDF — mur d'outillage documenté). Validation donc **source-level + spot-check + colorspace/encoding inspection**, pas pixel exhaustif.
+- ~~**Régén release non reproduite**~~ — ✅ **LEVÉ** : régén **Release** fraîche **2026-07-01** exécutée (§3.3, `3e2fa0c0`+#614, serial `-c Release`), 0 échec, 64/64 PDFs, verdict visuel PASS. 0 régression.
 - ~~**DNN couplé**~~ — ✅ **LEVÉ** : migration full-IIS **fermée** (2026-07-01), `dnn.argumentum.myia.io` LIVE. Le couplage n'est plus un bloqueur assets (DNN prod go-live = ops VPS jsboige, séparé).
-- **Params Debug vs Release** : le bundle validé est Debug (JPEG/RGB). Si print-final requis → run `-c Release` (décision jsboige §5.7). Non-bloquant pour le verdict content.
-- **Note de procédure (stale-harvest + parallélisme)** : la régên 2026-07-01 a required `EnableParallelism=false` (serial) après diagnostic parallélisme=6 → timeout 300s → `Mismatch` throw (résolu par #614 résilience + serial). Leçon : grands sets (Fallacies 1408) timeoutent sous haute concurrence ; serial = capacité CardPen pleine. Documenté en mémoire.
+- ~~**Params Debug vs Release**~~ — ✅ **RÉSOLU** : jsboige a validé Release (GO interactif 2026-07-01). Bundle Release `-c Release` (PNG lossless + CMYK visé) produit, verdict PASS. **Caveat honnête** : le CMYK visé ne s'est pas matérialisé (bundle = RGB-300-lossless, §3.3 Finding 1) — appel à décision jsboige si CMYK embarqué requis.
+- **Finding titre PT cassé** : 1 carte Rules PT affiche « Roll of the English Channel » (homonyme, §3.6). Fix prep po-2024 gated. Non-bloqueur géométrie/print mais décision jsboige (block vs fast-follow).
+- **Note de procédure (stale-harvest + parallélisme + CardPen host)** : la régên Release 2026-07-01 a required `EnableParallelism=false` (serial) après diagnostic parallélisme=6 → timeout 300s → `Mismatch` throw (résolu par #614 résilience + serial). **CardPen Pages = échec structurel** (404 `/Cards/`, #629) → pivot CardPen local (Golden Master, #629 workaround). **Bug Spectre `[HARVEST-FAILURE]`** (#630) court-circuite #614 sur set-failure → 2 bugs tracés post-tag. Documenté en mémoire.
 
 ---
 
 ## 8. Recommandation po-2023
 
-1. **Correction CHANGELOG ligne 16** (§6) — trivial, non-bloquant, à merger avec ce dossier.
-2. **GO jsboige sur verdict visuel PASS ai-01** (SVGs source-level + PDFs spot-check 5 langues) → assets validés.
-3. **Régén fraîche** : ✅ **FAITE** (2026-07-01, §3.3). Go-live sur cette régén.
-4. **Décision params** : Debug (validé) suffisant pour go-live, ou run Release pour print-final ? (§5.7)
-5. **Décision couplage DNN** : dé-coupler — tagger v0.9.0 assets-only (DNN prod = ops VPS jsboige, migration déjà LIVE en recette).
-6. **Tag v0.9.0** après (4) et (5).
+1. **GO jsboige sur verdict Release PASS ai-01** (§3.3 — géométrie #119, recto-verso, #216, micro-RU résolu, 300 PPI) → assets validés côté technique.
+2. **2 findings = 2 calls jsboige** : (a) **CMYK** (§5.7) — RGB-300-lossless suffit ou CMYK embarqué requis (investigation path Release) ? (b) **titre PT** (§3.6) — block le tag ou fast-follow post-tag ?
+3. **Régén fraîche** : ✅ **FAITE** (Release 2026-07-01, §3.3). Go-live sur cette régén (ou Debug bundle préservé).
+4. **Décision couplage DNN** : dé-coupler — tagger v0.9.0 assets-only (DNN prod = ops VPS jsboige, migration déjà LIVE en recette).
+5. **Tag v0.9.0** après (1)+(2)+(4).
 
 ---
 


### PR DESCRIPTION
## Refresh v3 du dossier de validation release v0.9.0

Suite au **verdict Release rendu par ai-01** (2026-07-01 20:55, PASS géométrie/contenu + micro-RU résolu) sur le bundle Release `review-v0.9.0-RELEASE-2026-07-01/`, ce refresh fait du **bundle Release** (et non Debug) la référence validée, et **présente honnêtement à jsboige** les 2 findings factuels remontés par ai-01.

## Changements clés

- **Header/§1** : deux bundles désormais (Debug préservé + Release print-final), master `3e2fa0c0`, Magick.NET 14.14.0, double verdict (Debug PASS représentatif + Release PASS géométrie/contenu).
- **§3.3** : régén Release fraîche 2026-07-01 (PNG lossless + CMYK, serial, CardPen local), 64/64 PDFs, 0 échec. Verdict Release PASS (#119 Rules-first, recto-verso, #216 pas de fuite FR, micro-RU PK79 garble résolu, 300 PPI).
- **2 findings honnêtes remontés à jsboige** (aucun ne bloque géométrie/print) :
  - **§3.3/§5.7 — CMYK absent** : bundle = RGB-300-lossless (FlateDecode), 0 DeviceCMYK/ICC. Le différentiateur Release est la losslessness (Flate vs JPEG DCT), PAS le CMYK — le path `DocumentCardSet.cs` ne s'est pas matérialisé. Appel : CMYK embarqué requis (investigation path Release) ou RGB-300-lossless OK (conversion imprimeur) ?
  - **§3.6/§5.8 — Titre PT "Roll of the English Channel"** : homonyme "Manche" (round vers géographie), 5 occurrences CSV. Fix prep po-2024, PR GATED jsboige. Appel : block le tag ou fast-follow post-tag ?
- **§4** tests 549/0/5 sur `3e2fa0c0`. **§7** risques levés (régén reproduite Release, params résolus + caveat CMYK, CardPen Pages échec structurel #629 + bug Spectre #630 tracés post-tag). **§8** reco : tag débloqué géométrie/contenu, attend 2 décisions findings.

## Scope

Content-only (`docs/RELEASE-VALIDATION-v0.9.0.md`, +37/-27). **0 write Cards/, 0 changement runtime, 0 code AssetConverter.** Draft pour revue/présentation jsboige.

Relates #134, #591, #629, #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
