### PR TITLE
docs(i18n): arbitrage 7 faux positifs scanner post-#640 (#633)

### DIFF
--- a/docs/investigations/2026-07-02-scanner-fp-arbitration.md
+++ b/docs/investigations/2026-07-02-scanner-fp-arbitration.md
@@ -1,0 +1,49 @@
+# Arbitrage des 7 faux positifs du scanner i18n — Argumentum
+
+**Date** : 2026-07-02 · **Auteur** : po-2024 (worker) · **Décision** : jsboige (post-tag)
+**Contexte** : post-#640 (refonte Rules i18n), le scanner `scan_translations.py` passe de 22 → 7 findings. Les 7 résiduels étaient classés « faux positifs documentés » sans arbitrage formel. Ce document fournit cet arbitrage.
+
+## Verdict synthétique
+
+**Les 7 sont tous légitimes (KEEP tel-quel).** Aucun n'est un défaut de traduction. La preuve structurelle : **le français lui-même (source canonique) garde plusieurs de ces termes non traduits** — les autres langues qui font de même sont donc cohérentes, pas contaminées. Le scanner déclenche sur un seuil mécanique (< 30 % de caractères CJK/cyrilliques) inadapté aux noms propres, emprunts et mnémoniques latins.
+
+## Détail cellule par cellule
+
+### Fallacies (taxonomie des sophismes)
+
+| PK | Cellule | FR (canon) | Autres langues | Verdict |
+|---|---|---|---|---|
+| **30** | `text_ru` = `Credo quia absurdum` | `Preuve par l'absurde fallacieuse` | EN = `Credo quia absurdum` (latin), ZH = `荒谬的信念` (traduit) | **KEEP** — locution latine canonique (Tertullien). EN la garde aussi en latin. FR fait le choix descriptif (plus clair pour un public FR). Cohérence inter-langue acceptable : le latin est l'usage établi pour ce sophisme. |
+| **475** | `text_zh` = `Gish Gallop` | `Gish gallop` **(emprunt non traduit !)** | EN = `Gish gallop`, RU = `Гиш-галоп` (translit) | **KEEP** — **le FR lui-même ne traduit pas** « Gish gallop » (emprunt consacré). ZH miroir = cohérent. *Polish optionnel* : ajouter une glose chinoise ex. « Gish Gallop（斯特劳斯曼轰炸）», mais pas un défaut. |
+| **927** | `text_zh` = `Creepypasta` | `Creepypasta` **(emprunt non traduit !)** | EN = `Creepypasta`, RU = `Крипипаста` | **KEEP** — idem : FR et EN gardent l'emprunt. ZH cohérent. |
+| **1363** | `text_zh` = `Whataboutism（什么主义）` | `Whataboutisme` (francisé) | EN = `Whataboutism`, RU = `Ватабаутизм` | **KEEP** — emprunt + glose chinoise. La glose « 什么主义 » (litt. « quoi-isme ») est la calque chinoise usuelle. *Polish optionnel* : « 诉诸虚伪 » (appeal to hypocrisy) est la forme plus canonique en rhétorique ZH, mais la forme actuelle est compréhensible. |
+
+### Virtues (cartes de vertus)
+
+| PK | Cellule | FR (canon) | Verdict |
+|---|---|---|---|
+| **107** | `title_zh` = `Celarent 三段论` | `Syllogisme Celarent` | **KEEP** — convention standard pour les mnémoniques latins de syllogismes (Celarent, Camestres, Barbara…). « 三段论 » = « syllogisme ». Le mnémonique latin se garde tel quel dans toutes les traditions logiques. (Note : RU est incohérent — `Celarent` latin vs `Каместрес` translittéré — mais c'est un défaut RU mineur, pas ZH.) |
+| **112** | `title_zh` = `Camestres 三段论` | `Syllogisme Camestres` | **KEEP** — idem. |
+
+### Scenarii (scénarios de jeu)
+
+| PK | Cellule | FR (canon) | Autres | Verdict |
+|---|---|---|---|---|
+| **6.1.3** | `title_zh` = `Johnny Johnny` | `Johnny Johnny` **(identique !)** | PT = `Johnny no Panthéon`, EN = *(vide)* | **KEEP** — nom propre. ZH = FR (identique), normal pour un nom propre. *Observation annexe* : le titre EN est **vide** (devrait être `Johnny Johnny` ou `Johnny at the Pantheon`) — c'est un trou EN, pas un défaut ZH. La référence « Panthéon » est gardée par FR/PT mais perdue par EN/RU/ZH : arbitrage de cohérence mineur, hors-scope. |
+
+## Recommandation pour le scanner
+
+Le seuil `< 30 % CJK/cyrillique` est trop agressif pour les **titres courts** (cellules HIGH = noms de cartes). Options pour réduire le bruit futur (non bloquant) :
+1. Exempter les cellules `< 12 caractères` du check script-ratio (trop court pour conclure).
+2. Ajouter une liste blanche de racines latines / emprunts consacrés (Credo, Gish, Creepypasta, Whataboutism, Celarent, Camestres, Straw man…).
+3. Croiser avec le FR : si le FR garde le terme non traduit, le ZH/RU qui fait de même n'est pas un défaut.
+
+Aucune de ces améliorations n'est requise pour le tag — ce sont des nice-to-have post-release.
+
+## Décision attendue
+
+**jsboige** : confirmer « garder tel-quel » pour les 7 (défaut recommandé), ou demander le polish optionnel (gloses ZH sur 475/927/1363). Ces 7 ne bloquent **pas** le tag v0.9.0 — le matériel est publiable en l'état.
+
+---
+
+Relates #633, #640, #140.


### PR DESCRIPTION
# docs(i18n): arbitrage des 7 faux positifs scanner post-#640 (#633)

Doc d'arbitrage pour les **7 findings résiduels** du scanner `scan_translations.py` après la refonte Rules #640 (22 → 7). Tâche tertiaire du dispatch ai-01 (deep-queue po-2024).

## Verdict : les 7 sont légitimes (KEEP tel-quel)

**Preuve structurelle** : le français lui-même (source canonique) garde plusieurs de ces termes **non traduits** — les autres langues qui font de même sont cohérentes, pas contaminées. Le scanner déclenche sur un seuil mécanique (`< 30 %` CJK/cyrillique) inadapté aux noms propres, emprunts et mnémoniques latins.

| PK | Cellule | Pourquoi c'est légitime |
|---|---|---|
| 30 (Fal) | `text_ru` = `Credo quia absurdum` | Locution latine canonique (Tertullien) — **EN la garde aussi en latin** |
| 475 (Fal) | `text_zh` = `Gish Gallop` | **FR canon = `Gish gallop` (emprunt non traduit)** — ZH miroir cohérent |
| 927 (Fal) | `text_zh` = `Creepypasta` | **FR canon = `Creepypasta` (emprunt non traduit)** — idem |
| 1363 (Fal) | `text_zh` = `Whataboutism（什么主义）` | Emprunt + glose (calque chinois usuel « quoi-isme ») |
| 107 (Vir) | `title_zh` = `Celarent 三段论` | Convention standard mnémoniques latins de syllogismes (三段论 = syllogisme) |
| 112 (Vir) | `title_zh` = `Camestres 三段论` | Idem |
| 6.1.3 (Sce) | `title_zh` = `Johnny Johnny` | Nom propre — **FR canon identique** (`Johnny Johnny`) |

## Ce document

- `docs/investigations/2026-07-02-scanner-fp-arbitration.md` — analyse cell-by-cell avec contrepartie FR (canon) + inter-langue pour chaque FP, recommandations d'amélioration du scanner (exemption `< 12 chars`, whitelist emprunts, croisement FR), et décision attendue jsboige.

## Impact

- **Aucun changement de code/CSV** — doc uniquement (1 fichier, +49 lignes).
- **Ne bloque pas le tag v0.9.0** — le matériel est publiable en l'état. Les 7 sont des FPs, non des défauts.
- Confirme définitivement la claim « 0 HIGH résiduel » post-#640 avec l'analyse complète.
- *Observation annexe notée* : PK6.1.3 title EN est **vide** (trou EN mineur, pas un défaut ZH) — hors-scope, pour suivi ultérieur éventuel.

## Décision attendue

**jsboige** (post-tag) : confirmer « garder tel-quel » pour les 7, ou demander le polish optionnel (gloses ZH sur 475/927/1363).

Relates #633, #640, #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
