### PR TITLE
docs(tools): #654 remark_* dry-run — extend mnemonics script + finding report (gated)

### DIFF
--- a/docs/investigations/2026-07-05-654-remark-dryrun.md
+++ b/docs/investigations/2026-07-05-654-remark-dryrun.md
@@ -1,0 +1,92 @@
+# #654 mnemonics → Latin — `remark_*` dry-run (extension of the title-only #695)
+
+**Source CSV:** `Cards/Fallacies/Argumentum Virtues - Taxonomy.csv` · **Base:** master `70bd1605`
+**Author:** po-2024 (worker) · **Date:** 2026-07-05
+**Dispatch:** `ka7vl5` (SECONDARY) · **Decision:** keep-Latin (VERIFIED jsboige 2026-07-04, dispatch q9xpks)
+**Status:** DRY-RUN ONLY — `--apply` stays gated post-tag (0 write under `Cards/`).
+
+Extends [`tools/mnemonics_to_latin.py`](../../tools/mnemonics_to_latin.py) (PR #695, merged) with a
+`--fields` flag so it can scan `remark_<lang>` in addition to `title_<lang>`. This report is the
+dry-run of `--fields remark`.
+
+## Headline finding — remark is NOT title-shaped (token-strip does not apply)
+
+**0 of 14 remark cells are auto-convertible by the title pipeline; all 14 are flagged ambiguous.**
+
+The title pipeline (`extract_translit_token`) works by stripping the language's structural native
+words (`Силлогизм` / `قياس` / `三段论` / `قیاس`) and recovering the mnemonic as an isolated residue.
+That works for titles because the title *is* just `<structural-word> <mnemonic>`. For remarks, the
+cell is a **full prose sentence** where the transliterated mnemonic is embedded mid-sentence
+(typically at the start, sometimes after a short lead like « Силлогизм в форме Дисамис »):
+
+- `remark_fr` always begins `<Mnemonic> relève de… / suit la forme…` (mnemonic at position 0).
+- `remark_<lang>` mirrors that, but the mnemonic is transliterated AND followed by native prose, so
+  the residue after structural-word stripping is multi-token → ambiguous guard correctly excludes it.
+
+**This is the correct signal**: a remark conversion is a **token substitution inside a sentence**,
+not an isolated-token swap. The deterministic title approach does not generalise to remark without a
+different extraction strategy (regex-find the transliterated mnemonic by matching it to the
+canonical Latin form known from `remark_fr`, then replace that substring).
+
+## Inventory (14 transliterated remark cells, code=truth on `70bd1605`)
+
+| pk | mnemonic | RU | AR | FA | ZH |
+|---:|---|:--:|:--:|:--:|:--:|
+| 116 | Darapti | ✗ | ✗ | ✗ | ✗ |
+| 117 | Felapton | ✗ | ✗ | ✗ | ✗ |
+| 118 | Disamis | ✗ | ✗ | ✗ | ✓ (kept-Latin) |
+| 119 | Datisi | ✗ | ✗ | ✗ | ✓ (kept-Latin) |
+
+**Totals**: 14 transliterated (RU 4 / AR 4 / FA 4 / ZH 2) + 2 ZH kept-Latin (pks 118, 119 — ZH
+already renders those two as Latin). The 14 are on pks **116-119 only** (the 3rd-figure Darapti /
+Felapton / Disamis / Datisi cluster); the other 15 mnemonic pks have no mnemonic in `remark_fr`
+(remark is a prose example, only these 4 modes spell the form out by name).
+
+## Options for jsboige (arbitration — not executed here)
+
+- **Option R1 — defer remark (reco).** The title scope (#695, 52 cells) is already delivered and
+  validated; the 14 remark cells are a *separate, smaller* surface with a different shape. Ship
+  v0.9.0 with title-only #654, treat remark as a post-tag follow-up. **Lowest risk.**
+- **Option R2 — extend the script with a remark-specific extractor.** Add a second code path: for
+  remark cells, regex-find the transliterated mnemonic by anchoring on the canonical form in
+  `remark_fr` (the sentence-initial token, or the token after a known lead phrase), and replace just
+  that substring with the Latin form. ~30 lines of code + tests on synthetic prose. Medium effort.
+- **Option R3 — manual edit.** 14 cells is small enough for a hand-edited CSV change reviewed by a
+  native reader (the prose context matters for naturalness). Heavier to review, but no script
+  fragility.
+
+The dry-run below is the evidence for whichever option jsboige picks.
+
+## Ambiguous cells (the 14, full content for manual review)
+
+> Residue shown is the post-strip remainder — for remarks it is the whole sentence minus any
+> structural word, hence multi-token. `reason: empty/multi-token/Latin-leak` = the ambiguity guard
+> firing on the multi-token prose residue (NOT a real data problem — the data is well-formed).
+
+- **pk 116 [ru] remark** `Darapti`: `Дарапти — силлогизм третьей фигуры, имеющий форму: все P есть M, все S есть M, следовательно, некоторые S есть P. Например: все врачи — профессионалы; все хирурги — врачи; следовательно, некоторые хирурги — профессионалы.`
+- **pk 116 [ar] remark** `Darapti`: `ينتمي دارابتي إلى الشكل الثالث: كل M هو P، وكل M هو S، إذن بعض S هو P. مثال: كل الأطباء مهنيون؛ كل الأطباء حاصلون على شهادات؛ إذن بعض الحاصلين على شهادات مهنيون.`
+- **pk 116 [zh] remark** `Darapti`: `达拉普蒂属于第三格：所有 M 都是 P，所有 M 都是 S，因此有些 S 是 P。例：所有医生都是专业人员；所有医生都有文凭；因此，有些有文凭者是专业人员。`
+- **pk 116 [fa] remark** `Darapti`: `داراپتی به شکل سوم تعلق دارد: همهٔ Mها P هستند، همهٔ Mها S هستند، پس برخی Sها P هستند. مثال: همهٔ پزشکان حرفه‌مندند؛ همهٔ پزشکان دانش‌آموخته‌اند؛ پس برخی دانش‌آموختگان حرفه‌مندند.`
+- **pk 117 [ru] remark** `Felapton`: `Фелаптон следует форме: ни один M не есть P, всякий M есть S, следовательно, некоторые S не есть P. Пример: ни одно животное не является духом; всякое животное является субстанцией; следовательно, некоторые субстанции не являются духами.`
+- **pk 117 [ar] remark** `Felapton`: `يتبع فيلابتون الصيغة الآتية: لا شيء من M هو P، وكل M هو S، إذن بعض S ليس P. مثال: لا شيء من الحيوان بروح؛ كل حيوان جوهر؛ إذن بعض الجواهر ليست أرواحًا.`
+- **pk 117 [zh] remark** `Felapton`: `费拉普顿遵循如下形式：没有 M 是 P，所有 M 都是 S，因此有些 S 不是 P。例：没有动物是精神；所有动物都是实体；因此，有些实体不是精神。`
+- **pk 117 [fa] remark** `Felapton`: `فلاپتون از این صورت پیروی می‌کند: هیچ Mای P نیست، هر Mای S است، پس برخی Sها P نیستند. مثال: هیچ جانوری روح نیست؛ هر جانوری جوهر است؛ پس برخی جوهرها روح نیستند.`
+- **pk 118 [ru] remark** `Disamis`: `Силлогизм в форме Дисамис состоит из высказывания следующего типа: некоторый M есть P, а всякий M есть S, следовательно, некоторый S есть P. …` *(mnemonic mid-sentence after « в формы »)*
+- **pk 118 [ar] remark** `Disamis`: `يتبع ديساميس الصيغة الآتية: بعض M هي P، وكل M هي S، إذن بعض S هي P. …`
+- **pk 118 [fa] remark** `Disamis`: `دیسامیس از این صورت پیروی می‌کند: برخی Mها P هستند؛ همهٔ Mها S هستند؛ پس برخی Sها P هستند. …`
+- **pk 119 [ru] remark** `Datisi`: `Силлогизм Датиси — это силлогизм особой формы Барбара, в котором большая посылка является O, меньшая — I, …` *(note: also embeds « Барбара » — pk 106's mnemonic — which R2 must NOT touch unless 106 is in scope)*
+- **pk 119 [ar] remark** `Datisi`: `يتبع داتيسي الصيغة الآتية: كل M هي P، وبعض M هي S، إذن بعض S هي P. …`
+- **pk 119 [fa] remark** `Datisi`: `داتیسی از این صورت پیروی می‌کند: همهٔ Mها P هستند؛ برخی Mها S هستند؛ پس برخی Sها P هستند. …`
+
+(ZH pks 118/119 are kept-Latin — `Disamis 遵循…` / `Datisi 遵循…` — so they are out of the conversion set.)
+
+## Reproducibility
+
+```bash
+python tools/mnemonics_to_latin.py --fields remark       # dry-run (this report)
+python tools/mnemonics_to_latin.py --fields title        # title-only (52 cells, #695 scope)
+python tools/mnemonics_to_latin.py --fields title,remark # both
+```
+
+Relates to #654, #695 (title-only script), dispatch `ka7vl5` SECONDARY. Base `70bd1605`. 0 write
+under `Cards/`, `--apply` gated post-tag.

--- a/tools/mnemonics_to_latin.py
+++ b/tools/mnemonics_to_latin.py
@@ -164,16 +164,18 @@ def has_latin_mnemonic(cell):
     return bool(cell) and bool(_MNEMONIC_RE.search(cell))
 
 
-def build_conversion_plan(rows):
+def build_conversion_plan(rows, fields=("title",)):
     """Build the per-cell replacement plan for Option B (keep-Latin).
 
     rows: list of dict (DictReader rows), keyed by column name incl. 'pk', 'title_fr',
           'title_ru', ... 'title_fa'. Pass the full Virtues CSV rows.
+    fields: tuple of field prefixes to scan (default title-only). Add 'remark' to also
+          scan remark_<lang> (the ~14 transliterated remark cells — separate scope, opt-in).
 
     Returns a list of OrderedDict entries:
-      {pk, lang, mnemonic, current_title, translit_token, proposed_title}
-    for every transliterated title cell (Option B reverts them to Latin). Ambiguous cells
-    are returned separately via the second return value (list of {pk, lang, current_title,
+      {pk, lang, field, mnemonic, current, translit_token, proposed}
+    for every transliterated cell (Option B reverts them to Latin). Ambiguous cells
+    are returned separately via the second return value (list of {pk, lang, field, current,
     reason}) so the caller can surface them without blocking the clean plan.
     """
     plan = []
@@ -185,39 +187,42 @@ def build_conversion_plan(rows):
             continue
         if pk not in MNEMONIC_PKS:
             continue
-        M = extract_mnemonic_latin(r.get("title_fr", ""))
-        if M is None:
-            # title_fr has no mnemonic for this pk — skip (should not happen for MNEMONIC_PKS).
-            continue
-        for lang in LANGS:
-            cell = r.get(f"title_{lang}", "")
-            if has_latin_mnemonic(cell):
-                continue  # kept-Latin
-            if not cell.strip():
-                # blank cell — not a transliteration, out of scope (blank-fill is another lane)
+        for field in fields:
+            # Canonical Latin mnemonic M is sourced from the FR counterpart of the SAME field.
+            # For `title` that is title_fr (always "Syllogisme <M>"); for `remark`, remark_fr.
+            M = extract_mnemonic_latin(r.get(f"{field}_fr", ""))
+            if M is None:
+                # FR counterpart has no mnemonic for this pk/field — nothing to convert.
                 continue
-            token, is_amb = extract_translit_token(cell, lang)
-            if is_amb:
-                ambiguous.append({
-                    "pk": pk, "lang": lang, "mnemonic": M,
-                    "current_title": cell, "residue": token,
-                    "reason": "empty/multi-token/Latin-leak" if token else "empty-residue",
-                })
-                continue
-            proposed = cell.replace(token, M)
-            # Safety: the replacement must actually change the cell and M must now be present.
-            if proposed == cell or not has_latin_mnemonic(proposed):
-                ambiguous.append({
-                    "pk": pk, "lang": lang, "mnemonic": M,
-                    "current_title": cell, "residue": token,
-                    "reason": "replace-noop-or-missing-after",
-                })
-                continue
-            plan.append(OrderedDict([
-                ("pk", pk), ("lang", lang), ("mnemonic", M),
-                ("current_title", cell), ("translit_token", token),
-                ("proposed_title", proposed),
-            ]))
+            for lang in LANGS:
+                cell = r.get(f"{field}_{lang}", "")
+                if has_latin_mnemonic(cell):
+                    continue  # kept-Latin
+                if not cell.strip():
+                    # blank cell — not a transliteration, out of scope (blank-fill is another lane)
+                    continue
+                token, is_amb = extract_translit_token(cell, lang)
+                if is_amb:
+                    ambiguous.append({
+                        "pk": pk, "lang": lang, "field": field, "mnemonic": M,
+                        "current": cell, "residue": token,
+                        "reason": "empty/multi-token/Latin-leak" if token else "empty-residue",
+                    })
+                    continue
+                proposed = cell.replace(token, M)
+                # Safety: the replacement must actually change the cell and M must now be present.
+                if proposed == cell or not has_latin_mnemonic(proposed):
+                    ambiguous.append({
+                        "pk": pk, "lang": lang, "field": field, "mnemonic": M,
+                        "current": cell, "residue": token,
+                        "reason": "replace-noop-or-missing-after",
+                    })
+                    continue
+                plan.append(OrderedDict([
+                    ("pk", pk), ("lang", lang), ("field", field), ("mnemonic", M),
+                    ("current", cell), ("translit_token", token),
+                    ("proposed", proposed),
+                ]))
     return plan, ambiguous
 
 
@@ -228,29 +233,27 @@ def render_report(plan, ambiguous, csv_path):
     lines.append(f"**Source CSV:** `{csv_path}`\n")
     lines.append(f"**Decision:** keep-Latin (VERIFIED jsboige 2026-07-04, dispatch q9xpks).\n")
     total = len(plan)
+    fields = sorted({e["field"] for e in plan} | {a["field"] for a in ambiguous}) or ["title"]
     by_lang = {lang: sum(1 for e in plan if e["lang"] == lang) for lang in LANGS}
-    lines.append(f"**Cells to convert (title only): {total}** "
-                 f"(RU {by_lang['ru']} / AR {by_lang['ar']} / ZH {by_lang['zh']} / FA {by_lang['fa']})\n")
+    lines.append(f"**Fields scanned:** {', '.join(fields)}\n")
+    lines.append(f"**Cells to convert: {total}** "
+                 f"(RU {by_lang.get('ru',0)} / AR {by_lang.get('ar',0)} / ZH {by_lang.get('zh',0)} / FA {by_lang.get('fa',0)})\n")
     if ambiguous:
         lines.append(f"\n> ⚠️ AMBIGUOUS cells excluded from the plan: {len(ambiguous)} (see bottom).\n")
     lines.append("\n## Plan (before → after)\n")
     for e in plan:
         lines.append(
-            f"- **pk {e['pk']} [{e['lang']}]** `{e['mnemonic']}`: "
-            f"`{e['current_title']}` → `{e['proposed_title']}` "
+            f"- **pk {e['pk']} [{e['lang']}] {e['field']}** `{e['mnemonic']}`: "
+            f"`{e['current']}` → `{e['proposed']}` "
             f"(token `{e['translit_token']}` → `{e['mnemonic']}`)"
         )
     if ambiguous:
         lines.append("\n## ⚠️ Ambiguous cells (excluded — manual review)\n")
         for a in ambiguous:
             lines.append(
-                f"- pk {a['pk']} [{a['lang']}] `{a['mnemonic']}`: "
-                f"`{a['current_title']}` (residue `{a['residue']}`, reason: {a['reason']})"
+                f"- pk {a['pk']} [{a['lang']}] {a['field']} `{a['mnemonic']}`: "
+                f"`{a['current']}` (residue `{a['residue']}`, reason: {a['reason']})"
             )
-    lines.append("\n## Out-of-scope flags\n")
-    lines.append("- **remark cells** also carry transliterated mnemonics (~14 cells; RU 4 / AR 4 "
-                 "/ ZH 2 / FA 4) — NOT in scope per dispatch (title only). Surfaced for jsboige "
-                 "to decide whether #654 extends to remark.\n")
     return "\n".join(lines)
 
 
@@ -295,7 +298,7 @@ def apply_plan(csv_path, plan):
         if pk not in by_pk:
             continue
         for e in by_pk[pk]:
-            idx = col_idx[f"title_{e['lang']}"]
+            idx = col_idx[f"{e['field']}_{e['lang']}"]
             old = row[idx]
             token = e["translit_token"]
             if token not in old:
@@ -331,20 +334,29 @@ def main(argv=None):
                    help="Write the CSV in place (line-by-line targeted replace). GATED post-tag.")
     p.add_argument("--report", default=None,
                    help="Optional path to write a markdown dry-run report.")
+    p.add_argument("--fields", default="title",
+                   help="Comma-separated field prefixes to scan (default 'title'). Add 'remark' "
+                        "to also scan remark_<lang> (~14 transliterated cells, separate scope).")
     args = p.parse_args(argv)
 
     if not os.path.exists(args.csv):
         print(f"ERROR: CSV not found: {args.csv}", file=sys.stderr)
         return 1
 
+    fields = tuple(f.strip() for f in args.fields.split(",") if f.strip())
+
     with open(args.csv, encoding="utf-8-sig", newline="") as f:
         rows = list(csv.DictReader(f))
 
-    plan, ambiguous = build_conversion_plan(rows)
+    plan, ambiguous = build_conversion_plan(rows, fields=fields)
 
-    by_lang = {lang: sum(1 for e in plan if e["lang"] == lang) for lang in LANGS}
-    print(f"#654 Option B (keep-Latin) plan: {len(plan)} title cells "
-          f"(RU {by_lang['ru']} / AR {by_lang['ar']} / ZH {by_lang['zh']} / FA {by_lang['fa']})")
+    by_field_lang = {}
+    for e in plan:
+        by_field_lang[(e["field"], e["lang"])] = by_field_lang.get((e["field"], e["lang"]), 0) + 1
+    print(f"#654 Option B (keep-Latin) plan [{','.join(fields)}]: {len(plan)} cells")
+    for field in fields:
+        fld = {lang: by_field_lang.get((field, lang), 0) for lang in LANGS}
+        print(f"  {field}: RU {fld['ru']} / AR {fld['ar']} / ZH {fld['zh']} / FA {fld['fa']}")
     if ambiguous:
         print(f"⚠️ {len(ambiguous)} ambiguous cell(s) excluded — see below.", file=sys.stderr)
 
@@ -365,12 +377,12 @@ def main(argv=None):
 
     # dry-run: always print the plan summary (first 60 entries) for eyeballing
     for e in plan[:60]:
-        print(f"  pk {e['pk']:>3} [{e['lang']}] {e['mnemonic']:<10} "
-              f"`{e['current_title']}` -> `{e['proposed_title']}`")
+        print(f"  pk {e['pk']:>3} [{e['lang']}] {e['field']:<7} {e['mnemonic']:<10} "
+              f"`{e['current']}` -> `{e['proposed']}`")
     if len(plan) > 60:
         print(f"  ... ({len(plan) - 60} more)")
     for a in ambiguous:
-        print(f"  AMBIGUOUS pk {a['pk']} [{a['lang']}]: `{a['current_title']}` "
+        print(f"  AMBIGUOUS pk {a['pk']} [{a['lang']}] {a['field']}: `{a['current']}` "
               f"(residue `{a['residue']}`, {a['reason']})", file=sys.stderr)
     return 2 if ambiguous else 0
 

--- a/tools/test_mnemonics_to_latin.py
+++ b/tools/test_mnemonics_to_latin.py
@@ -173,11 +173,11 @@ class TestBuildConversionPlan(unittest.TestCase):
         self.assertEqual(ambig, [])
         # proposed titles carry the Latin mnemonic
         by_lang = {e["lang"]: e for e in plan}
-        self.assertEqual(by_lang["ru"]["proposed_title"], "Силлогизм Camestres")
-        self.assertEqual(by_lang["ar"]["proposed_title"], "قياس Camestres")
-        self.assertEqual(by_lang["fa"]["proposed_title"], "قیاس Camestres")
-        # remark_ru is NOT in the plan (title-only scope)
-        self.assertFalse(any("remark" in e["proposed_title"] for e in plan))
+        self.assertEqual(by_lang["ru"]["proposed"], "Силлогизм Camestres")
+        self.assertEqual(by_lang["ar"]["proposed"], "قياس Camestres")
+        self.assertEqual(by_lang["fa"]["proposed"], "قیاس Camestres")
+        # remark_ru is NOT in the plan (title-only default scope)
+        self.assertFalse(any(e["field"] == "remark" for e in plan))
 
     def test_kept_latin_all_skip(self):
         rows = [_row(106, "Syllogisme Barbara",
@@ -199,8 +199,59 @@ class TestBuildConversionPlan(unittest.TestCase):
         rows = [_row(113, "Syllogisme Festino", title_zh="费斯蒂诺三段论")]
         plan, ambig = M.build_conversion_plan(rows)
         self.assertEqual(len(plan), 1)
-        self.assertEqual(plan[0]["proposed_title"], "Festino三段论")
+        self.assertEqual(plan[0]["proposed"], "Festino三段论")
         self.assertEqual(ambig, [])
+
+
+# ─── 4b. build_conversion_plan with fields=("remark",) — the #654 remark finding ──
+
+class TestBuildConversionPlanRemark(unittest.TestCase):
+    """The remark-scan contract (dispatch ka7vl5 SECONDARY). Remark cells are full prose
+    sentences where the transliterated mnemonic is embedded mid-sentence, so the title
+    pipeline's structural-word stripping yields a multi-token residue -> ambiguous. This is
+    the CORRECT signal: a remark conversion is a token substitution inside a sentence, not an
+    isolated-token swap, and is NOT auto-convertible by the title path. These tests lock that
+    finding so a future change does not silently start 'converting' remark cells unsafely."""
+
+    def test_remark_transliterated_mid_sentence_flagged_ambiguous(self):
+        # remark_<lang> mirrors remark_fr but with the mnemonic transliterated AND followed by
+        # native prose (real shape on master, cf. docs/investigations/2026-07-05-654-remark-dryrun.md).
+        rows = [{
+            "pk": "116", "title_fr": "Syllogisme Darapti", "title_ru": "",
+            "remark_fr": "Darapti relève de la troisième figure: …",
+            "remark_ru": "Дарапти — силлогизм третьей фигуры, ayant la forme: tous P est M, …",
+        }]
+        plan, ambig = M.build_conversion_plan(rows, fields=("remark",))
+        self.assertEqual(plan, [], "remark mid-sentence must NOT be auto-converted")
+        self.assertEqual(len(ambig), 1)
+        self.assertEqual(ambig[0]["field"], "remark")
+        self.assertEqual(ambig[0]["lang"], "ru")
+        self.assertEqual(ambig[0]["mnemonic"], "Darapti")
+
+    def test_remark_kept_latin_skipped(self):
+        # If remark_<lang> already carries the Latin mnemonic, it is skipped (kept-Latin), not
+        # flagged — same rule as title.
+        rows = [{
+            "pk": "118", "title_fr": "Syllogisme Disamis",
+            "remark_fr": "Disamis suit la forme: …",
+            "remark_zh": "Disamis 遵循如下形式：某些 M 是 P …",  # kept-Latin
+        }]
+        plan, ambig = M.build_conversion_plan(rows, fields=("remark",))
+        self.assertEqual(plan, [])
+        self.assertEqual(ambig, [])
+
+    def test_fields_title_remark_scans_both(self):
+        # With both fields, title entries land in the plan (clean) and remark entries in
+        # ambiguous — the title-only path is unaffected by the remark extension.
+        rows = [{
+            "pk": "116", "title_fr": "Syllogisme Darapti",
+            "title_ru": "Силлогизм Дарапти",          # transliterated title -> plan
+            "remark_fr": "Darapti relève de la troisième figure: …",
+            "remark_ru": "Дарапти — силлогisme troisième figure, …",  # mid-sentence -> ambiguous
+        }]
+        plan, ambig = M.build_conversion_plan(rows, fields=("title", "remark"))
+        self.assertTrue(any(e["field"] == "title" and e["lang"] == "ru" for e in plan))
+        self.assertTrue(any(a["field"] == "remark" and a["lang"] == "ru" for a in ambig))
 
 
 # ─── 5. apply_plan (CSV write contract) ──────────────────────────────────────


### PR DESCRIPTION
## #654 `remark_*` dry-run — extend mnemonics script + finding report (gated)

**Base:** `70bd1605` · **Dispatch:** `ka7vl5` (SECONDARY) · **Status: DRY-RUN ONLY** — `--apply` stays gated post-tag, 0 write under `Cards/`.

### What this adds

Extends [`tools/mnemonics_to_latin.py`](../../tools/mnemonics_to_latin.py) (PR #695, title-only, merged) with a `--fields` flag so it can also scan `remark_<lang>` (~14 transliterated cells). Backwards compatible: the title-only default still produces the **52-cell plan with 0 ambiguous** (grounding test passes).

| Change | Detail |
|---|---|
| `build_conversion_plan(rows, fields=("title",))` | new `fields` param; mnemonic `M` sourced from `<field>_fr`; plan entries carry field-agnostic keys (`current`/`proposed`, was `current_title`/`proposed_title`) |
| `render_report` | shows "Fields scanned" header + per-field/lang breakdown |
| `apply_plan` | column resolved as `<field>_<lang>` (was hardcoded `title_<lang>`) |
| `main()` | `--fields` arg (default `title`, comma-separated, add `remark`) |

### Headline finding — remark is NOT title-shaped

**0 of 14 remark cells are auto-convertible by the title pipeline; all 14 are flagged ambiguous.** This is the **correct signal**, not a bug: remark cells are full prose sentences where the transliterated mnemonic is embedded mid-sentence, so the title's structural-word stripping (`Силлогизм` / `قياس` / `三段论` / `قیاس`) yields a multi-token residue. A remark conversion is a **token substitution inside a sentence**, not an isolated-token swap — it needs a different extractor (regex on the sentence-initial mnemonic anchored to `remark_fr`) and is a **separate scope decision** for jsboige, not auto-convertible like title.

**Inventory (code=truth on `70bd1605`):** 14 transliterated (RU 4 / AR 4 / FA 4 / ZH 2) on pks **116-119 only** (the 3rd-figure Darapti/Felapton/Disamis/Datisi cluster); 2 ZH kept-Latin (pks 118/119). The other 15 mnemonic pks have no mnemonic in `remark_fr`.

### Options for jsboige (arbitration — not executed here)

- **R1 — defer remark (reco).** Title scope (#695, 52 cells) is delivered & validated; the 14 remark cells are a separate, smaller surface with a different shape. Ship v0.9.0 with title-only #654, treat remark as post-tag follow-up. **Lowest risk.**
- **R2 — remark-specific extractor.** Add a second code path: regex-find the transliterated mnemonic by anchoring on `remark_fr`, replace just that substring with Latin. ~30 LOC + tests on synthetic prose. Medium effort.
- **R3 — manual edit.** 14 cells is small enough for a hand-edited CSV change reviewed by a native reader (prose context matters for naturalness).

The dry-run report (`docs/investigations/2026-07-05-654-remark-dryrun.md`) is the evidence for whichever option jsboige picks — full content of the 14 cells included for manual review.

### Tests

`tools/test_mnemonics_to_latin.py` updated for the renamed keys + **3 new remark-contract tests**:
- remark mid-sentence → ambiguous (NOT auto-converted)
- remark kept-Latin → skipped (same rule as title)
- `fields=title,remark` scans both, title path unaffected

**29 tests pass** (26 + 3 new), grounding intact (52 cells / 0 ambiguous on real CSV).

### What this does NOT do

- ❌ No `--apply` (gated post-tag — 0 write under `Cards/`).
- ❌ No new conversion logic for remark (the finding is that title logic does NOT generalise; R2/R3 is jsboige's call).
- ❌ No change to the title-only #695 scope (backwards compatible).

### Reproducibility

```bash
python tools/mnemonics_to_latin.py --fields remark        # dry-run (this report, 14 ambiguous)
python tools/mnemonics_to_latin.py --fields title         # title-only (52 cells, #695 scope)
python tools/mnemonics_to_latin.py --fields title,remark  # both
python tools/test_mnemonics_to_latin.py                   # 29 tests
```

Relates to #654, #695 (title-only script). Dispatch `ka7vl5` SECONDARY. Base `70bd1605`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
