### PR TITLE
test(tests): nullable-cleanup Slice A — CS0108 + CS0219 (6 warnings, dispatch x0ykyn)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Collections/EqualityComparerFactoryContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Collections/EqualityComparerFactoryContractTests.cs
@@ -51,8 +51,8 @@ namespace Argumentum.AssetConverter.Tests.Collections
         {
             public int GetHashCodeCalls;
             public int EqualsCalls;
-            public Func<Sample, int> GetHashCode { get; }
-            public Func<Sample, Sample, bool> Equals { get; }
+            public new Func<Sample, int> GetHashCode { get; }
+            public new Func<Sample, Sample, bool> Equals { get; }
 
             public TrackedDelegates()
             {

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfDisposeContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfDisposeContractTests.cs
@@ -64,7 +64,6 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
         public void HappyPath_CreateActionDispose_InOrder_ResourceDisposed()
         {
             var rec = new LifecycleRecorder();
-            var tracker = (DisposableTracker)null!; // captured via the factory's Created list
 
             PdfManager.WriteAndDispose(rec.Factory(7), rec.Action());
 


### PR DESCRIPTION
## Scope

Executes **Slice A** of the #710 nullable-cleanup plan (#726 drift, dispatch `x0ykyn` PRIMARY). Base `240511c8`. **Mechanical fixes only** — no nullable-flow annotation, no SUT change, no CsvHelper-mapped entity. Release freeze unaffected (Tests/ only, no `Cards/`).

### Fixes (3 distinct warnings, 6 raw with build-echo)
- **CS0108 ×2** (member hiding) — [EqualityComparerFactoryContractTests.cs:54-55](Generation/Converters/Argumentum.AssetConverter.Tests/Collections/EqualityComparerFactoryContractTests.cs#L54): `TrackedDelegates.GetHashCode`/`Equals` hide `object.GetHashCode()`/`Equals()`. Intentional (delegate-tracker, not a real comparer — confirmed by the class's instrumented-call-count design). Added `new` keyword.
- **CS0219 ×1** (dead store) — [PdfDisposeContractTests.cs:67](Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfDisposeContractTests.cs#L67): `var tracker = (DisposableTracker)null!;` assigned but never read (the test asserts on `rec.Created[0]`, not the local). Removed the dead declaration.

### DoD
| Check | Result |
|-------|--------|
| `dotnet build Tests.csproj --no-incremental` | ✅ CS0108 4→0, CS0219 2→0, total 98→**92** (−6), **0 errors** |
| Targeted files free of CS0108/CS0219 | ✅ (remaining CS86xx there = Slice C scope) |
| `dotnet test` green, no regression | ✅ **587 pass / 1 fail (#133 permanent) / 5 skip (#719)** — baseline preserved |

### Why Slice A first
#710 §2 sequences smallest-blast-radius first: CS0108 + CS0219 are pure-mechanical. `new` on an intentional hide + removing an unread local **cannot** change runtime behavior or CsvHelper mapping — the exact fragility CLAUDE.md/#710 §3 document is untouched (no nullable annotation on a test entity). Slices B (CS8618, 20) and C (CS86xx flow, ~68) follow in separate PRs, full re-test after each.

---

## Gate boundaries

- ❌ No `Cards/` write, no rendering code change, no nullable-flow annotation (Slice C scope).
- ✅ Tests/ only, mechanical fixes, full test-suite re-run green.
- ✅ Reproducible: `dotnet build Tests.csproj --no-incremental` shows CS0108/CS0219 → 0 on this branch.

Relates: dispatch `x0ykyn` (PRIMARY Slice A), #710 (the plan), #726 (the drift that re-triggered), #587 (converter zero-warning), #133 (the 1 known-fail), #719 (the 5 skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
