### PR TITLE
docs(test-count): reconcile stale 548/549 -> 578 (empirical dotnet test, dispatch q9xpks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,7 +448,7 @@ Chaque famille doit avoir sa classe CSS définie dans le template JSON. Liste co
 
 ### Test Coverage (July 2026)
 
-- **548 tests pass**, 5 skips (GUI/infrastructure), 1 known-fail (`OwlE2EGenerationValidationTests.LoadedOntology_RdfTypeAndInScheme_DroppedByOwl2XmlRoundTrip` — OWLSharp round-trip bug, pre-existing, tracked #133 — does not affect generated assets)
+- **578 tests pass** (`dotnet test` on `Argumentum.AssetConverter.Tests`, 2026-07-05, .NET 9 — 584 total: 578 pass / 1 fail / 5 skip), 5 skips (GUI/infrastructure), 1 known-fail (`OwlE2EGenerationValidationTests.LoadedOntology_RdfTypeAndInScheme_DroppedByOwl2XmlRoundTrip` — OWLSharp round-trip bug, pre-existing, tracked #133 — does not affect generated assets)
 - Coverage includes: CsvDiffEngine, SyncSafetyChecker, DiffReport, CsvToGrid, MindMapHtmlWrapper, FallaciesLocalizationTests, TaxonomyValidationTests, Memo_Back localization, Playwright visual tests
 - Build is zero-warning (CS compiler warnings + NuGet audit, #587)
 - Issue #212 tracks Playwright visual regression tests for generated PDFs

--- a/docs/RELEASE-NOTES-v0.9.0.md
+++ b/docs/RELEASE-NOTES-v0.9.0.md
@@ -42,7 +42,7 @@ Restauration complète du pipeline depuis l'état Golden Master (avril 2024, `00
 
 ### 🧪 Qualité
 
-- **548 tests** passent (5 skips GUI/infrastructure, 1 known-fail = OWLSharp `rdf:type`/`inScheme` round-trip pré-existant, tracké #133 — n'affecte pas les assets générés) — montée depuis 0 en avril 2024.
+- **578 tests** passent (5 skips GUI/infrastructure, 1 known-fail = OWLSharp `rdf:type`/`inScheme` round-trip pré-existant, tracké #133 — n'affecte pas les assets générés) — montée depuis 0 en avril 2024.
 - Build Debug + Release verts, GitGuardian clean.
 - Couverture tests : CsvDiffEngine, SyncSafetyChecker, PdfAssembly, MindMap, ClassMap matrix (Fallacies/Virtues/Scenarii), localisation.
 


### PR DESCRIPTION
## Reconcile stale test counts → empirical 578 (dispatch `q9xpks` TERTIAIRE)

Empirical `dotnet test` on `Argumentum.AssetConverter.Tests` (2026-07-05, .NET 9):

```
578 pass / 1 fail / 5 skip / 584 total (9s)
```

The single fail is the pre-existing OWLSharp round-trip bug (tracked #133 — does not affect generated assets).

### Three live docs reconciled

| File:line | Before | After |
|---|---|---|
| `CLAUDE.md:451` | `548 tests pass` | `578 tests pass` (584 total: 578/1/5) |
| `docs/RELEASE-NOTES-v0.9.0.md:45` | `548 tests` | `578 tests` |
| `docs/RELEASE-VALIDATION-v0.9.0.md:108` | `549 pass / 0 fail / 5 skip` | `578 pass / 1 fail / 5 skip` (dossier v4) |

`CHANGELOG.md` was already at 578 (PR #689). Archive docs carrying a "⚠️ Superseded" banner are intentionally left unchanged.

### Method (code=truth)

The count is an **empirical `dotnet test` run**, not copied from another doc — the workspace dashboard reported 570 and dossier v4 reported 549, both wrong. Leçon `test-counter-empirical-dotnet-test`: never re-use a count from a body/report.

### Follow-up

#686 (still open) adds 3 tests — when it merges, bump **578 → 581** in the three files above.

Dispatch `q9xpks` (TERTIAIRE doc-hygiène). Base `d90ce613`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
