### PR TITLE
feat(cmyk): add --pdf-cmyk CLI entry point for standalone CMYK post-pass (#632)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Program.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Program.cs
@@ -370,6 +370,30 @@ namespace Argumentum.AssetConverter
 						Logger.LogSuccess($"Documentation générée avec succès dans {outputDir}");
 						return;
 					}
+					else if (args[0].Equals("--pdf-cmyk", StringComparison.OrdinalIgnoreCase))
+					{
+						// #632 - Standalone Ghostscript CMYK + OutputIntent post-pass on an EXISTING bundle.
+						// Runs ONLY ConverterMode.PdfCmykPostProcess: no harvest, no PDF regeneration - it
+						// discovers the PDFs already under the Target directory and converts them in place.
+						// Forces Release params so the pass is enabled even from a Debug build: the whole
+						// point of this entry point is to apply Release-quality CMYK to a bundle regenerated
+						// on a machine WITHOUT Ghostscript, from the one machine that has GS. Ghostscript must
+						// be resolvable: either on PATH, or prepend the GS bin dir to PATH before launching
+						// (the .NET child process inherits it). If GS cannot be found, the stage skips every
+						// PDF with a warning rather than crashing.
+						Logger.LogTitle("Mode post-traitement CMYK des PDF (#632)");
+						
+						var cmykConfigFileName = Path.Combine(Environment.CurrentDirectory, "AssetConverterConfig.json");
+						var cmykConfig = AssetConverterConfig.GetConfig(cmykConfigFileName, out var _);
+						
+						// Only the CMYK post-pass - replaces the default harvest+PDF Mode.
+						cmykConfig.Mode = ConverterMode.PdfCmykPostProcess;
+						// Enable the Release-gated CMYK stage regardless of the build configuration.
+						cmykConfig.ForceReleaseParams = true;
+						
+						await cmykConfig.Apply().ConfigureAwait(false);
+						return;
+					}
 				}
 
 				var configFileName = Path.Combine(Environment.CurrentDirectory, "AssetConverterConfig.json");


### PR DESCRIPTION
## Problème

Le stage CMYK+OutputIntent Ghostscript de #632 ne tournait **que** dans le cadre d'un run pipeline Release complet :
- le `Mode` par défaut **omet** `ConverterMode.PdfCmykPostProcess` (flag `1<<15`) ;
- le stage est **Release-gated** (`GetEnabled → EnabledRelease`).

Il n'existait **aucun moyen d'appliquer le CMYK en standalone sur un bundle déjà généré**. C'est pourtant exactement le besoin du tag : la régénération lourde du bundle se fait sur une machine worker **sans** Ghostscript, et le post-traitement CMYK imprimeur doit tourner sur **la seule machine qui a GS** (ai-01) — sans re-harvester.

## Changement

Ajoute une sous-commande **`--pdf-cmyk`** (mirroir des entry-points `--validate-*` existants) :
- `Mode = ConverterMode.PdfCmykPostProcess` **seul** → aucun harvest, aucune régénération PDF ; le processor découvre les PDFs déjà présents sous `Target/` et les convertit **en place** (atomic `File.Move` sur succès, skip gracieux si GS absent) ;
- `ForceReleaseParams = true` → active le stage Release-gated depuis n'importe quel build config.

GS résout via `PATH` (préfixer le bin GS avant le lancement, le process .NET hérite du PATH). L'**ICC SWOP est auto-extrait de Magick.NET au runtime** (`USWebCoatedSWOP`, même profil que la conversion per-image) → aucun profil manuel requis.

Config-only côté surface publique : +24 lignes dans `Program.cs`, aucune autre modification. `SkipConfigFile=true` respecté (pas d'édition JSON). Build 0 erreur.

## Vérification end-to-end sur ai-01 (GS 10.07.1)

```
$ PATH="$GS_BIN:$PATH" Argumentum.AssetConverter.exe --pdf-cmyk --non-interactive
Mode post-traitement CMYK des PDF (#632)
Loaded 16 card sets: ...
PDF CMYK post-process: 64 PDF(s) to convert, GS='gswin64c',
  ICC='C:\...\Temp\argumentum-USWebCoatedSWOP.icc'.
PDF CMYK post-process OK: '...Argumentum_Fallacies_Web_A0_ar.pdf'.   (~10s, A0 pleine taille)
```

Contrôle du PDF converti (`pdfimages -list` + grep PDF brut) :

| Contrôle | Avant | Après |
|---|---|---|
| Colorspace images | `rgb` 3-comp | **`cmyk` 4-comp** (178 DeviceCMYK) |
| OutputIntent | absent | **présent** (`GTS_PDFX` / `CGATS TR 001` / `SWOP`) |
| Page size / Producer | A0 / QuestPDF | A0 / GPL Ghostscript 10.07.1 |

## Scope / honnêteté

- Cible **colorspace CMYK + OutputIntent**, pas une certification PDF/X-3 formelle (pas de trim/bleed box) — cohérent avec le spec #632.
- Le bundle `bin/Debug/.../Target/` a été partiellement converti pendant le smoke test (output de build jetable, non commité, `.gitignore`) — sans effet sur le repo.
- Le run **standalone du tag** appliquera cette passe sur le **bundle v3** (contenu frais, une fois le deadlock harvest #651 mergé et le bundle régénéré).

Lié à #632. Chemin critique tag v0.9.0 (CMYK imprimeur obligatoire).

🤖 Coordinator ai-01
