### PR TITLE
[runtime pending] feat(dnn): #649 RulesExplorer i18n — mirror loc() culture cascade

### DIFF
--- a/DNNPlatform/Portals/1/2sxc/Argumentum/_RulesExplorer_RuleDetail.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Argumentum/_RulesExplorer_RuleDetail.cshtml
@@ -24,6 +24,31 @@
         height = 100
     };
 
+    // Culture-aware field selection for the Rule content-type.
+    // Mirrors FallacyExplorer (PR #490): cascade lang -> en -> fr on suffixed fields.
+    // ADDS a 4th fallback on the generic (unsuffixed) field: the Rule content-type
+    // currently exposes generic fields (Summary, Material, ...) holding the FR
+    // canonical value, with no language dimensions wired yet. Without the generic
+    // fallback, Loc() would return "" until the DB gains suffixed fields — breaking
+    // the current FR rendering. The generic fallback preserves FR during the
+    // DB-migration transition (gated on the 2sxc portal export, jsboige).
+    // See investigation PR #669 (RulesExplorer FR-only = cause of audit #662).
+    var lang = (CmsContext.Culture.CurrentCode ?? "fr-fr").Split(new[] { '-' })[0].ToLowerInvariant();
+    var supported = new HashSet<string> { "fr", "en", "ru", "pt", "es", "ar", "fa", "zh" };
+    if (!supported.Contains(lang)) { lang = "fr"; }
+
+    string Loc(dynamic entity, string field)
+    {
+        var dict = (IDictionary<string, object>)entity;
+        string pick(string key) => dict.ContainsKey(key) ? entity[key]?.ToString() ?? "" : "";
+        var primary = pick(field + "_" + lang);
+        if (!string.IsNullOrEmpty(primary)) return primary;
+        if (lang != "en") { var en = pick(field + "_en"); if (!string.IsNullOrEmpty(en)) return en; }
+        var fr = pick(field + "_fr");
+        if (!string.IsNullOrEmpty(fr)) return fr;
+        return pick(field);  // generic fallback — current FR canonical value
+    }
+
 }
 
 <link rel="stylesheet" href="@App.Path/src/styles/argumentum.css" data-enableoptimizations="150" />
@@ -31,28 +56,28 @@
 <div class="rule row mb-4 mb-md-5" @Edit.TagToolbar(ruleEntity)>
     <div class="col-md-4 position-relative">
         <h1>
-            @ruleEntity.EntityTitle
+            @Loc(ruleEntity, "EntityTitle")
         </h1>
         <h5>de @ruleEntity.MinNbPlayers &agrave; @ruleEntity.MaxNbPlayers joueurs </h5>
         <h2>@Resources.RuleSummary</h2>
-        @Html.Raw(ruleEntity.Summary)
+        @Html.Raw(Loc(ruleEntity, "Summary"))
     </div>
     <div class="col-md-8  position-relative">
         <h2>@Resources.RuleMaterial</h2>
-        @Html.Raw(ruleEntity.Material)
+        @Html.Raw(Loc(ruleEntity, "Material"))
         <h2>@Resources.RuleInstallation</h2>
-        @Html.Raw(ruleEntity.Installation)
+        @Html.Raw(Loc(ruleEntity, "Installation"))
     </div>
     <div class="col-md-12  position-relative">
-        @Html.Raw(ruleEntity.Content)
-        @if (ruleEntity.Variants != "")
+        @Html.Raw(Loc(ruleEntity, "Content"))
+        @if (!string.IsNullOrEmpty(Loc(ruleEntity, "Variants")))
         {
             <h2>@Resources.RuleVariants</h2>
-            @Html.Raw(ruleEntity.Variants)
+            @Html.Raw(Loc(ruleEntity, "Variants"))
         }
 
     </div>
-    @if (!string.IsNullOrEmpty(ruleEntity.Memo))
+    @if (!string.IsNullOrEmpty(Loc(ruleEntity, "Memo")))
     {
 <div class="col-md-12">
     <h2>@Resources.RuleMemoCard</h2>
@@ -64,11 +89,11 @@
                     <bleed>
                         <cut>
                             <safe>
-                                <div class="cardName">@Resources.RuleMemoCardFileNamePrefix - @ruleEntity.EntityTitle</div>
+                                <div class="cardName">@Resources.RuleMemoCardFileNamePrefix - @Loc(ruleEntity, "EntityTitle")</div>
                                 <div>
-                                    <p><em>@ruleEntity.EntityTitle</em></p>
+                                    <p><em>@Loc(ruleEntity, "EntityTitle")</em></p>
                                     <p><a class="@qrDomId" href='@qrLink' target="_blank"></a></p>
-                                    @Html.Raw(ruleEntity.Memo)
+                                    @Html.Raw(Loc(ruleEntity, "Memo"))
                                 </div>
 
                                 <div class="colorPalette">

--- a/DNNPlatform/Portals/1/2sxc/Argumentum/_RulesExplorer_RuleList.cshtml
+++ b/DNNPlatform/Portals/1/2sxc/Argumentum/_RulesExplorer_RuleList.cshtml
@@ -1,13 +1,41 @@
 @inherits Custom.Hybrid.Razor14
+@using ToSic.Razor.Blade;
+
+@{
+    // Culture-aware field selection for the Rule content-type.
+    // Mirrors FallacyExplorer (PR #490): cascade lang -> en -> fr on suffixed fields.
+    // ADDS a 4th fallback on the generic (unsuffixed) field: the Rule content-type
+    // currently exposes generic fields (Summary, Material, ...) holding the FR
+    // canonical value, with no language dimensions wired yet. Without the generic
+    // fallback, Loc() would return "" until the DB gains suffixed fields — breaking
+    // the current FR rendering. The generic fallback preserves FR during the
+    // DB-migration transition (gated on the 2sxc portal export, jsboige).
+    // See investigation PR #669 (RulesExplorer FR-only = cause of audit #662).
+    var lang = (CmsContext.Culture.CurrentCode ?? "fr-fr").Split(new[] { '-' })[0].ToLowerInvariant();
+    var supported = new HashSet<string> { "fr", "en", "ru", "pt", "es", "ar", "fa", "zh" };
+    if (!supported.Contains(lang)) { lang = "fr"; }
+
+    string Loc(dynamic entity, string field)
+    {
+        var dict = (IDictionary<string, object>)entity;
+        string pick(string key) => dict.ContainsKey(key) ? entity[key]?.ToString() ?? "" : "";
+        var primary = pick(field + "_" + lang);
+        if (!string.IsNullOrEmpty(primary)) return primary;
+        if (lang != "en") { var en = pick(field + "_en"); if (!string.IsNullOrEmpty(en)) return en; }
+        var fr = pick(field + "_fr");
+        if (!string.IsNullOrEmpty(fr)) return fr;
+        return pick(field);  // generic fallback — current FR canonical value
+    }
+}
 
 <link rel="stylesheet" href="@App.Path/src/styles/argumentum.css" data-enableoptimizations="150" />
 @foreach (var ruleEntity in AsList(Data))
 {
-    var view1Parameters = "details=" + ruleEntity.UrlKey+ "&mid=" + CmsContext.Module.Id;
+    var view1Parameters = "details=" + ruleEntity.UrlKey + "&mid=" + CmsContext.Module.Id;
 
     <div class="rule row mb-4 mb-md-5" @Edit.TagToolbar(ruleEntity)>
         <div class="col-md-12 position-relative">
-            <h2>@ruleEntity.EntityTitle</h2>
+            <h2>@Loc(ruleEntity, "EntityTitle")</h2>
             <a class="link-overlay" href="@Link.To(parameters: view1Parameters)"></a>
             <div class="col-md-12">
                 <div class="row">
@@ -15,10 +43,10 @@
                         <h6>de @ruleEntity.MinNbPlayers &agrave; @ruleEntity.MaxNbPlayers joueurs </h6>
                     </div>
                     <div class="col-12 col-md-6 col-lg-8">
-                        @Html.Raw(ruleEntity.Summary)
+                        @Html.Raw(Loc(ruleEntity, "Summary"))
                     </div>
                 </div>
-                
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What

Refactor the 2 RulesExplorer views to be **culture-aware**, mirroring the `loc()` pattern established in FallacyExplorer (PR #490). This is the concrete worker-able step — reco from investigation #669 — to take the rules page from FR-only (1/8 langs, audit #662) toward 8/8.

**Primary** task from ai-01 dispatch `tbxfhu`. Base `a41cbda6`. **`[runtime pending]`** — gated like #596 (not for merge until sandbox runtime validation).

## Changes (source-level)

| File | Change |
|------|--------|
| `_RulesExplorer_RuleList.cshtml` | Add `lang` detection (`CmsContext.Culture`) + `Loc()` helper; route `EntityTitle` + `Summary` through `Loc()`. |
| `_RulesExplorer_RuleDetail.cshtml` | Same helper; route `EntityTitle` (×3), `Summary`, `Material`, `Installation`, `Content`, `Variants` (cond + raw), `Memo` (cond + raw) through `Loc()`. |

Diff: 2 files, +89/−36.

## The `Loc()` cascade — key design decision

```
<field>_<lang>  →  <field>_en  →  <field>_fr  →  <field>   (generic)
```

The **4th fallback on the generic (unsuffixed) field** is the critical difference from FallacyExplorer:

- FallacyExplorer reads `App.Query["FallaciesFromCSV"]` (CSV-backed) → suffixed fields `text_fr`/`text_en` **exist in the source**.
- RulesExplorer reads the Rule **content-type** in DB → fields are **generic** (`Summary`, `Material`, …) holding the FR canonical value, with **no language dimensions wired**.

Without the generic fallback, `Loc()` would return `""` until the DB gains suffixed fields — **breaking the current FR rendering**. The generic fallback **preserves FR during the DB-migration transition**: today (FR-only DB) the cascade falls through to the generic field and renders exactly as before; once suffixed fields are added per language, the cascade picks them up automatically.

## Runtime validation PENDING (gated like #596)

These `.cshtml` templates are **interpreted by 2sxc at runtime in DNN** — they are **not** compiled by `dotnet build`, so they cannot be validated locally by the .NET pipeline. Runtime validation requires:

1. **The 2sxc sandbox** (source-level ≠ runtime-validated — same garde-fou as #596).
2. **The Rule content-type to gain the suffixed fields** (`Summary_en`, `Summary_ru`, …) — a **DB change**, gated on the **2sxc portal export** (jsboige, per #669 §3). Until then, the generic fallback keeps FR rendering intact.

**Not for merge** until sandbox runtime validation.

## Out of scope (noted, not done here)

- **`de X à Y joueurs` hardcoded FR** (RuleList l.15, RuleDetail l.61) — left for the UI-strings rail (#457 L1 / #487, `Enabled=false`), separate lane.
- **`@Resources.*` labels** (RuleSummary, RuleMaterial, …) — already culture-aware via 2sxc App Resources; untouched.
- **Numeric fields** (`MinNbPlayers`/`MaxNbPlayers`) + `UrlKey` — non-localizable; untouched.

## Why this is the critical-path step

Per #669: the multilingual porting has 3 layers (L1 UI strings rail built / L2 HTML pages not wired / L3 content DB-only bulk). The RulesExplorer refactor is the **code-side prerequisite** for L3 — without `Loc()` in the view, no amount of DB translation will surface on the rules page. It mirrors a pattern proven in production by #490, so the risk is contained and the runtime behavior is well-understood.

Relates: #669 #490 #662 #596 #458. ai-01 dispatch `tbxfhu` (primary).

🤖 Worker po-2023 (GLM)
