### PR TITLE
test(tests): nullable-cleanup Slice C-1 — WebBasedGenerator arrange/assert null (#710, x0ykyn PRIMARY)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfAlternateFaceAndBackContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PdfAlternateFaceAndBackContractTests.cs
@@ -27,8 +27,13 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
     public class PdfAlternateFaceAndBackContractTests
     {
         // Helper: build a card list from (front, back) tuples; null/empty back = no back.
-        private static List<CardImages> Cards(params (string front, string back)[] specs)
-            => specs.Select(s => new CardImages { Front = s.front, Back = s.back }).ToList();
+        // `back` is nullable here because the contract tests deliberately pass null to exercise
+        // OrderImagesForAlternateFaceAndBack's IsNullOrEmpty guard (a Rules card has no back).
+        // The `s.back!` suppression at the CardImages.Back assignment acknowledges that the prod
+        // entity annotates Back as non-nullable, but prod tolerates a null Back at runtime via the
+        // guard — this is the intentional null-passing idiom #710 §2 flags for test arrange.
+        private static List<CardImages> Cards(params (string front, string? back)[] specs)
+            => specs.Select(s => new CardImages { Front = s.front, Back = s.back! }).ToList();
 
         // ─────────────────────────────────────────────────────────────────────────────
         // (1) Per-card emission — back-then-front when a back exists, front-only otherwise.

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/UpdateTableFromRecordsTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/UpdateTableFromRecordsTests.cs
@@ -23,7 +23,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 			table.Columns.Add(PrimaryKey, typeof(string));
 			table.Columns.Add("text_en", typeof(string));
 			table.Columns.Add("desc_en", typeof(string));
-			table.PrimaryKey = new[] { table.Columns[PrimaryKey] };
+			table.PrimaryKey = new[] { table.Columns[PrimaryKey]! };
 			foreach (var row in rows)
 			{
 				var dr = table.NewRow();
@@ -33,7 +33,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 			return table;
 		}
 
-		private static Dictionary<string, object> Record(string pk, string textEn = null, string descEn = null)
+		private static Dictionary<string, object> Record(string pk, string? textEn = null, string? descEn = null)
 		{
 			var dict = new Dictionary<string, object> { [PrimaryKey] = pk };
 			if (textEn != null) dict["text_en"] = textEn;
@@ -69,7 +69,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 			// Simulates the most common Bug 2 scenario: LLM returns PK as JSON number
 			// (e.g. 1 instead of "1"), Json.NET deserializes as double, DataTable column
 			// is string. Without coercion Rows.Find returns null silently.
-			var table = BuildTable(new object[] { "1", "old", null });
+			var table = BuildTable(new object[] { "1", "old", null! });
 			var tables = new Dictionary<string, DataTable> { [""] = table };
 			var records = new List<Dictionary<string, object>>
 			{
@@ -92,7 +92,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 		{
 			// addNewRows=false → record with unknown PK must be dropped, but a warning
 			// should be emitted (was silent before Bug 2 fix).
-			var table = BuildTable(new object[] { "1", "old", null });
+			var table = BuildTable(new object[] { "1", "old", null! });
 			var tables = new Dictionary<string, DataTable> { [""] = table };
 			var records = new List<Dictionary<string, object>>
 			{
@@ -115,7 +115,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 		[Fact]
 		public void UpdateTableFromRecords_WhenAddNewRowsTrue_CreatesRow()
 		{
-			var table = BuildTable(new object[] { "1", "old", null });
+			var table = BuildTable(new object[] { "1", "old", null! });
 			var tables = new Dictionary<string, DataTable> { [""] = table };
 			var records = new List<Dictionary<string, object>>
 			{
@@ -131,7 +131,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 				resultTables: tables);
 
 			table.Rows.Find("2").Should().NotBeNull();
-			table.Rows.Find("2")["text_en"].Should().Be("brand new");
+			table.Rows.Find("2")!["text_en"].Should().Be("brand new");
 		}
 
 		[Fact]
@@ -154,8 +154,8 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 
 			tables.Should().ContainKey("text_en");
 			tables.Should().ContainKey("desc_en");
-			tables["text_en"].Rows.Find("1")["text_en"].Should().Be("new title");
-			tables["desc_en"].Rows.Find("1")["desc_en"].Should().Be("new desc");
+			tables["text_en"].Rows.Find("1")!["text_en"].Should().Be("new title");
+			tables["desc_en"].Rows.Find("1")!["desc_en"].Should().Be("new desc");
 			// Original global table must remain untouched in per-field mode
 			table.Rows[0]["text_en"].Should().Be("old title");
 		}
@@ -165,7 +165,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 		{
 			// Per-field path used to throw NullReferenceException when Rows.Find returned
 			// null. It must now skip the field with a warning instead of crashing.
-			var table = BuildTable(new object[] { "1", "old", null });
+			var table = BuildTable(new object[] { "1", "old", null! });
 			var tables = new Dictionary<string, DataTable> { [""] = table };
 			var records = new List<Dictionary<string, object>>
 			{


### PR DESCRIPTION
## Slice C-1 of #710 nullable-cleanup — WebBasedGenerator arrange/assert null (CS86xx)

First sub-lot of **Slice C** (CS86xx nullable-flow), the riskiest slice per #710 §2 (it touches arrange/assert code with intentional null-passing). Follows Slice A (#727, CS0108+CS0219) and Slice B (#728, CS8618). Shipped in small, cohesive, per-area sub-lots with a full re-test after each.

### Scope — 13 distinct CS86xx across 2 files in `WebBasedGenerator/`

Both files are **test-only arrange/assert** null-handling. **Neither touches CsvHelper mapping or parsing code** — the CLAUDE.md missing/null-field fragility class is explicitly not in scope.

#### `UpdateTableFromRecordsTests.cs` (9) — `DataSetInfo.UpdateTableFromRecords` contract suite (DataTable round-trip, GSheetSync-adjacent; no CsvHelper)

| Line | Code | Fix | Rationale |
|------|------|-----|-----------|
| L26 | CS8619 | `table.Columns[PrimaryKey]!` | Column was just `Add()`'d on the prior line → indexer's nullable annotation is provably non-null |
| L36 | CS8625 | `Record(string pk, string? textEn = null, string? descEn = null)` | Body already null-checks both → `string?` is the honest param type |
| L72/95/118/168 | CS8625 | `new object[] { "1", "old", null! }` | The null is the desc cell value; DataTable stores as DBNull. Runtime-legal, annotation-strict |
| L134/157/158 | CS8602 | `Rows.Find("x")!["col"]` | Prior line asserts `.Should().NotBeNull()`; `!` acknowledges the assertion the compiler can't track |

#### `PdfAlternateFaceAndBackContractTests.cs` (4) — `PdfManager.OrderImagesForAlternateFaceAndBack` contract suite (recto-verso ordering, pure; no CSV)

All 4 are `Cards(("Fx", null))` passing null-back to exercise the prod `IsNullOrEmpty` guard ("Rules have no back"). **ONE helper-signature change fixes all four:**

```csharp
// before
private static List<CardImages> Cards(params (string front, string back)[] specs)
    => specs.Select(s => new CardImages { Front = s.front, Back = s.back }).ToList();
// after
private static List<CardImages> Cards(params (string front, string? back)[] specs)
    => specs.Select(s => new CardImages { Front = s.front, Back = s.back! }).ToList();
```

Making the tuple's `back` honestly nullable documents the test intent (deliberate null to exercise the guard); the single `s.back!` suppression at the `CardImages.Back` assignment acknowledges that the prod entity annotates `Back` non-nullable but tolerates a null Back at runtime via the guard. This is the intentional null-passing idiom #710 §2 calls out for test arrange — documented inline in the helper comment.

### DoD (measured on this branch, base master `240511c8`)

- `dotnet build` Tests.csproj --no-incremental: **the 2 target files emit 0 CS86xx (13→0)**. **0 errors.**
- `dotnet test`: **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression — `UpdateTableFromRecords` + `PdfAlternateFaceAndBack` suites all green.

### CsvHelper safety (#710 §3)

**NOT IN SCOPE.** Neither file is a CsvHelper-mapped entity or exercises the CSV load path. The mapping-risk suites (`CsvBaseStrictContractTests`, `CsvParserTests`) are untouched.

### Slice C remaining (~19 distinct CS86xx, subsequent sub-lots)

CsvGridConversion, MmGenerator (incl. the #715-introduced CS8603 at L281), SvgConversion×2, SvgDisambiguation, SvgPostProcessing, OwlE2E, FallacyLinkFallback×3, LoggerMarkup, UtilityExtensions, PKHierarchical, ImageFileGenerator×2, SimpleImageGenerator. These touch parsing/OWL/mindmap code paths and need closer per-line reading; follow with the same re-test-after-each discipline.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 CsvHelper-mapped type changed (only test-arrange null annotations).

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice C-1). Independent of #727/#728 (different files; this branch off master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
