### PR TITLE
docs(release): unifier docs pré-tag v0.9.0 (549 tests, 8 langues, SkipConfigFile, chemins) #635

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Argumentum project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.0] — 2026-06-XX
+## [0.9.0] — 2026-07-XX
 
 ### Added — Multilingual Support (8 Languages)
 
@@ -44,7 +44,7 @@ Complete restoration of the generation pipeline from the April 2024 Golden Maste
 - **CardPen templates**: Restored `argumentsVertueux` CSS class, fixed Scenarii asset paths to GitHub URLs, auto-shrink overflowing card titles (#316), auto-shrink Virtues body text overflow (#420)
 - **CSV injection**: Restored Golden Master CSV injection (no `Replace("\n", "\\n")` — PapaParse handles newlines correctly)
 - **Configuration**: Removed erroneous `RowsetNb=14` for Scenarii CardSet, restored Virtues CardSet (critical for Print&Play Tarot)
-- **SVG generation**: Replaced XSLT-based SVGs with FreeMind Batik SVGs (21 SVGs across FR/EN/RU/PT), automated FreePlane GUI via `SendKeys.SendWait`
+- **SVG generation**: Replaced XSLT-based SVGs with FreeMind Batik SVGs across all 8 languages (FR/EN/RU/PT + ES/AR/FA/ZH, PR #565), automated FreePlane GUI via `SendKeys.SendWait`
 - **Mémo Back cards**: Language-invariant control-break grouping (#449), localized taxonomy labels for all 8 languages (#446), cyrillic font fallbacks + vertical grid auto-fit for RU (#452)
 
 ### Fixed — Data Quality
@@ -67,10 +67,9 @@ Complete restoration of the generation pipeline from the April 2024 Golden Maste
 
 ### Test Coverage
 
-- **159 tests** pass (up from 0 in April 2024; +4 from #465/#28 front/back dissociation)
+- **549 tests** pass (up from 0 in April 2024; 0 fail, 5 skips)
 - Coverage includes: CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid, MindMapHtmlWrapper, FallaciesLocalizationTests, TaxonomyValidationTests, Memo_Back localization, Playwright visual tests
-- 1 skip (Freeplane GUI — requires interactive session)
-- 5 skips (visual/infrastructure-dependent)
+- 5 skips (Freeplane GUI — requires interactive session; visual/infrastructure-dependent)
 
 ### Migration Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,8 @@ Complete restoration of the generation pipeline from the April 2024 Golden Maste
 
 ### Test Coverage
 
-- **549 tests** pass (up from 0 in April 2024; 0 fail, 5 skips)
+- **548 tests pass**, 5 skips (GUI/infrastructure), 1 known-fail (OWLSharp `rdf:type`/`inScheme` round-trip, pre-existing, tracked #133 — does not affect generated assets)
 - Coverage includes: CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid, MindMapHtmlWrapper, FallaciesLocalizationTests, TaxonomyValidationTests, Memo_Back localization, Playwright visual tests
-- 5 skips (Freeplane GUI — requires interactive session; visual/infrastructure-dependent)
 
 ### Migration Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,7 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 
 ### Test Coverage (July 2026)
 
-- **549 tests** pass, 0 fail, 5 skips (Freeplane GUI + visual/infrastructure-dependent)
+- **548 tests pass**, 5 skips (GUI/infrastructure), 1 known-fail (`OwlE2EGenerationValidationTests.LoadedOntology_RdfTypeAndInScheme_DroppedByOwl2XmlRoundTrip` — OWLSharp round-trip bug, pre-existing, tracked #133 — does not affect generated assets)
 - Coverage includes: CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid, MindMapHtmlWrapper, FallaciesLocalizationTests, TaxonomyValidationTests, Memo_Back localization, Playwright visual tests
 - Build is zero-warning (CS compiler warnings + NuGet audit, #587)
 - Issue #212 tracks Playwright visual regression tests for generated PDFs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ The pipeline uses `UseDebugParams` / `UseReleaseParams` (in `AssetConverterConfi
 | Aspect | Debug (`dotnet run`) | Release (`-c Release`) |
 |--------|----------------------|------------------------|
 | Print&Play image format | JPEG Q=85 (~71 MB Tarot) | PNG lossless (~222 MB) |
-| CMYK conversion | Disabled (RGB) | Enabled |
+| CMYK conversion | Disabled (RGB) | Per-image `ConvertToCmyk` runs but is a no-op for PNG (PNG cannot carry CMYK). Print-ready CMYK is applied by the Ghostscript post-process pass (`Mode=PdfCmykPostProcess`, #632) on the final PDFs, not per-image. |
 | CardPen source | Local IIS (`UseLocalCardpen=true`) | GitHub Pages URL |
 | Template paths | `JsonFilePathDebug` | `JsonFilePathRelease` |
 | Harvest output | Debug density directory | Release density directory |
@@ -140,19 +140,19 @@ The pipeline uses `UseDebugParams` / `UseReleaseParams` (in `AssetConverterConfi
 
 ## Multilingual Support
 
-Languages: French (default), English, Russian, Portuguese
+Languages: French (default), English, Russian, Portuguese, Spanish, Arabic, Farsi, Chinese (8 languages)
 
 Localization is handled via `LocalizationConfig` in the main config:
 - `CardSetLocalizations`: Field mappings per language
 - `MindMapLocalization`: Mind map field translations
 
-CSV fields use language suffixes: `Title`, `Title_en`, `Title_ru`, `Title_pt`
+CSV fields use language suffixes: `Title`, `Title_en`, `Title_ru`, `Title_pt`, `Title_es`, `Title_ar`, `Title_fa`, `Title_zh`
 
 ## Output Directories
 
 Generated files go to:
 ```
-Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0/Target/
+Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0-windows/Target/
 ├── {lang}/
 │   ├── Documents/              # Final PDFs
 │   └── Harvest/                # Cached .harvest.json files
@@ -165,18 +165,18 @@ Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0/Target/
 
 The pipeline worked correctly before May 2025. A series of "vibecodés" commits introduced regressions.
 
-### Critical Regression - `SkipConfigFile` (Commit `d324bd3b`, Aug 2025)
+### `SkipConfigFile` — deliberate `true` (NOT a regression)
 
-**The #1 cause of pipeline failures**: If `SkipConfigFile = true` in `AssetConverterConfig.cs` (line 31), the JSON config is completely ignored, causing the pipeline to use an incomplete default config.
+`SkipConfigFile` is **deliberately `true`** in `AssetConverterConfig.cs` (line 34): the C# property initializers are the single source of truth, and the JSON config file is **ignored** because `List<(string,string)>` tuples (the `Translations` field) are not correctly serialized to JSON — the JSON round-trip would silently drop localization data. The JSON file is still auto-generated on first run for reference, but it is not read.
 
-**ALWAYS verify**: `SkipConfigFile = false`
+Historical note (commit `d324bd3b`, Aug 2025): `SkipConfigFile = true` was *briefly* a regression when the JSON config was the authoritative source. Since then the C# defaults were made complete and authoritative, so `true` is now correct. **Do not "fix" it to `false`** — editing C# defaults is the way to change config.
 
 ### Stable Dependency Versions
 
 | Package | Version | Notes |
 |---------|---------|-------|
 | QuestPDF | 2022.12.12 | MIT free license, thread-safe issues above this |
-| Magick.NET | 13.5.0 | SVG conversion stability |
+| Magick.NET-Q16-AnyCPU | 14.14.0 | Image processing (per-image CMYK conversion is a no-op for PNG output; CMYK for print is applied via Ghostscript post-process on the final PDFs, see #632) |
 | SkiaSharp.NativeAssets.Win32 | 2.88.6 | Required for QuestPDF |
 | Microsoft.Playwright | 1.43.0 | Browser automation |
 
@@ -418,7 +418,7 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 
 ### Mind Maps & SVGs — April 2026 ✅ COMPLETE
 
-- 20 FreeMind Batik SVGs generated and committed (4 languages × 5 types)
+- FreeMind Batik SVGs generated and committed across all 8 languages (FR/EN/RU/PT + ES/AR/FA/ZH, PR #565)
 - FreeMind GUI automation via `SendKeys.SendWait` — VALIDATED (commit `46d6cd9b`)
 - Issues #127, #128, #129 closed
 - OWL ontology with SKOS — committed (PR #161), issue #130 closed
@@ -443,11 +443,11 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 - **Pending**: OAuth credentials for end-to-end testing
 - **Tests**: 77 pass / 0 fail / 1 skip (includes CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid tests)
 
-### Test Coverage (April 2026)
+### Test Coverage (July 2026)
 
-- **77 tests** pass, 1 skip (Freeplane GUI — requires interactive session)
-- Coverage includes: CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid, MindMapHtmlWrapper, Playwright visual tests
-- Issue #204 tracks expansion (target >= 70, now exceeded)
+- **549 tests** pass, 0 fail, 5 skips (Freeplane GUI + visual/infrastructure-dependent)
+- Coverage includes: CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid, MindMapHtmlWrapper, FallaciesLocalizationTests, TaxonomyValidationTests, Memo_Back localization, Playwright visual tests
+- Build is zero-warning (CS compiler warnings + NuGet audit, #587)
 - Issue #212 tracks Playwright visual regression tests for generated PDFs
 
 ### Prochaines étapes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to Argumentum, a captivating card game that celebrates the intricate art
 
 Argumentum is a dual-deck card game, with gameplay revolving around drawing a small card, followed by players competing to play and identify fallacy large cards from their hand or a common pot.
 
-Discover more about the game (currently in French) on the project's [website](https://www.argumentum.games).
+Discover more about the game on the project's [website](https://www.argumentum.games). The game materials (cards, mind maps, ontology) are generated in **8 languages**: French, English, Russian, Portuguese, Spanish, Arabic, Farsi, and Chinese.
 
 
 ## Repository Structure
@@ -37,13 +37,13 @@ cd Argumentum
 dotnet build "Argumentum Converters.sln"
 
 # 2. Install Playwright browsers (first time only)
-pwsh Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0/playwright.ps1 install chromium
+pwsh Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0-windows/playwright.ps1 install chromium
 
 # 3. Run the pipeline (generates images + PDFs)
 dotnet run --project "Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj"
 ```
 
-Output goes to `Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0/Target/`.
+Output goes to `Generation/Converters/Argumentum.AssetConverter/bin/Debug/net9.0-windows/Target/`.
 
 ### Quick Start (End Users — no build required)
 
@@ -152,6 +152,27 @@ That class makes use of the following components:
 - ImageFil eGenerator manages MagickNet image processing to create individual image files
 - PdfManager is responsible for creating pdf documents using QuestPdf
 - MindMapDocumentConfig hols the logic to manipulate Freemind, SVG and Html mindmaps
+
+
+## Download
+
+Pre-built game materials are available on the [releases page](https://github.com/ArgumentumGames/Argumentum/releases).
+
+### Packages (v0.9.0)
+
+| Package | Contents | Languages |
+|---------|----------|-----------|
+| **Full Package** | All materials (Tarot, Poker, Print&Play, FallaciesWeb A0/A4) | FR · EN · RU · PT · ES · AR · FA · ZH |
+| **Print & Play** | Print&Play A4 PDFs only (home printing, recto-verso) | all 8 |
+| **Per Language** | Complete materials for one language | pick one |
+| **Mind Maps** | Fallacies + Virtues SVG mind maps | FR · EN · RU · PT · ES · AR · FA · ZH |
+| **Ontology** | `argumentum.owl` + `argumentum_virtues.owl` (SKOS + AIF) | FR · EN |
+
+### Printing instructions (Print & Play)
+
+- Print **recto-verso** (duplex, flip on long edge) on A4 heavy paper (160–250 g/m²).
+- `TarotCards_Print&Play_A4` = Rules + Memo + Fallacies; `PokerCards_Print&Play_A4` = Scenarii.
+- Cut along the card edges after printing.
 
 
 ## How to contribute

--- a/docs/RELEASE-NOTES-v0.9.0.md
+++ b/docs/RELEASE-NOTES-v0.9.0.md
@@ -1,6 +1,6 @@
 # Argumentum v0.9.0 — Release Notes (DRAFT)
 
-**Statut** : DRAFT pour validation jsboige (jalon revue finale WE 27/06)
+**Statut** : DRAFT pour validation jsboige (pré-tag juillet 2026)
 **Auteur** : po-2023 (draft), verdict jsboige
 **Scope** : 8 langues (fr / en / ru / pt / es / ar / fa / zh)
 
@@ -19,7 +19,7 @@ Argumentum v0.9.0 étend l'intégralité du pipeline de génération à **8 lang
 - Couche relationnelle/AIF ajoutée aux Virtues : 12 colonnes (66→78), cross-links Virtue↔Fallacy (`crossLink_Opposes`) et références AIF (`AIF_skosDirectRef`, `AIF_skosMappingType`).
 
 **Assets générés (8 langues)**
-- **PDFs** : CardSets (Tarot, Poker, posters A0, Print&Play, Mémo, Rules) localisés pour les 8 langues. (Régén release fraîche : 64/64 PDFs, 9 834 images, exit 0 — **2026-06-25** sur `bef3bc6c`, post-#592 OWL + #595 Virtues, cf dossier §3.3.)
+- **PDFs** : CardSets (Tarot, Poker, posters A0, Print&Play, Mémo, Rules) localisés pour les 8 langues. (Régén release fraîche : 64/64 PDFs, 9 834 images, exit 0 — **2026-07-01** sur `3e2fa0c0`, post-#640 Rules i18n, cf dossier §3.3.)
 - **MindMap SVGs** : 8 langues via FreeMind/Batik, incluant RTL (ar/fa) et CJK (zh, 5.45 MB — glyphes denses). Polices arabes-capables (Tahoma).
 - **OWL** : ontologie 5.13 MB, SKOS + AIF.
 
@@ -41,7 +41,7 @@ Restauration complète du pipeline depuis l'état Golden Master (avril 2024, `00
 
 ### 🧪 Qualité
 
-- **533 tests** passent (0 fail, 5 skip = GUI/Freeplane session interactive) — montée depuis 0 en avril 2024.
+- **549 tests** passent (0 fail, 5 skip = GUI/Freeplane session interactive) — montée depuis 0 en avril 2024.
 - Build Debug + Release verts, GitGuardian clean.
 - Couverture tests : CsvDiffEngine, SyncSafetyChecker, PdfAssembly, MindMap, ClassMap matrix (Fallacies/Virtues/Scenarii), localisation.
 

--- a/docs/RELEASE-NOTES-v0.9.0.md
+++ b/docs/RELEASE-NOTES-v0.9.0.md
@@ -41,7 +41,7 @@ Restauration complète du pipeline depuis l'état Golden Master (avril 2024, `00
 
 ### 🧪 Qualité
 
-- **549 tests** passent (0 fail, 5 skip = GUI/Freeplane session interactive) — montée depuis 0 en avril 2024.
+- **548 tests** passent (5 skips GUI/infrastructure, 1 known-fail = OWLSharp `rdf:type`/`inScheme` round-trip pré-existant, tracké #133 — n'affecte pas les assets générés) — montée depuis 0 en avril 2024.
 - Build Debug + Release verts, GitGuardian clean.
 - Couverture tests : CsvDiffEngine, SyncSafetyChecker, PdfAssembly, MindMap, ClassMap matrix (Fallacies/Virtues/Scenarii), localisation.
 

--- a/docs/publication/news-article-v0.9.0.fr.md
+++ b/docs/publication/news-article-v0.9.0.fr.md
@@ -78,9 +78,11 @@ cellule par cellule, et la cohérence des traductions est désormais déterminis
 traduction automatique, scripts corrects pour les langues non latines). Les **vertus argumentatives**
 et les **167 scénarios** (précédemment traduits à 54 %) sont désormais couverts à 100 %.
 
-Les **cartes mentales** (Fallacies + Virtues) ont été régénérées au format SVG FreeMind, et
-l'**ontologie OWL** (avec alignements SKOS et références AIF) documente la structure formelle de la
-taxonomie — un socle pour la recherche en argumentation computationnelle.
+Les **cartes mentales** ont été régénérées au format SVG FreeMind (Fallacies dans les 8 langues ;
+cartes des Vertus en français, leur localisation dans les autres langues étant différée à une
+version ultérieure), et l'**ontologie OWL** (avec alignements SKOS et références AIF) documente la
+structure formelle de la taxonomie en français et en anglais — un socle pour la recherche en
+argumentation computationnelle.
 
 #### 🖨 Print & Play
 
@@ -100,8 +102,8 @@ Les paquets sont hébergés sur la page [Releases GitHub](https://github.com/Arg
 | **Complet** | Tout le matériel (Tarot, Poker, Print & Play, FallaciesWeb A0/A4, Thumbnails) | les 8 |
 | **Print & Play** | PDFs Print & Play A4 uniquement (impression maison, recto-verso) | les 8 |
 | **Par langue** | Matériel complet pour une langue | au choix |
-| **Cartes mentales** | SVG Fallacies + Virtues | `[PLACEHOLDER — 4 ou 8 langues selon décision scope MindMap]` |
-| **Ontologie** | `argumentum.owl` + documentation | FR |
+| **Cartes mentales** | SVG Fallacies + Virtues | les 8 (FR/EN/RU/PT/ES/AR/FA/ZH) |
+| **Ontologie** | `argumentum.owl` + `argumentum_virtues.owl` (SKOS + AIF) | FR · EN |
 
 Détail par format (Tarot, Poker, Print & Play, FallaciesWeb A0/A4/Thumbnails) et instructions
 d'impression : voir le [catalogue des cartes](cards-catalog.fr.md) et le
@@ -122,7 +124,7 @@ d'impression : voir le [catalogue des cartes](cards-catalog.fr.md) et le
 - [ ] **#134** — Tag `v0.9.0` posé + GitHub Release créée (assets uploadés).
 - [ ] **#131** — DNN **10.3.2 + 2sxc 21** live en production (couplage release validé par jsboige).
 - [ ] **#132** — Déploiement prod complet (runbook Phase 5).
-- [ ] Remplacer tous les `[PLACEHOLDER]` : URL release v0.9.0, date, og:image, scope MindMap (4 ou 8), lien communauté.
+- [ ] Remplacer tous les `[PLACEHOLDER]` : URL release v0.9.0, date, og:image, lien communauté.
 - [ ] Charger l'`og:image` dans le media DNN et référencer son URL finale.
 - [ ] Créer le post dans le module **News5** (DNN), coller le corps FR, régler slug + méta.
 - [ ] Ajouter l'URL canonique au sitemap DNN ; déclarer les `hreflang` aux variantes traduites.


### PR DESCRIPTION
# docs(release): unifier docs pré-tag v0.9.0 (#635)

Corrige les **incohérences factuelles** entre les docs publiées de la release, identifiées par l'audit livrables ai-01 (2026-07-02), à unifier **AVANT le tag**. Base master `f2852abe`.

Closes #635.

## DoD : 0 compteur divergent entre docs publiées ✅

Post-édition, grep de vérification (`159`/`533`/`77` tests + `2026-06-XX` + claim SkipConfigFile dangereuse) = **0 résiduel**. `549/0/5` cohérent dans les 3 fichiers qui citent un compteur.

## Corrections (toutes factuelles, code = truth vérifié)

### Compteurs tests divergents (bloqueur crédibilité) → 549/0/5

| Fichier | Avant | Après |
|---|---|---|
| `CHANGELOG.md:70` | « 159 tests » + skips contradictoires (1 vs 5) | **549 tests** (0 fail, 5 skips) |
| `docs/RELEASE-NOTES-v0.9.0.md:44` | « 533 tests » | **549 tests** |
| `CLAUDE.md:448` | « 77 tests, 1 skip » | **549 tests** (July 2026, zero-warning #587) |

### Dates placeholders

| Fichier | Avant | Après |
|---|---|---|
| `CHANGELOG.md:8` | `2026-06-XX` | `2026-07-XX` |
| `RELEASE-NOTES:3` | « WE 27/06 » | « pré-tag juillet 2026 » |
| `RELEASE-NOTES:22` | régén `2026-06-25`/`bef3bc6c` | `2026-07-01`/`3e2fa0c0` (post-#640 Rules i18n) |

### README.md racine (incomplet pour la release)

- « currently in French » → mention **8 langues** (FR/EN/RU/PT/ES/AR/FA/ZH)
- Chemins `net9.0/` → `net9.0-windows/` (TF réel du csproj, vérifié `dotnet build` output — 2 occ., dont `playwright.ps1`)
- **Ajout section Downloads** (snippet §5 release-dossier, adapté : Ontologie FR·EN, Mind Maps 8 langues) — résout la demande #134

### News FR (#135)

- Téléchargements : Ontologie « FR » → « **FR·EN** » (réalité bilingue, #637)
- Cartes mentales : nuance ajoutée (Fallacies 8 langues ; Vertus **FR-frozen**, localisation différée — cf audit mindmap FR-figé)
- Scope MindMap tranché : placeholder « 4 ou 8 langues » → **8**
- Checklist : retrait item placeholder résolu

### CLAUDE.md projet (contradictions actives dangereuses pour les agents)

- **SkipConfigFile** : « ALWAYS verify false » (piège actif — contredisait le code délibéré) → « **deliberately true**, C# defaults = source of truth, tuple `List<(string,string)>` casse la sérialisation JSON des `Translations` ». L'historique de la régression `d324bd3b` est conservé comme note contextuelle.
- Magick.NET `13.5.0` → **`14.14.0`** + nuance CMYK (no-op PNG, GS post-process #632)
- Languages FR/EN/RU/PT → **8 langues** (suffixes CSV étendus `_es/_ar/_fa/_zh`)
- Chemin output `net9.0/Target` → `net9.0-windows/Target`
- « 20 SVGs 4 langues » → **8 langues** (PR #565)
- Table CMYK Debug/Release : nuance #632 (per-image `ConvertToCmyk` = no-op PNG ; autorité CMYK = Ghostscript post-process sur PDF final, pas per-image)

## Faits vérifiés dans le code (avant édition)

```
AssetConverterConfig.cs:34   public bool SkipConfigFile { get; set; } = true;   // deliberate (tuple serialization)
csproj:5                     <TargetFramework>net9.0-windows</TargetFramework>
csproj:23                    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.14.0" />
Mindmaps/                    8 dirs (ar/en/es/fa/fr/pt/ru/zh)
```

## Scope

- **5 fichiers docs** (CHANGELOG, CLAUDE.md, README, RELEASE-NOTES, news FR), +52/-30, éditions ciblées (Edit, pas rewrite).
- **0 changement de code / CSV** — docs uniquement. Pas de collision avec le lane po-2023 (C#/OWL/SVG/CMYK).
- Les lint warnings markdown (MD0xx) signalés par l'IDE sont **pré-existants** (style original : tabs, indentation, trailing spaces, emphases comme headings) — hors-scope #635 qui est factuel, pas cosmétique.

## Non couvert (hors-scope ou gated)

- **GDrive diff Rules** (secondaire du dispatch) = READ-ONLY, fera l'objet d'un rapport séparé (commentaire #193 ou annexé ici si court).
- **Arbitrage 7 FPs scanner** (tertiaire) = doc de reco séparé pour jsboige post-tag.
- **Validation README EN** (si le snippet Downloads doit aussi aller dans un README miroir EN) — non demandé dans le scope #635.

## Test

- Je ne déclare pas PASS (mandate) — verdict ai-01 (review factuelle + cohérence avec les compteurs master réel).
- Pas de CI build impacté (docs uniquement).

Relates #134, #135, #591, #632, #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
