### PR TITLE
fix(cmyk): #632 follow-up — raise GS per-PDF timeout 180→900s (Bundle v3)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/PdfCmykPostProcess/PdfCmykPostProcessConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/PdfCmykPostProcess/PdfCmykPostProcessConfig.cs
@@ -45,8 +45,11 @@ namespace Argumentum.AssetConverter.PdfCmykPostProcess
         /// </summary>
         public string IccProfilePath { get; set; }
 
-        /// <summary>Per-PDF Ghostscript timeout in seconds (default 180).</summary>
-        public int TimeoutSeconds { get; set; } = 180;
+        /// <summary>Per-PDF Ghostscript timeout in seconds (default 900).</summary>
+        // #632 follow-up (2026-07-03): raised 180→900s. Large TarotCards/P&P/Poker PDFs
+        // (200+ pages PNG-lossless, ~123MB) need 250-350s each; 180s timed out on 23/80
+        // during Bundle v3 CMYK conversion. 900s gives comfortable headroom.
+        public int TimeoutSeconds { get; set; } = 900;
 
         /// <summary>
         /// Entry point dispatched from <see cref="AssetConverterConfig.Apply"/> when


### PR DESCRIPTION
## What

Raise the Ghostscript per-PDF CMYK post-process timeout default **180s → 900s**. This is the committed counterpart of the local override used to complete the Bundle v3 CMYK conversion (ai-01 dispatch `8b3ymj`, GO on the open ASK; #632 follow-up).

## Why

During the Bundle v3 CMYK post-pass (2026-07-03), the 180s default **timed out on 23/80 PDFs** (`GS exit=-1`, TIMEOUT). The large TarotCards / Print&Play / Poker PDFs (200+ pages PNG-lossless, ~123MB) need **250-350s each**. A targeted retry at 900s converted **23/23 cleanly**, and the full bundle reached 80/80 DeviceCMYK + OutputIntent SWOP.

900s gives comfortable headroom for the heaviest PDFs without risk of indefinite hangs (GS is single-PDF-serial here).

## Change

`PdfCmykPostProcessConfig.TimeoutSeconds`: `= 180` → `= 900` (+ comment documenting the rationale). 1 file, +5/-2.

## Safety

- Valid int literal — no compilation risk.
- **No test asserts the 180 default** (`PdfCmykPostProcessTests.cs` uses its own config instances) — config-instance tests unaffected.
- Default-only change; operators who need a different value still set `TimeoutSeconds` explicitly.

## Scope

Minimal follow-up to #632/#652 (the CMYK GS post-process + `--pdf-cmyk` entry-point). Base `27442add`. No test/build regression expected (config default).

Relates: #632 #652 #140. Bundle v3 80/80 CMYK complete (verdict colorimétrique #632 = PASS, ai-01).

🤖 Worker po-2023 (GLM)
