### PR TITLE
fix(build): replace obsolete WebClient with HttpClient (SYSLIB0014) — zéro-warning résiduel

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Tests/TranslationCoverageReport.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Tests/TranslationCoverageReport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,6 +19,11 @@ namespace Argumentum.AssetConverter.Tests
     /// </summary>
     public class TranslationCoverageReport
     {
+        // HttpClient is intended to be instantiated once and reused (SYSLIB0014: WebClient is
+        // obsolete since .NET 6 — sockets exhaustion + obsolescence). Static field = one instance
+        // for the lifetime of the report generator.
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         private readonly AssetConverterConfig _config;
         private readonly TranslationCoverageConfig _coverageConfig;
         private readonly Dictionary<string, Dictionary<string, Dictionary<string, double>>> _coverageData;
@@ -124,12 +130,9 @@ namespace Argumentum.AssetConverter.Tests
                 List<Fallacy> fallacies;
                 if (taxonomyFilePath.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Télécharger le fichier depuis l'URL
-                    using (var client = new System.Net.WebClient())
-                    {
-                        string csvContent = await client.DownloadStringTaskAsync(taxonomyFilePath);
-                        fallacies = ParseCsvContent(csvContent);
-                    }
+                    // Télécharger le fichier depuis l'URL (HttpClient remplace WebClient, obsolète SYSLIB0014)
+                    string csvContent = await _httpClient.GetStringAsync(taxonomyFilePath);
+                    fallacies = ParseCsvContent(csvContent);
                 }
                 else
                 {


### PR DESCRIPTION
## fix(build): replace obsolete `WebClient` with `HttpClient` (SYSLIB0014)

**Base:** `70bd1605` · **Dispatch:** `ka7vl5` (TERTIAIRE — zéro-warning résiduel lane) · **Scope:** non-Cards (release freeze is on `Cards/` only).

### The warning

`TranslationCoverageReport.LoadTaxonomyData` used `new System.Net.WebClient()` + `DownloadStringTaskAsync` to fetch the taxonomy CSV from an http URL. `WebClient` is obsolete since .NET 6 (**SYSLIB0014**: use `HttpClient`). This was the **only source-level CS warning** left in the converter project — the build is otherwise zero-warning (#587), but this one SYSLIB0014 had survived.

```
Tests/TranslationCoverageReport.cs(128,41): warning SYSLIB0014: 'WebClient.WebClient()' est obsolète.
```

### The fix

Static readonly `HttpClient` field (the recommended pattern — `HttpClient` is meant to be instantiated once and reused; per-use instantiation risks socket exhaustion under load) + `GetStringAsync`. The enclosing method is already `async Task<List<Fallacy>>`, so the swap is a **1:1 behavioral equivalent** (download a string from a URL, then `ParseCsvContent`).

```csharp
// before
using (var client = new System.Net.WebClient())
{
    string csvContent = await client.DownloadStringTaskAsync(taxonomyFilePath);
    fallacies = ParseCsvContent(csvContent);
}

// after
private static readonly HttpClient _httpClient = new HttpClient();
...
string csvContent = await _httpClient.GetStringAsync(taxonomyFilePath);
fallacies = ParseCsvContent(csvContent);
```

**Behavior: unchanged.** The http branch still downloads then parses; the local-file branch is untouched.

### Verification

- `dotnet build` → no SYSLIB0014 remains (grep on build output: empty).
- `dotnet test` → **578 pass / 1 fail (pre-existing OWL #133 known-fail, unrelated) / 5 skip / 584 total** — baseline preserved (leçon: empirical `dotnet test`, not a doc claim).

### Remaining warning (NOT fixed here — flagged)

```
MSB3073 + SGEN: "Failed to generate the serializer for Argumentum.AssetConverter.dll"
(from Microsoft.XmlSerializer.Generator)
```

This is a **build-time tooling warning** (sgen config / `XmlSerializer` generation), not a source-level CS warning, and fixing it is build-config territory (likely: review whether the `Microsoft.XmlSerializer.Generator` package is even needed, or fix the type that fails to serialize). Riskier during release freeze → deferred to a post-release tooling pass. Surfaced here so it's tracked.

### What this does NOT do

- ❌ No `Cards/` write (release freeze).
- ❌ No SGEN/MSB3073 fix (tooling, deferred).
- ❌ No behavior change (1:1 API swap in an async method).

Relates to #587 (zéro-warning), dispatch `ka7vl5` TERTIAIRE. Base `70bd1605`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
