### PR TITLE
test(tests): nullable-cleanup Slice B — CS8618 constructor-init (#710, x0ykyn PRIMARY)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Collections/EqualityComparerFactoryContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Collections/EqualityComparerFactoryContractTests.cs
@@ -42,7 +42,7 @@ namespace Argumentum.AssetConverter.Tests.Collections
         /// </summary>
         private sealed class Sample
         {
-            public string Id { get; init; }
+            public string Id { get; init; } = null!;
         }
 
         // A real, observable getHashCode/equals pair keyed on Id. If the factory ever swaps the two

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/HtmlGeneration/ScribanGeneratorTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/HtmlGeneration/ScribanGeneratorTests.cs
@@ -8,8 +8,8 @@ namespace Argumentum.AssetConverter.Tests.HtmlGeneration
     public class FallacyRecord
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Description { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
         public bool IsActive { get; set; }
     }
 

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/CsvBaseStrictContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/CsvBaseStrictContractTests.cs
@@ -44,8 +44,8 @@ namespace Argumentum.AssetConverter.Tests.Parsing
         /// </summary>
         public class ContractEntity : CsvBase<ContractEntity, ContractEntityMap>
         {
-            public string Required { get; set; }
-            public string Optional { get; set; }
+            public string Required { get; set; } = null!;
+            public string Optional { get; set; } = null!;
         }
 
         public sealed class ContractEntityMap : ClassMap<ContractEntity>

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/CsvParserTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/CsvParserTests.cs
@@ -14,8 +14,8 @@ namespace Argumentum.AssetConverter.Tests.Parsing
         public class FallacyRecord
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public string Description { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public string Description { get; set; } = string.Empty;
         }
 
         // Dummy parser for testing purposes

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/InterpolateCacheTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/InterpolateCacheTests.cs
@@ -15,13 +15,13 @@ namespace Argumentum.AssetConverter.Tests.Parsing
     {
         private class TypeA
         {
-            public string Text { get; set; }
-            public string Family { get; set; }
+            public string Text { get; set; } = string.Empty;
+            public string Family { get; set; } = string.Empty;
         }
 
         private class TypeB
         {
-            public string Text { get; set; }
+            public string Text { get; set; } = string.Empty;
             public int Value { get; set; }
         }
 


### PR DESCRIPTION
## Slice B of #710 nullable-cleanup plan — CS8618 constructor-init warnings

Follows Slice A (#727, CS0108+CS0219). Executes dispatch `x0ykyn` PRIMARY.

### Scope — 10 distinct CS8618 warnings across 5 test-fixture files

All 10 are **synthetic test entities / SUT doubles** (not production domain entities like `Fallacy`/`Rule`). Per #710 §2, two fix idioms:

| Idiom | Applied to | Rationale |
|-------|-----------|-----------|
| `= string.Empty;` | Plain string props set by object initializer (FallacyRecord.Name/Description, TypeA.Text/Family, TypeB.Text) | The test only ever constructs these via `new Foo { Name = ... }`, so the initializer is never observed; `string.Empty` documents "filled by initializer" |
| `= null!;` | (a) `init`-only `Sample.Id`; (b) CsvBase-derived `ContractEntity.Required/Optional` | The #710 §2 test-fixture idiom: "logically required but set later by CsvHelper load" — suppression is honest because CsvHelper will overwrite |

### CSVHelper safety (the #710 §3 risk, CLAUDE.md fragility)

**NO type is changed to nullable.** Every fix keeps the property type as non-nullable `string` and only adds a default initializer. CsvHelper keys on the property **TYPE** + the ClassMap, not on C# default initializers, so mapping behavior (the missing-field vs null-field distinction) is **byte-identical**. Direct confirmation: the suites that exercise the real CsvHelper load path (`CsvBaseStrictContractTests`, `CsvParserTests`) both pass **unchanged** after the fix.

### Diff

```
EqualityComparerFactoryContractTests.cs:45  Sample.Id (init)              → = null!;
ScribanGeneratorTests.cs:11,12              FallacyRecord.Name/Description → = string.Empty;
CsvBaseStrictContractTests.cs:47,48         ContractEntity.Required/Optional → = null!;
CsvParserTests.cs:17,18                     FallacyRecord.Name/Description → = string.Empty;
InterpolateCacheTests.cs:18,19,24           TypeA.Text/Family + TypeB.Text → = string.Empty;
```

### DoD (measured)

- `dotnet build` Tests.csproj --no-incremental: **CS8618 20→0**. Total CS warnings **92→78 (−14)**. **0 errors.**
- `dotnet test`: **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression — the CsvHelper-mapping-risk suites (CsvBaseStrict, CsvParser, Interpolate, Scriban) all green.

### Cumulative

Slice A #727 + this Slice B: **98→78 warnings (−20)**. Slice C (CS86xx nullable-flow, ~68 remaining) follows in separate PRs with full re-test after each — that slice touches assertions/arrange with intentional null-passing and needs the most judgment.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 type changed to nullable (only default initializers added) → no CsvHelper semantics drift.

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
