### PR TITLE
feat(pnp): #645 Print&Play Standard (jeu complet) + Light (échantillon historique)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/CardSetInfo.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/CardSetInfo.cs
@@ -143,6 +143,11 @@ namespace Argumentum.AssetConverter
 		public static readonly string ScenariiPrintAndPlay = "Scenarii-Print&Play";
 		public static readonly string RulesPrintAndPlay = "Rules-Print&Play";
 		public static readonly string MemoPrintAndPlay = "Memo-Print&Play";
+		// #645 — Print&Play "Light" (historical sample, print_and_play=1) vs "Standard" (all cards, free digital game).
+		// FallaciesPrintAndPlayLight = the 35 Feb-2022 demo fallacies (filter print_and_play=1), vs FallaciesPrintAndPlay = all 176 real cards.
+		// ScenariiPrintAndPlayFull = all 167 scenarii (no filter), vs ScenariiPrintAndPlay = the 27 demo scenarii (print_and_play=1).
+		public static readonly string FallaciesPrintAndPlayLight = "Fallacies-Print&Play-Light";
+		public static readonly string ScenariiPrintAndPlayFull = "Scenarii-Print&Play-Full";
 		public static readonly string FallaciesWeb = "Fallacies-Web";
 		public static readonly string FallaciesWebLight = "Fallacies-Web-Light";
 		public static readonly string FallaciesWebThumbnails = "Fallacies-Web-Thumbnails";

--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/WebBasedGeneratorConfig.cs
@@ -242,6 +242,29 @@ namespace Argumentum.AssetConverter
 						Dpi = 300
 					}
 				},
+				// #645 — Light P&P: same proven Fallacies P&P config, but the historical "print_and_play=1" sample (~35 cards) instead of all real cards (carte 1/2 = 176).
+				new CardSetConfig(){
+					Name =KnownCardSets.FallaciesPrintAndPlayLight,
+					FaceCardSetInfo = new CardSetInfo()
+					{
+						DataSet = KnownDataSets.FallaciesTaxonomy,
+						CsvFilterField = "print_and_play",
+						CsvFilterValues = new List<string>(new []
+						{
+							"1"
+						}),
+						JsonFilePathRelease = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Fallacies/Argumentum_Fallacies_Face_fr.json",
+						JsonFilePathDebug = @"..\..\..\..\..\..\Cards\Fallacies\Argumentum_Fallacies_Face_fr.json",
+						Dpi = 300
+					},
+					BackCardSetInfo = new CardSetInfo()
+					{
+						DataSet = KnownDataSets.None,
+						JsonFilePathRelease = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Fallacies/Argumentum_Fallacies_Back_fr.json",
+						JsonFilePathDebug = @"..\..\..\..\..\..\Cards\Fallacies\Argumentum_Fallacies_Back_fr.json",
+						Dpi = 300
+					}
+				},
 				new CardSetConfig(){
 					Name =KnownCardSets.Memo,
 					FaceCardSetInfo = new CardSetInfo()
@@ -283,6 +306,26 @@ namespace Argumentum.AssetConverter
 						{
 							"1"
 						}),
+						RowsetNb = 0,
+						Dpi = 300
+					},
+					BackCardSetInfo = new CardSetInfo()
+					{
+						DataSet = KnownDataSets.Scenarii,
+						JsonFilePathRelease = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Scenarii/Argumentum_Scenarii_Back_fr.json",
+						JsonFilePathDebug = @"..\..\..\..\..\..\Cards\Scenarii\Argumentum_Scenarii_Back_fr.json",
+						RowsetNb = 14,  // Requis car template utilise {{rowset.[0].catégorie}}
+						Dpi = 300
+					}
+				},
+				// #645 — Standard P&P: same proven Scenarii P&P config, but ALL 167 scenarii (no print_and_play filter) instead of the 27-card demo sample.
+				new CardSetConfig(){
+					Name =KnownCardSets.ScenariiPrintAndPlayFull,
+					FaceCardSetInfo = new CardSetInfo()
+					{
+						DataSet = KnownDataSets.Scenarii,
+						JsonFilePathRelease = "https://raw.githubusercontent.com/ArgumentumGames/Argumentum/master/Cards/Scenarii/Argumentum_Scenarii_Face_fr.json",
+						JsonFilePathDebug = @"..\..\..\..\..\..\Cards\Scenarii\Argumentum_Scenarii_Face_fr.json",
 						RowsetNb = 0,
 						Dpi = 300
 					},
@@ -627,7 +670,8 @@ namespace Argumentum.AssetConverter
 					{
 						new DocumentCardSet()
 						{
-							CardSetName = KnownCardSets.ScenariiPrintAndPlay,
+							// #645 — Standard P&P Poker = all 167 scenarii (free digital game), was the 27-card demo sample.
+							CardSetName = KnownCardSets.ScenariiPrintAndPlayFull,
 							NbCopies = 1,
 							SaveOriginalImage = false,
 							FrontCards = new DocumentCard()
@@ -643,6 +687,123 @@ namespace Argumentum.AssetConverter
 								WidthMM = 63.5m,   // Standard poker: 2.5" = 63.5mm (was 58mm - incorrect)
 							}
 						}
+					}),
+				},
+				// #645 — Print&Play LIGHT variants (historical Feb-2022 sample: print_and_play=1). Standard docs above carry ALL cards (free digital game).
+				new CardSetDocumentConfig()
+				{
+					DocumentName = "Argumentum_TarotCards_Print&Play_Light_A4_fr.pdf",
+					Enabled = true,
+					Translations = new List<(string sourceLang, string destLang)>(new []
+					{
+						("fr", "en"),
+						("fr", "ru"),
+						("fr", "pt"),
+						("fr", "es"),
+						("fr", "ar"),
+						("fr", "fa"),
+						("fr", "zh")
+					}),
+
+					DocumentFormat = CardDocumentFormat.PrintAndPlay,
+					PageSize = "A4",
+					CardSets = new List<DocumentCardSet>(new[]
+					{
+						new DocumentCardSet()
+						{
+							CardSetName = KnownCardSets.RulesPrintAndPlay,
+							NbCopies = 1,
+							SaveOriginalImage = false,
+							FrontCards = new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 113,
+								WidthMM = 60,
+							},
+							BackCards =  new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 113,
+								WidthMM = 60,
+							}
+						},
+						new DocumentCardSet()
+						{
+							// #645 Light = historical print_and_play=1 sample (~35 fallacy cards)
+							CardSetName = KnownCardSets.FallaciesPrintAndPlayLight,
+							NbCopies = 1,
+							SaveOriginalImage = false,
+							FrontCards = new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 113,
+								WidthMM = 60,
+							},
+							BackCards =  new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 113,
+								WidthMM = 60,
+							}
+						},
+						new DocumentCardSet()
+						{
+							CardSetName = KnownCardSets.MemoPrintAndPlay,
+							NbCopies = 1,
+							SaveOriginalImage = false,
+							FrontCards = new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 113,
+								WidthMM = 60,
+							},
+							BackCards =  new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 113,
+								WidthMM = 60,
+							}
+						},
+					}),
+				},
+				new CardSetDocumentConfig()
+				{
+					DocumentName = "Argumentum_PokerCards_Print&Play_Light_A4_fr.pdf",
+					Enabled = true,
+					Translations = new List<(string sourceLang, string destLang)>(new []
+					{
+						("fr", "en"),
+						("fr", "ru"),
+						("fr", "pt"),
+						("fr", "es"),
+						("fr", "ar"),
+						("fr", "fa"),
+						("fr", "zh")
+					}),
+
+					DocumentFormat = CardDocumentFormat.PrintAndPlay,
+					PageSize = "A4",
+					CardSets = new List<DocumentCardSet>(new[]
+					{
+						new DocumentCardSet()
+						{
+							// #645 Light = historical print_and_play=1 sample (27 scenarii)
+							CardSetName = KnownCardSets.ScenariiPrintAndPlay,
+							NbCopies = 1,
+							SaveOriginalImage = false,
+							FrontCards = new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 88.9m,
+								WidthMM = 63.5m,
+							},
+							BackCards =  new DocumentCard()
+							{
+								BorderMM = 0,
+								HeigthMM = 88.9m,
+								WidthMM = 63.5m,
+							}
+						},
 					}),
 				},
 				new CardSetDocumentConfig()


### PR DESCRIPTION
## feat(pnp): Print&Play Standard (jeu complet) + Light (échantillon historique) — #645

Clôt #645. Décisions produit **jsboige, interactif ai-01, VÉRIFIÉ 2026-07-02** :
> Print&Play : on fait tenir tout dans du A4. Une **version light** = l'échantillon de l'ancien print&play ; la **version standard** = **toutes les cartes** (jeu numérique désormais entièrement gratuit, plus seulement un essai).
> Les **2 P&P doivent faire partie du bundle v3** du tag v0.9.0.
> Light = **la colonne `print_and_play`** (sample fév. 2022).

### Partition retenue

| Variante | Fallacies | Scenarii | Rules | Virtues | Memo |
|---|---|---|---|---|---|
| **Standard** (`..._Print&Play_A4`) | **176** (`carte∈{1,2}`) | **167** (tous) | ✅ | ✅ | ✅ ×5 |
| **Light** (`..._Print&Play_Light_A4`) | **35** (`print_and_play=1`) | **27** (`print_and_play=1`) | ✅ | ❌ | ✅ ×1 |

Comptes CSV vérifiés (code=truth, master `99145fab`) : Fallacies 1408 lignes → `carte∈{1,2}`=176, `print_and_play=1`=35 ; Scenarii 167 lignes → `print_and_play=1`=27.

### Changements (config-only, `WebBasedGeneratorConfig.cs` + `Cardpen/CardSetInfo.cs`)

1. **2 nouveaux `KnownCardSets`** : `FallaciesPrintAndPlayLight` (filtre `print_and_play=1`) et `ScenariiPrintAndPlayFull` (aucun filtre → 167).
2. **2 nouveaux `CardSetConfig`** — clones **exacts** des configs P&P déjà prouvées (mêmes templates, mêmes `RowsetNb`, même géométrie de rendu), seul le **filtre** change. Aucune logique touchée.
3. **Poker P&P existant → Standard** : bascule `Scenarii-Print&Play` (27) → `Scenarii-Print&Play-Full` (167). Le doc `Argumentum_PokerCards_Print&Play_A4_fr.pdf` porte désormais tous les scénarios.
4. **Tarot P&P existant = déjà Standard** : `Argumentum_TarotCards_Print&Play_A4_fr.pdf` contenait déjà Fallacies 176 + Virtues + Rules + Memo → inchangé.
5. **2 nouveaux documents Light** (A4, `CardDocumentFormat.PrintAndPlay`, 8 langues comme le reste du bundle) :
   - `Argumentum_TarotCards_Print&Play_Light_A4_fr.pdf` = Rules + Fallacies-light(35) + Memo.
   - `Argumentum_PokerCards_Print&Play_Light_A4_fr.pdf` = Scenarii-light(27).

### Choix produit à valider (reviewables, additifs)

- **Light exclut les Virtues** (elles n'existaient pas dans l'échantillon fév. 2022). À confirmer.
- **Light inclut Rules + Memo** pour rester un échantillon *jouable*. Memo à 1 copie (vs 5 en Standard).
- Nommage : Standard = nom historique **sans suffixe** (fichiers existants inchangés) ; Light = suffixe **`_Light_`**.

### Discipline respectée

- **Aucune modification de CSV** ni de template CardPen (les CSV sont la vérité, injectés tels quels).
- Clone des configs P&P prouvées — pas de `RowsetNb` forcé ni `rscount=0` réintroduit.
- `AssetConverterConfig.json` non touché (généré, `.gitignore` — la source de vérité reste le C#).
- Build ✅ 0 erreur. Tests : voir CI.

### Validation restante (hors PR, lane régén)

La validation **visuelle/volumétrie** des PDFs Standard (volume ~300+ cartes/langue, pages A4, poids, lock QuestPDF) se fait à la **régénération bundle v3** (lane po-2023 + verdict visuel ai-01), pas dans cette PR de config.

Relates #642 (décision D), #134 (release v0.9.0), #631 (dossier validation).

🤖 ai-01
