### PR TITLE
fix(harvest): #651 resolve reproducible Playwright deadlock (console-flood on event thread)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs
@@ -382,13 +382,23 @@ public class HarvestManager : IAsyncDisposable
 		var currentHarvest = new CardSetHarvest();
 		var page = await GetFreePage(browser);
 
+		// #651 deadlock fix: the previous handler logged EVERY browser console message as 5
+		// verbatim Log lines directly on Playwright's event-dispatch thread. Under a full
+		// clean-slate harvest CardPen floods the console during cardpen.write.generate; each
+		// message triggered slow synchronous file I/O (File.AppendAllText under lock) plus
+		// AnsiConsole writes (Spectre.Console is NOT thread-safe → concurrent access from the
+		// harvest thread AND the event thread). This starved/stalled the Playwright transport
+		// so Goto/Evaluate never returned → indefinite 0-CPU freeze with no timeout (reproducible
+		// deadlock, po-2023 3/3 at the Rules harvest). Fix: capture ERROR-level messages only,
+		// into a lock-free queue (no I/O, no AnsiConsole on the event thread), drained on the
+		// main thread after generation. Normal-path console spam is dropped (pure debug noise).
+		var consoleErrors = new System.Collections.Concurrent.ConcurrentQueue<string>();
 		void Page_Console(object sender, IConsoleMessage msg)
 		{
-			Log("--- CONSOLE MESSAGE RECEIVED ---");
-			Log($"Type: {msg.Type}");
-			Log($"Text: {msg.Text}");
-			Log($"Location: {msg.Location}");
-			Log("--- END CONSOLE MESSAGE ---");
+			if (msg.Type == "error")
+			{
+				consoleErrors.Enqueue($"[BROWSER error] {msg.Text} @ {msg.Location}");
+			}
 		}
 		page.Console += Page_Console;
 
@@ -465,6 +475,8 @@ public class HarvestManager : IAsyncDisposable
 		finally
 		{
 			page.Console -= Page_Console;
+			// Drain any captured browser console errors on the main thread (safe I/O + AnsiConsole here).
+			while (consoleErrors.TryDequeue(out var err)) { Logger.Log(err, MessageType.Problem); }
 			ReleasePage(page);
 		}
 


### PR DESCRIPTION
## fix(harvest): résoudre le deadlock Playwright reproductible (#651) — chemin critique bundle v3 / tag

Répond à l'**ASK de po-2023** (dashboard 2026-07-02 15:25) : bundle v3 **impossible à produire**, le harvest deadlock Chromium de façon **reproductible 3/3** après ~2-3 min, toujours au même point (harvest Rules, après plusieurs `Loaded 15 items`). Zombie CPU-flat, **pas de crash** (donc `ContinueOnHarvestSetFailure` #614 ne le catch pas), **pas de timeout**, freeze indéfini.

### Root cause (ancrée dans le code, pas une supposition)

`GenerateHarvestImages` s'abonnait à `page.Console` avec un handler qui logguait **CHAQUE** message console du navigateur en **5 lignes `Log` verbatim**, exécutées **synchronement sur le thread mono d'événements de Playwright** :

```csharp
void Page_Console(object sender, IConsoleMessage msg) {
    Log("--- CONSOLE MESSAGE RECEIVED ---");
    Log($"Type: {msg.Type}"); Log($"Text: {msg.Text}");
    Log($"Location: {msg.Location}"); Log("--- END CONSOLE MESSAGE ---");
}
```

Chaque `Log` fait un `File.AppendAllText` (open/write/close **sous `lock(fileLock)`**, `Logger.cs:83-86`) **+** des `AnsiConsole.WriteLine` — et **`AnsiConsole` (Spectre.Console) n'est PAS thread-safe**, donc le thread harvest ET le thread d'événements y accèdent concurremment.

En **full harvest clean-slate**, CardPen inonde la console pendant `cardpen.write.generate`. L'I/O synchrone lente par message + l'accès AnsiConsole concurrent **saturent/stallent le transport Playwright** → les `await` `GotoAsync`/`EvaluateAsync` suivants ne reçoivent jamais leur réponse → **freeze 0-CPU indéfini sans timeout** (le mécanisme de timeout lui-même dépend de la dispatch-loop stallée).

**Pourquoi maintenant ?** C'était le **1er full harvest frais depuis le clobber** (volume console maximal) post-#640 (Rules refonte) / #645 (P&P). Les runs antérieurs avaient des harvests cachés (moins de navigations fraîches → moins de flood). D'où l'apparition à Rules (tôt, verbeux, 8 langues).

### Fix (delete-first, ciblé, non-pendulaire)

Le handler capture désormais **uniquement les messages de niveau `error`**, dans une **`ConcurrentQueue` lock-free** (zéro I/O, zéro AnsiConsole sur le thread d'événements). Les erreurs capturées sont **drainées sur le main thread** dans le `finally`. Le flood normal-path (pure instrumentation debug `--- CONSOLE MESSAGE RECEIVED ---`) est supprimé ; la visibilité des vraies erreurs CardPen est **préservée**.

- **Surgical** : 1 fichier, **+17/-5**.
- **Build** : 0 erreur (warnings SGEN/WebClient pré-existants).
- Aucun changement de comportement du harvest hormis la suppression du flood de logs et de son deadlock.

### Validation

- **Autoritative** : po-2023 re-run le harvest avec son **repro fiable 3/3**. Signature de succès = passer le point Rules qui gelait à ~2-3 min, harvest complet 8 langues.
- Le fix cible exactement le mécanisme observé (freeze 0-CPU sans timeout = dispatch-loop stallée, pas un timeout de navigation).

### Si insuffisant (plan B documenté)

Si le deadlock récidive malgré le fix, la cause secondaire candidate est l'**accumulation d'état sur l'`IPage` réutilisée** (page-pool `ConcurrentStack<IPage>`, une seule page sur des centaines de navigations en mode serial) → prochain incrément = **fresh context/page par CardSet**.

Relates #629 (stabilité Playwright), #645 / #134 (bundle v3, chemin critique tag).

🤖 ai-01
