### PR TITLE
fix(logger): #630 escape Spectre markup on all console paths + non-throwing render fallback

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Utility/LoggerMarkupSafetyTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Utility/LoggerMarkupSafetyTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using Argumentum.AssetConverter;
+using FluentAssertions;
+using Spectre.Console;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Utility
+{
+    /// <summary>
+    /// Regression tests for issue #630: a message containing square brackets (e.g. the
+    /// <c>[HARVEST-FAILURE]</c> marker emitted by the #614 per-set resilience path) was fed
+    /// unescaped to Spectre.Console markup rendering. The StyleParser then threw
+    /// <c>InvalidOperationException("Could not find color or style 'HARVEST-FAILURE'")</c>
+    /// from inside the resilience catch block, killing the whole run instead of degrading
+    /// gracefully.
+    ///
+    /// Two guarantees are pinned here:
+    ///  (1) bracketed messages render literally (Markup.Escape on every console path), and
+    ///  (2) Logger.Log never throws on any rendering failure (plain-text fallback), because
+    ///      #614 calls it from catch paths where a throw is fatal to the run.
+    /// </summary>
+    public class LoggerMarkupSafetyTests
+    {
+        /// <summary>
+        /// Routes AnsiConsole to a plain StringWriter for the duration of a test so output can
+        /// be asserted, then restores the previous console.
+        /// </summary>
+        private static string CaptureConsole(Action action)
+        {
+            var writer = new StringWriter();
+            var console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Interactive = InteractionSupport.No,
+                Out = new AnsiConsoleOutput(writer),
+            });
+            var previous = AnsiConsole.Console;
+            AnsiConsole.Console = console;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                AnsiConsole.Console = previous;
+            }
+            return writer.ToString();
+        }
+
+        [Fact]
+        public void Log_Problem_WithHarvestFailureMarker_DoesNotThrow_AndRendersLiterally()
+        {
+            // Exact shape emitted by HarvestManager's #614 resilience path.
+            var message = "[HARVEST-FAILURE] Card set 'FallaciesTarot' / 'fr' failed and was skipped: boom";
+
+            string output = null;
+            var act = () => { output = CaptureConsole(() => Logger.Log(message, MessageType.Problem)); };
+
+            act.Should().NotThrow("a bracketed failure marker must not be parsed as Spectre style markup (#630)");
+            output.Should().Contain("[HARVEST-FAILURE]", "the marker must survive rendering literally for log greppability");
+        }
+
+        [Theory]
+        [InlineData(MessageType.Title)]
+        [InlineData(MessageType.Problem)]
+        [InlineData(MessageType.Instructions)]
+        [InlineData(MessageType.Explanations)]
+        [InlineData(MessageType.Warning)]
+        [InlineData(MessageType.Success)]
+        [InlineData(MessageType.Info)]
+        public void Log_AnyMessageType_WithBracketedContent_DoesNotThrow(MessageType messageType)
+        {
+            // Brackets show up in real messages: failure markers, file paths, exception text,
+            // Mustache/template fragments quoted in diagnostics.
+            var message = "path [C:\\x] marker [HARVEST-FAILURE] template {{field}} style [bold red]";
+
+            var act = () => CaptureConsole(() => Logger.Log(message, messageType));
+
+            act.Should().NotThrow($"no console rendering path may propagate for {messageType} (#630)");
+        }
+
+        [Fact]
+        public void Log_InvalidMessageType_StillThrowsArgumentOutOfRange()
+        {
+            // The render-failure fallback must not swallow the guard clause for invalid enums.
+            var act = () => CaptureConsole(() => Logger.Log("x", (MessageType)999));
+
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void LogException_WithBracketsInExceptionMessage_DoesNotThrow()
+        {
+            var ex = new InvalidOperationException("outer [HARVEST-FAILURE]",
+                new IOException("inner [bold red] not-a-style"));
+
+            var act = () => CaptureConsole(() => Logger.LogException(ex));
+
+            act.Should().NotThrow("exception messages routinely contain brackets and are rendered on failure paths");
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/Logger.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Logger.cs
@@ -61,7 +61,7 @@ public class Logger
 		}
 		catch (Exception ex)
 		{
-			AnsiConsole.MarkupLine($"[bold red]Error during logger initialization: {ex.Message}[/]");
+			AnsiConsole.MarkupLine($"[bold red]Error during logger initialization: {Markup.Escape(ex.Message)}[/]");
 		}
 	}
 
@@ -90,47 +90,57 @@ public class Logger
 		{
 			// Log initialization errors to the console to ensure they are visible
 			// as the file logger itself may be the source of the problem.
-			AnsiConsole.MarkupLine($"[bold red]Failed to write to log file '{LogFile}'. Exception: {ex.Message}[/]");
+			AnsiConsole.MarkupLine($"[bold red]Failed to write to log file '{Markup.Escape(LogFile)}'. Exception: {Markup.Escape(ex.Message)}[/]");
 		}
 
-		switch (messageType)
+		try
 		{
-			case MessageType.Info:
-			case MessageType.Success:
-			case MessageType.Warning:
-				var markup = messageType == MessageType.Info ? "dim" : messageType == MessageType.Warning ? "sandybrown" : "green3";
-				if (LogInfo || messageType != MessageType.Info)
-				{
-					AnsiConsole.MarkupLine($"{Stopwatch.Elapsed}: [{markup}]{Markup.Escape(message)}[/]");
-				}
-				break;
-			case MessageType.Title:
-				AnsiConsole.WriteLine();
-				AnsiConsole.WriteLine();
-				var rule = new Rule($"[bold]{message}[/]");
-				AnsiConsole.Write(rule);
-				AnsiConsole.WriteLine();
-				break;
-			case MessageType.Problem:
-				AnsiConsole.WriteLine();
-				AnsiConsole.MarkupLine($"[bold red]{message}[/]");
-				AnsiConsole.WriteLine();
-				break;
-			case MessageType.Instructions:
-			case MessageType.Explanations:
-				AnsiConsole.WriteLine();
-				var header = messageType.ToString();
-				var color = messageType==MessageType.Instructions ? Color.Yellow : Color.PaleGreen1;
-				AnsiConsole.Write(
-					new Panel(message)
-						.Header(header)
-						.Collapse()
-						.RoundedBorder()
-						.BorderColor(color));
-				AnsiConsole.WriteLine();
-				break;
-			default:
-				throw new ArgumentOutOfRangeException(nameof(messageType), messageType, null);
+			switch (messageType)
+			{
+				case MessageType.Info:
+				case MessageType.Success:
+				case MessageType.Warning:
+					var markup = messageType == MessageType.Info ? "dim" : messageType == MessageType.Warning ? "sandybrown" : "green3";
+					if (LogInfo || messageType != MessageType.Info)
+					{
+						AnsiConsole.MarkupLine($"{Stopwatch.Elapsed}: [{markup}]{Markup.Escape(message)}[/]");
+					}
+					break;
+				case MessageType.Title:
+					AnsiConsole.WriteLine();
+					AnsiConsole.WriteLine();
+					var rule = new Rule($"[bold]{Markup.Escape(message)}[/]");
+					AnsiConsole.Write(rule);
+					AnsiConsole.WriteLine();
+					break;
+				case MessageType.Problem:
+					AnsiConsole.WriteLine();
+					AnsiConsole.MarkupLine($"[bold red]{Markup.Escape(message)}[/]");
+					AnsiConsole.WriteLine();
+					break;
+				case MessageType.Instructions:
+				case MessageType.Explanations:
+					AnsiConsole.WriteLine();
+					var header = messageType.ToString();
+					var color = messageType==MessageType.Instructions ? Color.Yellow : Color.PaleGreen1;
+					AnsiConsole.Write(
+						new Panel(Markup.Escape(message))
+							.Header(header)
+							.Collapse()
+							.RoundedBorder()
+							.BorderColor(color));
+					AnsiConsole.WriteLine();
+					break;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(messageType), messageType, null);
+			}
+		}
+		catch (Exception renderEx) when (renderEx is not ArgumentOutOfRangeException)
+		{
+			// Console rendering must never propagate (#630): the #614 per-set resilience calls
+			// Log() from its catch path, so a Spectre StyleParser failure here would kill the
+			// whole run instead of degrading gracefully. Fall back to plain (markup-free) output.
+			AnsiConsole.WriteLine($"{Stopwatch.Elapsed}: [{messageType}] {message} (console render failed: {renderEx.Message})");
 		}
 
 
@@ -193,7 +203,7 @@ public class Logger
 		}
 		catch (Exception logEx)
 		{
-			AnsiConsole.MarkupLine($"[bold red]Failed to write exception to log file '{LogFile}'. Exception: {logEx.Message}[/]");
+			AnsiConsole.MarkupLine($"[bold red]Failed to write exception to log file '{Markup.Escape(LogFile)}'. Exception: {Markup.Escape(logEx.Message)}[/]");
 		}
 	}
 


### PR DESCRIPTION
## Problème (#630)

Quand un harvest set échoue, le marqueur `[HARVEST-FAILURE]` injecté par la résilience per-set #614 est rendu par `Logger.Log(..., MessageType.Problem)`. Ce chemin passait le message **non-escapé** à `AnsiConsole.MarkupLine` → le StyleParser de Spectre interprète `[HARVEST-FAILURE]` comme un token de style → `InvalidOperationException` levée **depuis le catch de la résilience** → le run entier meurt au lieu de dégrader gracieusement. Le filet #614 était donc court-circuité par son propre message d'échec.

L'audit du Logger a montré que le bug est une **asymétrie** : le chemin `Info/Warning/Success` escape déjà (`Markup.Escape`), mais `Problem`, `Title` (Rule) et `Instructions/Explanations` (Panel — le ctor `Panel(string)` parse aussi le markup) ne le faisaient pas. Les handlers internes du logger interpolaient aussi `ex.Message`/`LogFile` sans escape.

## Fix (les deux options du body de l'issue, complémentaires)

1. **Escape systématique** : `Markup.Escape(message)` sur les 3 chemins manquants + sur `ex.Message`/`LogFile` des handlers internes. Le marqueur `[HARVEST-FAILURE]` s'affiche désormais littéralement (greppable).
2. **Ceinture non-throwing** : le rendu console est enveloppé d'un try/catch avec fallback plain-text (`AnsiConsole.WriteLine`, sans parsing markup) — **aucun échec de rendu ne peut plus se propager hors de `Logger.Log`**, quelle que soit une future régression d'escape. Le garde-fou `ArgumentOutOfRangeException` (enum invalide) est préservé via un exception filter.

Le fichier log (`File.AppendAllText`) écrivait déjà le texte brut — non affecté.

## Tests

`LoggerMarkupSafetyTests` (10 tests, console routée vers un `StringWriter` via `IAnsiConsole` custom) :
- Repro exact #630 : `[HARVEST-FAILURE] Card set ... failed and was skipped` en `Problem` → ne throw plus **et** rend le marqueur littéralement.
- Theory sur les 7 `MessageType` avec contenu à crochets/moustaches/pseudo-styles.
- L'enum invalide throw toujours `ArgumentOutOfRangeException` (la ceinture ne l'avale pas).
- `LogException` avec crochets dans les messages d'exception.

**Contre-vérification** : contre l'ancien code (stash du fix), **5/10 échouent** — exactement les 5 chemins non-escapés ; les chemins déjà sûrs passent. Les tests pinnent donc réellement le fix.

Suite complète : **566 pass / 1 known-fail (OWLSharp round-trip #133, pré-existant) / 5 skip**. 0 warning introduit.

## Impact

- Hardening du chemin régén : un set en échec logge proprement et le run continue (#614 restauré).
- Milestone v0.9.x mais mergeable dès maintenant : protège les prochaines régénérations (dont d'éventuels re-runs bundle).

Closes #630. Relates #613, #614.

🤖 Coordinator ai-01
