### PR TITLE
tools(i18n): #654 Virtues mnemonic→Latin conversion script + tests + dry-run (gated prep)

### DIFF
--- a/docs/investigations/2026-07-05-654-mnemonics-dryrun.md
+++ b/docs/investigations/2026-07-05-654-mnemonics-dryrun.md
@@ -1,0 +1,67 @@
+# #654 mnemonics → Latin (Option B / S2) — dry-run report
+
+**Source CSV:** `Cards/Fallacies/Argumentum Virtues - Taxonomy.csv`
+
+**Decision:** keep-Latin (VERIFIED jsboige 2026-07-04, dispatch q9xpks).
+
+**Cells to convert (title only): 52** (RU 14 / AR 16 / ZH 6 / FA 16)
+
+
+## Plan (before → after)
+
+- **pk 108 [ar]** `Darii`: `قياس داريي` → `قياس Darii` (token `داريي` → `Darii`)
+- **pk 108 [fa]** `Darii`: `قیاس داریی` → `قیاس Darii` (token `داریی` → `Darii`)
+- **pk 109 [ar]** `Ferio`: `قياس فيريو` → `قياس Ferio` (token `فيريو` → `Ferio`)
+- **pk 109 [fa]** `Ferio`: `قیاس فریو` → `قیاس Ferio` (token `فریو` → `Ferio`)
+- **pk 112 [ru]** `Camestres`: `Силлогизм Каместрес` → `Силлогизм Camestres` (token `Каместрес` → `Camestres`)
+- **pk 112 [ar]** `Camestres`: `قياس كامستريس` → `قياس Camestres` (token `كامستريس` → `Camestres`)
+- **pk 112 [fa]** `Camestres`: `قیاس کامسترس` → `قیاس Camestres` (token `کامسترس` → `Camestres`)
+- **pk 113 [ru]** `Festino`: `Силлогизм Фестино` → `Силлогизм Festino` (token `Фестино` → `Festino`)
+- **pk 113 [ar]** `Festino`: `قياس فستينو` → `قياس Festino` (token `فستينو` → `Festino`)
+- **pk 113 [zh]** `Festino`: `费斯蒂诺三段论` → `Festino三段论` (token `费斯蒂诺` → `Festino`)
+- **pk 113 [fa]** `Festino`: `قیاس فستینو` → `قیاس Festino` (token `فستینو` → `Festino`)
+- **pk 114 [ru]** `Baroco`: `Силлогизм Бароко` → `Силлогизм Baroco` (token `Бароко` → `Baroco`)
+- **pk 114 [ar]** `Baroco`: `قياس باروكو` → `قياس Baroco` (token `باروكو` → `Baroco`)
+- **pk 114 [zh]** `Baroco`: `巴罗科三段论` → `Baroco三段论` (token `巴罗科` → `Baroco`)
+- **pk 114 [fa]** `Baroco`: `قیاس باروکو` → `قیاس Baroco` (token `باروکو` → `Baroco`)
+- **pk 116 [ru]** `Darapti`: `Силлогизм Дарапти` → `Силлогизм Darapti` (token `Дарапти` → `Darapti`)
+- **pk 116 [ar]** `Darapti`: `قياس دارابتي` → `قياس Darapti` (token `دارابتي` → `Darapti`)
+- **pk 116 [zh]** `Darapti`: `达拉普蒂三段论` → `Darapti三段论` (token `达拉普蒂` → `Darapti`)
+- **pk 116 [fa]** `Darapti`: `قیاس داراپتی` → `قیاس Darapti` (token `داراپتی` → `Darapti`)
+- **pk 117 [ru]** `Felapton`: `Силлогизм Фелаптон` → `Силлогизм Felapton` (token `Фелаптон` → `Felapton`)
+- **pk 117 [ar]** `Felapton`: `قياس فيلابتون` → `قياس Felapton` (token `فيلابتون` → `Felapton`)
+- **pk 117 [zh]** `Felapton`: `费拉普顿三段论` → `Felapton三段论` (token `费拉普顿` → `Felapton`)
+- **pk 117 [fa]** `Felapton`: `قیاس فلاپتون` → `قیاس Felapton` (token `فلاپتون` → `Felapton`)
+- **pk 118 [ru]** `Disamis`: `Силлогизм Дисамис` → `Силлогизм Disamis` (token `Дисамис` → `Disamis`)
+- **pk 118 [ar]** `Disamis`: `قياس ديساميس` → `قياس Disamis` (token `ديساميس` → `Disamis`)
+- **pk 118 [fa]** `Disamis`: `قیاس دیسامیس` → `قیاس Disamis` (token `دیسامیس` → `Disamis`)
+- **pk 119 [ru]** `Datisi`: `Силлогизм Датиси` → `Силлогизм Datisi` (token `Датиси` → `Datisi`)
+- **pk 119 [ar]** `Datisi`: `قياس داتيسي` → `قياس Datisi` (token `داتيسي` → `Datisi`)
+- **pk 119 [fa]** `Datisi`: `قیاس داتیسی` → `قیاس Datisi` (token `داتیسی` → `Datisi`)
+- **pk 120 [ru]** `Bocardo`: `Силлогизм Бокардо` → `Силлогизм Bocardo` (token `Бокардо` → `Bocardo`)
+- **pk 120 [ar]** `Bocardo`: `قياس بوكاردو` → `قياس Bocardo` (token `بوكاردو` → `Bocardo`)
+- **pk 120 [fa]** `Bocardo`: `قیاس بوکاردو` → `قیاس Bocardo` (token `بوکاردو` → `Bocardo`)
+- **pk 121 [ru]** `Ferison`: `Силлогизм Ферисон` → `Силлогизм Ferison` (token `Ферисон` → `Ferison`)
+- **pk 121 [ar]** `Ferison`: `قياس فيريسون` → `قياس Ferison` (token `فيريسون` → `Ferison`)
+- **pk 121 [fa]** `Ferison`: `قیاس فریسون` → `قیاس Ferison` (token `فریسون` → `Ferison`)
+- **pk 123 [ru]** `Camenes`: `Силлогизм Каменес` → `Силлогизм Camenes` (token `Каменес` → `Camenes`)
+- **pk 123 [ar]** `Camenes`: `قياس كامينيس` → `قياس Camenes` (token `كامينيس` → `Camenes`)
+- **pk 123 [fa]** `Camenes`: `قیاس کامنس` → `قیاس Camenes` (token `کامنس` → `Camenes`)
+- **pk 124 [ru]** `Dimatis`: `Силлогизм Диматис` → `Силлогизм Dimatis` (token `Диматис` → `Dimatis`)
+- **pk 124 [ar]** `Dimatis`: `قياس ديماتيس` → `قياس Dimatis` (token `ديماتيس` → `Dimatis`)
+- **pk 124 [fa]** `Dimatis`: `قیاس دیماتیس` → `قیاس Dimatis` (token `دیماتیس` → `Dimatis`)
+- **pk 125 [ru]** `Fesapo`: `Силлогизм Фесапо` → `Силлогизм Fesapo` (token `Фесапо` → `Fesapo`)
+- **pk 125 [ar]** `Fesapo`: `قياس فيسابو` → `قياس Fesapo` (token `فيسابو` → `Fesapo`)
+- **pk 125 [fa]** `Fesapo`: `قیاس فساپو` → `قیاس Fesapo` (token `فساپو` → `Fesapo`)
+- **pk 126 [ru]** `Fresison`: `Силлогизм Фресисон` → `Силлогизм Fresison` (token `Фресисон` → `Fresison`)
+- **pk 126 [ar]** `Fresison`: `قياس فريسيسون` → `قياس Fresison` (token `فريسيسون` → `Fresison`)
+- **pk 126 [zh]** `Fresison`: `弗雷西松式三段论` → `Fresison式三段论` (token `弗雷西松` → `Fresison`)
+- **pk 126 [fa]** `Fresison`: `قیاس فِرِسیسون` → `قیاس Fresison` (token `فِرِسیسون` → `Fresison`)
+- **pk 127 [ru]** `Bamalip`: `Силлогизм Бамалип` → `Силлогизм Bamalip` (token `Бамалип` → `Bamalip`)
+- **pk 127 [ar]** `Bamalip`: `قياس باماليب` → `قياس Bamalip` (token `باماليب` → `Bamalip`)
+- **pk 127 [zh]** `Bamalip`: `巴马利普式三段论` → `Bamalip式三段论` (token `巴马利普` → `Bamalip`)
+- **pk 127 [fa]** `Bamalip`: `قیاس بامالیپ` → `قیاس Bamalip` (token `بامالیپ` → `Bamalip`)
+
+## Out-of-scope flags
+
+- **remark cells** also carry transliterated mnemonics (~14 cells; RU 4 / AR 4 / ZH 2 / FA 4) — NOT in scope per dispatch (title only). Surfaced for jsboige to decide whether #654 extends to remark.

--- a/tools/mnemonics_to_latin.md
+++ b/tools/mnemonics_to_latin.md
@@ -1,0 +1,84 @@
+# `mnemonics_to_latin.py` — Virtues syllogistic-mnemonic normaliser (#654, Option B)
+
+A stdlib-only Python tool that reverts the transliterated syllogistic mnemonics in the Virtues
+taxonomy to their canonical Latin form for the 4 non-Latin languages (RU/AR/ZH/FA), so all 8
+languages are consistent with FR/EN/ES/PT (which already keep the Latin technical term).
+
+**Decision (VERIFIED jsboige 2026-07-04, dispatch `q9xpks`):** Option B "keep-Latin" — Scenario
+S2 of [`docs/investigations/2026-07-03-654-mnemonics-celltable.md`](../docs/investigations/2026-07-03-654-mnemonics-celltable.md).
+The 19 classical mnemonics (Barbara, Celarent, … Bamalip) are Latin canonical terms; the
+languages that transliterated some of them revert to Latin.
+
+**This is NOT translation.** It is a deterministic script-conversion of a fixed Latin technical
+term already present in `title_fr`. gpt-5.5 is inappropriate (would hallucinate transliterations
+/ drift). The transliteration per language is detected in the current cell (the language's own
+established rendering) and swapped for the canonical Latin form — never invented.
+
+## Run
+
+```bash
+# Dry-run (default): print the 52-cell plan, write nothing.
+python tools/mnemonics_to_latin.py
+
+# Dry-run + write a markdown report (the 52 cells before/after).
+python tools/mnemonics_to_latin.py --report docs/investigations/2026-07-05-654-mnemonics-dryrun.md
+
+# Apply in place (GATED — do NOT run on prod CSV until #654 is unblocked post-tag).
+python tools/mnemonics_to_latin.py --apply
+```
+
+**Exit code:** `0` = plan built / applied cleanly; `1` = CSV not found; `2` = ambiguous cells
+excluded from the plan (`--apply` is refused until they are resolved in
+`STRUCTURAL_TOKENS` / `extract_translit_token`).
+
+No dependencies beyond the Python 3 standard library (`csv`, `argparse`, `os`, `sys`, `re`).
+
+## Scope (code=truth on master `d90ce613`)
+
+| Field | Cells transliterated | In scope? |
+|-------|---------------------|-----------|
+| `title_<lang>` | **52** (RU 14 / AR 16 / ZH 6 / FA 16) | ✅ converted |
+| `description_<lang>` | 0 (descriptions carry no mnemonic) | N/A |
+| `remark_<lang>` | ~14 (RU 4 / AR 4 / ZH 2 / FA 4) | ⛔ out of scope (title-only per dispatch) |
+
+The 14 `remark_*` cells are surfaced in the dry-run report as a follow-up flag — extending the
+script to `remark` is a one-line change if jsboige decides #654 covers it.
+
+## How it works
+
+1. For each mnemonic pk (the 19 depth-7 CQ rows whose `title_fr` = `Syllogisme <M>`), read the
+   canonical Latin mnemonic `M` from `title_fr`.
+2. For each non-Latin language, if `title_<lang>` already contains `M` → kept-Latin, SKIP.
+3. Otherwise (transliterated): strip the language's structural native words
+   (`Силлогизм` / `قياس` / `المنطقي` / `三段论` / `式` / `قیاس`) — the residue is the
+   transliterated mnemonic token. Guard: if the residue is empty, multi-token, or contains
+   Latin letters, the cell is flagged **ambiguous** and excluded (surfaced for manual review).
+4. Plan: replace the transliterated token with `M` inside `title_<lang>`.
+5. `--apply`: parse the CSV with `csv.reader`, modify **only** the `title_<lang>` field, reserialise with `QUOTE_MINIMAL` + CRLF + BOM. The diff vs the input is exactly the 52 swapped
+   tokens — quoting, delimiters, line endings and the BOM are byte-preserved.
+
+### The CJK-boundary fix (why not `\b`)
+
+Latin-mnemonic detection uses `(?<![A-Za-z])…(?![A-Za-z])`, NOT `\b…\b`. Under `re.UNICODE`
+(default for `str`), `\w` includes CJK letters, so `\b` does **not** fire at the Latin→CJK
+boundary — `"Festino三段论"` would be missed (the ZH cells would be spuriously flagged
+ambiguous). The Latin-letter lookaround is the contract pinned by `test_cjk_glued_boundary`.
+
+## Tests
+
+```bash
+python tools/test_mnemonics_to_latin.py
+```
+
+26 contract tests (stdlib `unittest`): mnemonic extraction, the CJK-boundary regression,
+translit-token extraction per language with ambiguity guards, plan-building on synthetic CSV,
+`--apply` round-trip (title-only, BOM/CRLF preserved, idempotent), and a **grounding test** on
+the real Virtues CSV asserting the plan is exactly 52 cells / 0 ambiguous. If the corpus drifts,
+the grounding test surfaces it before a worker re-runs `--apply`.
+
+## Sources
+
+- [`docs/investigations/2026-07-03-654-virtues-mnemonics-inventory.md`](../docs/investigations/2026-07-03-654-virtues-mnemonics-inventory.md) — analysis-only inventory (#660).
+- [`docs/investigations/2026-07-03-654-mnemonics-celltable.md`](../docs/investigations/2026-07-03-654-mnemonics-celltable.md) — apply-ready cell table (#668).
+- [`docs/investigations/2026-07-05-654-mnemonics-dryrun.md`](../docs/investigations/2026-07-05-654-mnemonics-dryrun.md) — the 52-cell dry-run report produced by this script.
+- Issue #654, dispatch `q9xpks`. Base `d90ce613`.

--- a/tools/mnemonics_to_latin.py
+++ b/tools/mnemonics_to_latin.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+mnemonics_to_latin.py — deterministic Virtues syllogistic-mnemonic normaliser (#654).
+
+Decision (VERIFIED jsboige 2026-07-04, dispatch q9xpks): Option B "keep-Latin" (Scenario
+S2 of docs/investigations/2026-07-03-654-mnemonics-celltable.md). The 19 classical syllogistic
+mnemonics (Barbara, Celarent, ... Bamalip) are LATIN CANONICAL technical terms; the languages
+that transliterated some of them to native script (RU/AR/ZH/FA) revert to the Latin form for
+consistency with FR/EN/ES/PT, which already keep them Latin (20/20).
+
+WHY A SCRIPT (not gpt-5.5, not a C# test)
+  This is NOT translation. It is a deterministic script-conversion: a fixed Latin technical
+  term already present in title_fr must replace its transliterated rendering in the 4 non-Latin
+  languages. gpt-5.5 would be inappropriate (would hallucinate transliterations / drift). A
+  Python stdlib script reads the CSV, builds a verified per-cell replacement plan, and applies
+  it. The transliteration per language is NOT invented — it is detected in the current cell and
+  swapped for the canonical Latin form already in title_fr for that pk.
+
+WHAT IT DOES (Option B / S2 — keep-Latin)
+  For each mnemonic pk (106-127, the 19 depth-7 CQ rows whose title_fr = "Syllogisme <M>"),
+  and each of RU/AR/ZH/FA:
+    - If title_<lang> already contains the Latin mnemonic  -> kept-Latin, SKIP.
+    - Else (transliterated) -> extract the transliterated token by removing the language's
+      structural native words (Силлогизм / قياس / 三段论 / 式 / ...), verify the residue is a
+      single non-empty token with no Latin leakage, and plan the replacement
+      "<translit>" -> "<M>" inside title_<lang>.
+
+SCOPE (verified code=truth on master d90ce613, where FR title carries a mnemonic)
+  52 title cells transliterated: RU 14 / AR 16 / ZH 6 / FA 16.
+  description cells: 0 (descriptions carry no mnemonic). remark cells: 14 — OUT OF SCOPE per
+  dispatch (title only); surfaced in the dry-run report as a follow-up flag, not converted.
+
+USAGE
+  python tools/mnemonics_to_latin.py --csv "Cards/Fallacies/Argumentum Virtues - Taxonomy.csv"
+      # default: dry-run, prints the 52-cell plan + summary, writes no file.
+
+  python tools/mnemonics_to_latin.py --csv <PATH> --report docs/investigations/<NAME>.md
+      # dry-run, additionally writes a markdown report (the 52 cells before/after).
+
+  python tools/mnemonics_to_latin.py --csv <PATH> --apply
+      # WRITES the CSV in place (UTF-8 BOM preserved, line-by-line targeted replace so the
+      # rest of the file — quoting, delimiters, line endings — is byte-preserved except the
+      # swapped mnemonic token). GATED: do NOT run --apply on prod CSV until #654 is unblocked
+      # post-tag (dispatch q9xpks). Use --dry-run until then.
+
+  python tools/test_mnemonics_to_latin.py
+      # stdlib unittest: logic contract (mnemonic extraction, translit detection per lang,
+      # plan-building on synthetic CSV, apply round-trip, 52-cell grounding on the real CSV).
+
+DEPENDENCIES: Python 3 stdlib only (csv, argparse, os, sys, re, collections).
+
+Exit codes: 0 = plan built / applied cleanly; 2 = one or more AMBIGUOUS cells detected
+            (residue not a single clean token) — the plan still prints but --apply is refused
+            until the ambiguous cells are reviewed and resolved in this file.
+"""
+
+import argparse
+import csv
+import os
+import re
+import sys
+from collections import OrderedDict
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants — grounded in the corpus (code=truth), never from memory.
+# 19 classical syllogistic mnemonics, source: docs/investigations/2026-07-03-654
+# (verified against title_fr of pks 106-127 on master d90ce613).
+# ─────────────────────────────────────────────────────────────────────────────
+
+MNEMONICS = [
+    "Barbara", "Celarent", "Darii", "Ferio", "Cesare", "Camestres", "Festino",
+    "Baroco", "Darapti", "Felapton", "Disamis", "Datisi", "Bocardo", "Ferison",
+    "Camenes", "Dimatis", "Fesapo", "Fresison", "Bamalip",
+]
+
+# The 19 pks whose title_fr = "Syllogisme <M>" (pks 110/115/122 are figure-rows, no mnemonic).
+MNEMONIC_PKS = [106, 107, 108, 109, 111, 112, 113, 114, 116, 117, 118, 119,
+                120, 121, 123, 124, 125, 126, 127]
+
+# Map pk -> canonical Latin mnemonic (extracted from title_fr, verified code=truth).
+# Built once from the FR column; asserted in tests.
+_PK_TO_MNEMONIC = {
+    106: "Barbara", 107: "Celarent", 108: "Darii", 109: "Ferio", 111: "Cesare",
+    112: "Camestres", 113: "Festino", 114: "Baroco", 116: "Darapti", 117: "Felapton",
+    118: "Disamis", 119: "Datisi", 120: "Bocardo", 121: "Ferison", 123: "Camenes",
+    124: "Dimatis", 125: "Fesapo", 126: "Fresison", 127: "Bamalip",
+}
+
+# Languages in scope (the 4 that transliterate Latin mnemonics).
+LANGS = ["ru", "ar", "zh", "fa"]
+
+# Structural native words surrounding the mnemonic in each language.
+# Learned from the kept-Latin cells (e.g. RU pk106 "Силлогизм Barbara"): remove these and the
+# residue is the mnemonic token (Latin in kept cells, transliterated in the cells we convert).
+# Order matters for ZH (longest first so "式三段论" strips before "三段论").
+STRUCTURAL_TOKENS = {
+    "ru": ["Силлогизм"],
+    "ar": ["قياس", "المنطقي"],   # "قياس <M>" or "قياس <M> المنطقي"
+    "zh": ["式三段论", "三段论"],  # "<M>三段论" or "<M> 式三段论"
+    "fa": ["قیاس"],
+}
+
+# Regex: detect a Latin mnemonic as a standalone Latin word (case-sensitive — the canonical
+# forms are capitalised). Used to (a) extract M from title_fr, (b) detect kept-Latin cells to
+# skip, (c) verify the proposed title now carries M.
+#
+# We CANNOT use \b...\b here: under re.UNICODE (default for str), \w includes CJK/Arabic/Cyrillic
+# letters, so \b does NOT fire at the Latin→CJK boundary (e.g. "Festino三段论" — no \b between the
+# 'o' and '三'). We assert Latin-letter boundaries only: (?<![A-Za-z]) / (?![A-Za-z]). This still
+# matches "Festino" glued to CJK/Arabic/Cyrillic script, which is exactly what we want.
+_MNEMONIC_RE = re.compile(r"(?<![A-Za-z])(" + "|".join(MNEMONICS) + r")(?![A-Za-z])")
+
+# Latin-letter range (basic) to detect Latin leakage in a supposedly-transliterated residue.
+_LATIN_RE = re.compile(r"[A-Za-z]")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core logic
+# ─────────────────────────────────────────────────────────────────────────────
+
+def extract_mnemonic_latin(title_fr):
+    """Return the canonical Latin mnemonic present in title_fr, or None.
+
+    title_fr for mnemonic pks is always "Syllogisme <M>" (verified). We match <M> against the
+    19 known forms. Returns None if no mnemonic is present (e.g. a figure-row title).
+    """
+    if not title_fr:
+        return None
+    m = _MNEMONIC_RE.search(title_fr)
+    return m.group(1) if m else None
+
+
+def extract_translit_token(title_lang, lang):
+    """Extract the transliterated mnemonic token from a non-Latin title cell.
+
+    Strips the language's structural native words (STRUCTURAL_TOKENS[lang]) and surrounding
+    whitespace from title_lang. The residue is the mnemonic token — either Latin (kept) or
+    transliterated. Caller distinguishes via has_latin_mnemonic().
+
+    Returns (residue, ambiguous_flag):
+      - residue: the stripped string
+      - ambiguous_flag: True if the residue is empty OR contains a space (multi-token) OR
+        contains Latin letters (would mean we missed a structural word). Ambiguous cells are
+        excluded from the plan and surfaced for manual review.
+    """
+    if not title_lang:
+        return "", True  # missing cell — ambiguous (cannot convert safely)
+    s = title_lang
+    for tok in STRUCTURAL_TOKENS.get(lang, []):
+        s = s.replace(tok, "")
+    s = s.strip().strip("‏‎").strip()  # strip RTL/LTR marks + whitespace
+    ambiguous = False
+    if not s or " " in s:
+        ambiguous = True
+    if _LATIN_RE.search(s):
+        # Latin letters remain -> a structural word was not stripped -> unsafe.
+        ambiguous = True
+    return s, ambiguous
+
+
+def has_latin_mnemonic(cell):
+    """True if the cell already contains a Latin mnemonic (kept-Latin -> skip)."""
+    return bool(cell) and bool(_MNEMONIC_RE.search(cell))
+
+
+def build_conversion_plan(rows):
+    """Build the per-cell replacement plan for Option B (keep-Latin).
+
+    rows: list of dict (DictReader rows), keyed by column name incl. 'pk', 'title_fr',
+          'title_ru', ... 'title_fa'. Pass the full Virtues CSV rows.
+
+    Returns a list of OrderedDict entries:
+      {pk, lang, mnemonic, current_title, translit_token, proposed_title}
+    for every transliterated title cell (Option B reverts them to Latin). Ambiguous cells
+    are returned separately via the second return value (list of {pk, lang, current_title,
+    reason}) so the caller can surface them without blocking the clean plan.
+    """
+    plan = []
+    ambiguous = []
+    for r in rows:
+        try:
+            pk = int(r["pk"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        if pk not in MNEMONIC_PKS:
+            continue
+        M = extract_mnemonic_latin(r.get("title_fr", ""))
+        if M is None:
+            # title_fr has no mnemonic for this pk — skip (should not happen for MNEMONIC_PKS).
+            continue
+        for lang in LANGS:
+            cell = r.get(f"title_{lang}", "")
+            if has_latin_mnemonic(cell):
+                continue  # kept-Latin
+            if not cell.strip():
+                # blank cell — not a transliteration, out of scope (blank-fill is another lane)
+                continue
+            token, is_amb = extract_translit_token(cell, lang)
+            if is_amb:
+                ambiguous.append({
+                    "pk": pk, "lang": lang, "mnemonic": M,
+                    "current_title": cell, "residue": token,
+                    "reason": "empty/multi-token/Latin-leak" if token else "empty-residue",
+                })
+                continue
+            proposed = cell.replace(token, M)
+            # Safety: the replacement must actually change the cell and M must now be present.
+            if proposed == cell or not has_latin_mnemonic(proposed):
+                ambiguous.append({
+                    "pk": pk, "lang": lang, "mnemonic": M,
+                    "current_title": cell, "residue": token,
+                    "reason": "replace-noop-or-missing-after",
+                })
+                continue
+            plan.append(OrderedDict([
+                ("pk", pk), ("lang", lang), ("mnemonic", M),
+                ("current_title", cell), ("translit_token", token),
+                ("proposed_title", proposed),
+            ]))
+    return plan, ambiguous
+
+
+def render_report(plan, ambiguous, csv_path):
+    """Return a human-readable markdown report (string) of the dry-run plan."""
+    lines = []
+    lines.append(f"# #654 mnemonics → Latin (Option B / S2) — dry-run report\n")
+    lines.append(f"**Source CSV:** `{csv_path}`\n")
+    lines.append(f"**Decision:** keep-Latin (VERIFIED jsboige 2026-07-04, dispatch q9xpks).\n")
+    total = len(plan)
+    by_lang = {lang: sum(1 for e in plan if e["lang"] == lang) for lang in LANGS}
+    lines.append(f"**Cells to convert (title only): {total}** "
+                 f"(RU {by_lang['ru']} / AR {by_lang['ar']} / ZH {by_lang['zh']} / FA {by_lang['fa']})\n")
+    if ambiguous:
+        lines.append(f"\n> ⚠️ AMBIGUOUS cells excluded from the plan: {len(ambiguous)} (see bottom).\n")
+    lines.append("\n## Plan (before → after)\n")
+    for e in plan:
+        lines.append(
+            f"- **pk {e['pk']} [{e['lang']}]** `{e['mnemonic']}`: "
+            f"`{e['current_title']}` → `{e['proposed_title']}` "
+            f"(token `{e['translit_token']}` → `{e['mnemonic']}`)"
+        )
+    if ambiguous:
+        lines.append("\n## ⚠️ Ambiguous cells (excluded — manual review)\n")
+        for a in ambiguous:
+            lines.append(
+                f"- pk {a['pk']} [{a['lang']}] `{a['mnemonic']}`: "
+                f"`{a['current_title']}` (residue `{a['residue']}`, reason: {a['reason']})"
+            )
+    lines.append("\n## Out-of-scope flags\n")
+    lines.append("- **remark cells** also carry transliterated mnemonics (~14 cells; RU 4 / AR 4 "
+                 "/ ZH 2 / FA 4) — NOT in scope per dispatch (title only). Surfaced for jsboige "
+                 "to decide whether #654 extends to remark.\n")
+    return "\n".join(lines)
+
+
+def apply_plan(csv_path, plan):
+    """Apply the plan in place, modifying ONLY the title_<lang> field of each target row.
+
+    Strategy: parse the CSV with csv.reader (preserves column order), replace the transliterated
+    token ONLY inside the title_<lang> field (the description_*/remark_* fields of the same row
+    are left untouched — they are out of the title-only scope of dispatch q9xpks, even when they
+    also contain the transliterated mnemonic), then reserialise with QUOTE_MINIMAL + CRLF + BOM.
+
+    Round-trip fidelity: verified that QUOTE_MINIMAL + lineterminator='\\r\\n' reproduces the
+    original bytes byte-for-byte (modulo the BOM, which we re-prepend). So the diff between the
+    input and the written file is exactly the 52 swapped mnemonic tokens, nothing else.
+
+    Returns the count of fields modified.
+    """
+    import io
+    with open(csv_path, "rb") as f:
+        raw_bytes = f.read()
+    has_bom = raw_bytes.startswith(b"\xef\xbb\xbf")
+    # utf-8-sig strips the BOM when decoding (so we detected it at byte level above).
+    raw = raw_bytes.decode("utf-8-sig")
+
+    reader = csv.reader(io.StringIO(raw))
+    rows = list(reader)
+    if not rows:
+        return 0
+    header = rows[0]
+    col_idx = {name: i for i, name in enumerate(header)}
+
+    by_pk = {}
+    for e in plan:
+        by_pk.setdefault(e["pk"], []).append(e)
+
+    applied = 0
+    for row in rows[1:]:
+        try:
+            pk = int(row[col_idx["pk"]])
+        except (KeyError, IndexError, ValueError):
+            continue
+        if pk not in by_pk:
+            continue
+        for e in by_pk[pk]:
+            idx = col_idx[f"title_{e['lang']}"]
+            old = row[idx]
+            token = e["translit_token"]
+            if token not in old:
+                continue  # already converted / mismatch — skip, do not fail the run
+            new = old.replace(token, e["mnemonic"], 1)
+            if new != old:
+                row[idx] = new
+                applied += 1
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n")
+    writer.writerows(rows)
+    out_bytes = (b"\xef\xbb\xbf" if has_bom else b"") + buf.getvalue().encode("utf-8")
+
+    with open(csv_path, "wb") as f:
+        f.write(out_bytes)
+    return applied
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────────────
+
+DEFAULT_CSV = os.path.join("Cards", "Fallacies", "Argumentum Virtues - Taxonomy.csv")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Virtues syllogistic-mnemonic normaliser (#654, Option B keep-Latin).")
+    p.add_argument("--csv", default=DEFAULT_CSV, help="Path to the Virtues taxonomy CSV.")
+    p.add_argument("--dry-run", action="store_true", default=True,
+                   help="Default: build the plan and print it, write no file.")
+    p.add_argument("--apply", action="store_true",
+                   help="Write the CSV in place (line-by-line targeted replace). GATED post-tag.")
+    p.add_argument("--report", default=None,
+                   help="Optional path to write a markdown dry-run report.")
+    args = p.parse_args(argv)
+
+    if not os.path.exists(args.csv):
+        print(f"ERROR: CSV not found: {args.csv}", file=sys.stderr)
+        return 1
+
+    with open(args.csv, encoding="utf-8-sig", newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    plan, ambiguous = build_conversion_plan(rows)
+
+    by_lang = {lang: sum(1 for e in plan if e["lang"] == lang) for lang in LANGS}
+    print(f"#654 Option B (keep-Latin) plan: {len(plan)} title cells "
+          f"(RU {by_lang['ru']} / AR {by_lang['ar']} / ZH {by_lang['zh']} / FA {by_lang['fa']})")
+    if ambiguous:
+        print(f"⚠️ {len(ambiguous)} ambiguous cell(s) excluded — see below.", file=sys.stderr)
+
+    if args.report:
+        os.makedirs(os.path.dirname(os.path.abspath(args.report)), exist_ok=True)
+        with open(args.report, "w", encoding="utf-8") as f:
+            f.write(render_report(plan, ambiguous, args.csv))
+        print(f"Report written: {args.report}")
+
+    if args.apply:
+        if ambiguous:
+            print("REFUSED: --apply cannot run while ambiguous cells exist. Resolve them in "
+                  "STRUCTURAL_TOKENS / extract_translit_token first.", file=sys.stderr)
+            return 2
+        n = apply_plan(args.csv, plan)
+        print(f"Applied {n} replacement(s) to {args.csv}")
+        return 0
+
+    # dry-run: always print the plan summary (first 60 entries) for eyeballing
+    for e in plan[:60]:
+        print(f"  pk {e['pk']:>3} [{e['lang']}] {e['mnemonic']:<10} "
+              f"`{e['current_title']}` -> `{e['proposed_title']}`")
+    if len(plan) > 60:
+        print(f"  ... ({len(plan) - 60} more)")
+    for a in ambiguous:
+        print(f"  AMBIGUOUS pk {a['pk']} [{a['lang']}]: `{a['current_title']}` "
+              f"(residue `{a['residue']}`, {a['reason']})", file=sys.stderr)
+    return 2 if ambiguous else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_mnemonics_to_latin.py
+++ b/tools/test_mnemonics_to_latin.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Contract tests for mnemonics_to_latin.py (#654, Option B keep-Latin) — stdlib only.
+
+Run with plain `python`:
+
+    python tools/test_mnemonics_to_latin.py
+    python -m unittest tools.test_mnemonics_to_latin   # via repo root
+
+What it pins (the contract #654 Option B depends on):
+  1. extract_mnemonic_latin — the 19 canonical forms parse from title_fr; figure-rows give None.
+  2. has_latin_mnemonic — Latin mnemonic detection independent of \b (the CJK-boundary case:
+     "Festino三段论" MUST be detected, which \b...\b fails under re.UNICODE).
+  3. extract_translit_token — structural-word stripping per lang (RU/AR/ZH/FA), with the
+     ambiguity guards (empty residue, multi-token, Latin-leak).
+  4. build_conversion_plan — on a synthetic CSV that mirrors the real structure, produces the
+     expected plan and correctly classifies kept-Latin vs transliterated.
+  5. apply_plan — modifies ONLY title_<lang> (remark_*/description_* untouched), preserves
+     BOM + CRLF, and is idempotent (apply twice == apply once).
+  6. GROUNDING on the real Virtues CSV — the plan is exactly 52 title cells
+     (RU 14 / AR 16 / ZH 6 / FA 16) with 0 ambiguous, matching dispatch q9xpks. If the corpus
+     drifts, this test surfaces it before a worker re-runs the script.
+
+Exit code: 0 = all pass. The grounding test is skipped if the real CSV is absent (e.g. running
+in a checkout without Cards/).
+"""
+
+import io
+import os
+import sys
+import csv
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import mnemonics_to_latin as M  # noqa: E402
+
+REPO_ROOT = os.path.dirname(HERE)
+REAL_CSV = os.path.join(REPO_ROOT, "Cards", "Fallacies", "Argumentum Virtues - Taxonomy.csv")
+
+
+# ─── 1. extract_mnemonic_latin ───────────────────────────────────────────────
+
+class TestExtractMnemonicLatin(unittest.TestCase):
+    def test_all_19_canonical_forms_parse(self):
+        for m in M.MNEMONICS:
+            self.assertEqual(M.extract_mnemonic_latin(f"Syllogisme {m}"), m, f"title for {m}")
+
+    def test_pk_to_mnemonic_map_complete(self):
+        # Every mnemonic pk must map to a canonical form, and vice-versa.
+        self.assertEqual(len(M.MNEMONIC_PKS), 19)
+        for pk in M.MNEMONIC_PKS:
+            self.assertIn(pk, M._PK_TO_MNEMONIC)
+            self.assertIn(M._PK_TO_MNEMONIC[pk], M.MNEMONICS)
+
+    def test_figure_rows_return_none(self):
+        # pks 110/115/122 are the figure-rows ("Syllogisme de Nème figure") — no mnemonic.
+        self.assertIsNone(M.extract_mnemonic_latin("Syllogisme de deuxième figure"))
+        self.assertIsNone(M.extract_mnemonic_latin("Syllogisme de 3e figure"))
+        self.assertIsNone(M.extract_mnemonic_latin("Syllogisme de quatrième figure"))
+
+    def test_empty_and_none(self):
+        self.assertIsNone(M.extract_mnemonic_latin(""))
+        self.assertIsNone(M.extract_mnemonic_latin(None))
+
+    def test_case_sensitive(self):
+        # Canonical forms are capitalised; lowercase must NOT match (avoids false positives).
+        self.assertIsNone(M.extract_mnemonic_latin("syllogisme barbara minuscule"))
+
+
+# ─── 2. has_latin_mnemonic (the \b vs CJK-boundary contract) ──────────────────
+
+class TestHasLatinMnemonic(unittest.TestCase):
+    def test_latin_with_space(self):
+        self.assertTrue(M.has_latin_mnemonic("Силлогизм Camestres"))
+
+    def test_cjk_glued_boundary(self):
+        # THIS IS THE BUG THE FIX ADDRESSES: "Festino三段论" — \b fails (三 is \w under UNICODE),
+        # so the Latin-letter lookaround must catch it. If this regresses, ZH cells get
+        # spuriously flagged ambiguous and excluded from the plan.
+        self.assertTrue(M.has_latin_mnemonic("Festino三段论"))
+        self.assertTrue(M.has_latin_mnemonic("Bamalip式三段论"))
+
+    def test_pure_transliterated(self):
+        self.assertFalse(M.has_latin_mnemonic("Силлогизм Каместрес"))
+        self.assertFalse(M.has_latin_mnemonic("قياس داريي"))
+        self.assertFalse(M.has_latin_mnemonic("费斯蒂诺三段论"))
+
+    def test_substring_rejected(self):
+        # A mnemonic glued to another Latin letter is NOT a match (lookaround assertions on
+        # [A-Za-z] only). "Barbaracide" / "preBarbara" must not be detected as the mnemonic.
+        self.assertFalse(M._MNEMONIC_RE.search("Barbaracide"))
+        self.assertFalse(M._MNEMONIC_RE.search("preBarbara"))
+
+
+# ─── 3. extract_translit_token ───────────────────────────────────────────────
+
+class TestExtractTranslitToken(unittest.TestCase):
+    def test_ru(self):
+        tok, amb = M.extract_translit_token("Силлогизм Каместрес", "ru")
+        self.assertEqual(tok, "Каместрес")
+        self.assertFalse(amb)
+
+    def test_ar_with_suffix(self):
+        # AR kept-Latin cells have " المنطقي" suffix; the transliterated ones may too.
+        tok, amb = M.extract_translit_token("قياس كامستريس", "ar")
+        self.assertEqual(tok, "كامستريس")
+        self.assertFalse(amb)
+
+    def test_ar_strip_qualifier(self):
+        tok, amb = M.extract_translit_token("قياس كامستريس المنطقي", "ar")
+        self.assertEqual(tok, "كامستريس")
+        self.assertFalse(amb)
+
+    def test_zh_plain(self):
+        tok, amb = M.extract_translit_token("费斯蒂诺三段论", "zh")
+        self.assertEqual(tok, "费斯蒂诺")
+        self.assertFalse(amb)
+
+    def test_zh_shi_form(self):
+        tok, amb = M.extract_translit_token("弗雷西松式三段论", "zh")
+        self.assertEqual(tok, "弗雷西松")
+        self.assertFalse(amb)
+
+    def test_fa(self):
+        tok, amb = M.extract_translit_token("قیاس داریی", "fa")
+        self.assertEqual(tok, "داریی")
+        self.assertFalse(amb)
+
+    def test_ambiguous_empty(self):
+        tok, amb = M.extract_translit_token("", "ru")
+        self.assertTrue(amb)
+
+    def test_ambiguous_latin_leak(self):
+        # If a structural word fails to strip, Latin letters remain -> ambiguous (unsafe).
+        # Here we pass an AR cell but a made-up lang with no structural tokens known.
+        tok, amb = M.extract_translit_token("Силлогизм Каместрес", "fa")
+        # 'fa' has no 'Силлогизм' token -> residue still contains Cyrillic (not Latin) so the
+        # Latin-leak guard is fine, but the residue has a space -> ambiguous via multi-token.
+        self.assertTrue(amb)
+
+
+# ─── 4. build_conversion_plan (synthetic CSV) ────────────────────────────────
+
+def _row(pk, title_fr, title_ru="", title_ar="", title_zh="", title_fa="",
+         remark_ru="", description_ru=""):
+    """Build a CSV-shaped dict with the columns the planner reads."""
+    return {
+        "pk": str(pk), "title_fr": title_fr,
+        "title_ru": title_ru, "title_ar": title_ar,
+        "title_zh": title_zh, "title_fa": title_fa,
+        "remark_ru": remark_ru, "description_ru": description_ru,
+    }
+
+
+class TestBuildConversionPlan(unittest.TestCase):
+    def test_mixed_row_transliterated_and_kept(self):
+        rows = [
+            # pk 112: RU transliterated + AR transliterated + FA transliterated, EN kept (not in scope)
+            _row(112, "Syllogisme Camestres",
+                 title_ru="Силлогизм Каместрес",    # transliterated -> convert
+                 title_ar="قياس كامستريس",            # transliterated -> convert
+                 title_zh="Camestres 三段论",         # kept-Latin -> skip
+                 title_fa="قیاس کامسترس",             # transliterated -> convert
+                 remark_ru="see Каместрес in remark"),  # must NOT trigger a plan entry
+        ]
+        plan, ambig = M.build_conversion_plan(rows)
+        langs = sorted(e["lang"] for e in plan)
+        self.assertEqual(langs, ["ar", "fa", "ru"])  # zh skipped (kept-Latin)
+        self.assertEqual(ambig, [])
+        # proposed titles carry the Latin mnemonic
+        by_lang = {e["lang"]: e for e in plan}
+        self.assertEqual(by_lang["ru"]["proposed_title"], "Силлогизм Camestres")
+        self.assertEqual(by_lang["ar"]["proposed_title"], "قياس Camestres")
+        self.assertEqual(by_lang["fa"]["proposed_title"], "قیاس Camestres")
+        # remark_ru is NOT in the plan (title-only scope)
+        self.assertFalse(any("remark" in e["proposed_title"] for e in plan))
+
+    def test_kept_latin_all_skip(self):
+        rows = [_row(106, "Syllogisme Barbara",
+                     title_ru="Силлогизм Barbara", title_ar="قياس Barbara",
+                     title_zh="Barbara 三段论", title_fa="قیاس Barbara")]
+        plan, ambig = M.build_conversion_plan(rows)
+        self.assertEqual(plan, [])
+        self.assertEqual(ambig, [])
+
+    def test_figure_row_excluded(self):
+        rows = [_row(110, "Syllogisme de deuxième figure",
+                     title_ru="Силлогизм второй фигуры")]
+        plan, ambig = M.build_conversion_plan(rows)
+        self.assertEqual(plan, [])
+        self.assertEqual(ambig, [])
+
+    def test_zh_cjk_glued_not_flagged_ambiguous(self):
+        # Regression: "Festino三段论" must convert cleanly (was spuriously ambiguous pre-fix).
+        rows = [_row(113, "Syllogisme Festino", title_zh="费斯蒂诺三段论")]
+        plan, ambig = M.build_conversion_plan(rows)
+        self.assertEqual(len(plan), 1)
+        self.assertEqual(plan[0]["proposed_title"], "Festino三段论")
+        self.assertEqual(ambig, [])
+
+
+# ─── 5. apply_plan (CSV write contract) ──────────────────────────────────────
+
+class TestApplyPlan(unittest.TestCase):
+    def _write_csv(self, path, rows_dict):
+        fields = ["pk", "title_fr", "title_ru", "title_ar", "title_zh", "title_fa",
+                  "remark_ru", "description_ru"]
+        with open(path, "wb") as f:
+            f.write(b"\xef\xbb\xbf")  # BOM like the real file
+            buf = io.StringIO()
+            w = csv.writer(buf, quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n")
+            w.writerow(fields)
+            for r in rows_dict:
+                w.writerow([r.get(k, "") for k in fields])
+            f.write(buf.getvalue().encode("utf-8"))
+
+    def _read_csv(self, path):
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            return list(csv.DictReader(f))
+
+    def test_apply_modifies_title_only(self):
+        rows = [_row(112, "Syllogisme Camestres",
+                     title_ru="Силлогизм Каместрес",
+                     remark_ru="remark has Каместрес")]
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "virtues.csv")
+            self._write_csv(p, rows)
+            plan, ambig = M.build_conversion_plan(self._read_csv(p))
+            self.assertEqual(ambig, [])
+            self.assertEqual(len(plan), 1)
+            n = M.apply_plan(p, plan)
+            self.assertEqual(n, 1)
+            after = self._read_csv(p)
+            self.assertEqual(after[0]["title_ru"], "Силлогизм Camestres")
+            # remark_ru is UNCHANGED despite containing the transliterated token
+            self.assertEqual(after[0]["remark_ru"], "remark has Каместрес")
+
+    def test_apply_preserves_bom_and_crlf(self):
+        rows = [_row(112, "Syllogisme Camestres", title_ru="Силлогизм Каместрес")]
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "virtues.csv")
+            self._write_csv(p, rows)
+            plan, _ = M.build_conversion_plan(self._read_csv(p))
+            M.apply_plan(p, plan)
+            with open(p, "rb") as fh:
+                raw = fh.read()
+            self.assertTrue(raw.startswith(b"\xef\xbb\xbf"), "BOM must be preserved")
+            # every newline is CRLF
+            self.assertEqual(raw.replace(b"\r\n", b"").count(b"\n"), 0)
+
+    def test_apply_is_idempotent(self):
+        rows = [_row(112, "Syllogisme Camestres", title_ru="Силлогизм Каместрес",
+                     title_fa="قیاس کامسترس")]
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "virtues.csv")
+            self._write_csv(p, rows)
+            plan1, _ = M.build_conversion_plan(self._read_csv(p))
+            n1 = M.apply_plan(p, plan1)
+            plan2, _ = M.build_conversion_plan(self._read_csv(p))
+            n2 = M.apply_plan(p, plan2)
+            self.assertEqual(n1, 2)
+            self.assertEqual(n2, 0, "second apply must change nothing (already Latin)")
+
+
+# ─── 6. GROUNDING on the real Virtues CSV ────────────────────────────────────
+
+@unittest.skipUnless(os.path.exists(REAL_CSV),
+                     "real Virtues CSV not present (run from a full checkout)")
+class TestGroundingRealCSV(unittest.TestCase):
+    """The corpus contract: on master d90ce613 the plan is exactly 52 cells (RU 14 / AR 16 /
+    ZH 6 / FA 16) with 0 ambiguous. If this drifts, the corpus changed under us — investigate
+    BEFORE re-running --apply (the dispatch count is stale)."""
+
+    def test_plan_is_52_cells_0_ambiguous(self):
+        with open(REAL_CSV, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.DictReader(f))
+        plan, ambig = M.build_conversion_plan(rows)
+        by_lang = {lang: sum(1 for e in plan if e["lang"] == lang) for lang in M.LANGS}
+        self.assertEqual(len(plan), 52, f"plan size drifted: {len(plan)} (was 52)")
+        self.assertEqual(by_lang, {"ru": 14, "ar": 16, "zh": 6, "fa": 16},
+                         f"per-lang drift: {by_lang}")
+        self.assertEqual(ambig, [], f"ambiguous cells appeared: {ambig}")
+
+    def test_all_19_mnemonic_pks_present_in_corpus(self):
+        with open(REAL_CSV, encoding="utf-8-sig", newline="") as f:
+            rows = {int(r["pk"]): r for r in csv.DictReader(f)}
+        for pk in M.MNEMONIC_PKS:
+            self.assertIn(pk, rows, f"mnemonic pk {pk} missing from corpus")
+            self.assertIsNotNone(M.extract_mnemonic_latin(rows[pk]["title_fr"]),
+                                 f"pk {pk} title_fr lost its mnemonic")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## #654 — Virtues mnemonic→Latin conversion script (Option B keep-Latin, gated prep)

**Base:** `d90ce613` · **Decision:** Option B "keep-Latin" (Scenario S2) — **VERIFIED jsboige 2026-07-04** (dispatch `q9xpks`) · **Status: DEFER post-tag** — 0 prod CSV write.

### What this delivers

A deterministic Python tool that reverts the transliterated syllogistic mnemonics to canonical Latin for the 4 non-Latin languages (RU/AR/ZH/FA), so all 8 languages are consistent with FR/EN/ES/PT (which already keep the Latin technical term).

**This is NOT gpt-5.5.** It is a script-conversion of a fixed Latin technical term already present in `title_fr`. The transliteration per language is *detected in the current cell* (the language's own established rendering) and swapped for the canonical Latin form — never invented, never machine-transliterated.

| Deliverable | File |
|---|---|
| Conversion script (dry-run / `--apply` / `--report`) | `tools/mnemonics_to_latin.py` |
| Unit tests (26, stdlib `unittest`) | `tools/test_mnemonics_to_latin.py` |
| Tool doc | `tools/mnemonics_to_latin.md` |
| Dry-run report (52 cells before/after) | `docs/investigations/2026-07-05-654-mnemonics-dryrun.md` |

### Scope (code=truth on `d90ce613`)

| Field | Transliterated cells | In scope? |
|---|---|---|
| `title_<lang>` | **52** (RU 14 / AR 16 / ZH 6 / FA 16) | ✅ converted |
| `description_<lang>` | 0 (carry no mnemonic) | N/A |
| `remark_<lang>` | ~14 (RU 4 / AR 4 / ZH 2 / FA 4) | ⛔ title-only per dispatch — flagged for follow-up |

The 52-cell count matches dispatch `q9xpks` exactly. The doc inventory (#668, base `27442add`) said 53 — the small drift is base difference + title-only vs title+desc+remark method; the verified current count on `d90ce613` is **52**.

### Key design points (please review)

1. **`\b` → Latin-letter lookaround.** Latin-mnemonic detection uses `(?<![A-Za-z])…(?![A-Za-z])`, not `\b…\b`. Under `re.UNICODE`, `\w` includes CJK letters, so `\b` does **not** fire at the Latin→CJK boundary — `"Festino三段论"` would be missed and the 6 ZH cells spuriously flagged ambiguous. Regression pinned by `test_cjk_glued_boundary`.
2. **Translit extraction by structural-word stripping.** Per lang: `Силлогизм` / `قياس` / `المنطقي` / `三段论` / `式` / `قیاس` are removed; the residue is the mnemonic token. Ambiguous residue (empty / multi-token / Latin-leak) is excluded and surfaced for manual review — currently 0 ambiguous on the real CSV.
3. **`--apply` is title-only and byte-safe.** It parses with `csv.reader`, modifies **only** `title_<lang>` (verified: on pk 112, `remark_ru` still contains `Каместрес` after apply — out of scope), and reserialises with `QUOTE_MINIMAL` + CRLF + BOM. Round-trip is byte-identical except the 52 swapped tokens. Idempotent (apply twice == apply once). All 26 tests pass.

### GATED — no prod write

`#654` is **DEFER post-tag**. This PR ships the *tested script* + *dry-run report*; the `--apply` on the prod CSV waits for the tag. `--apply` was validated on a **copy** only (52 replacements, BOM/CRLF preserved, idempotent, title-only asserted). No `Cards/` file is modified by this PR.

### Follow-up flags (for jsboige, non-blocking)

- **~14 `remark_*` cells** also transliterate mnemonics (out of title-only scope). If #654 should cover remark too, it's a one-line scope change in the script.
- The conversion is reversible by symmetry (Latin → transliteration would need the inverse map, not currently built — not needed for Option B).

### Sources

- Inventory: `docs/investigations/2026-07-03-654-virtues-mnemonics-inventory.md` (#660)
- Cell table: `docs/investigations/2026-07-03-654-mnemonics-celltable.md` (#668)
- Issue #654 · dispatch `q9xpks`

Relates #654, #660, #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
