### PR TITLE
test(tests): nullable-cleanup Slice C-2 — MmGenerator XDocument + #715 CS8603 (#710, x0ykyn)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MmGeneratorTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/MmGeneratorTests.cs
@@ -83,7 +83,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
 
                 var xmlDoc = XDocument.Parse(mmContent);
                 xmlDoc.Should().NotBeNull();
-                xmlDoc.Root.Name.LocalName.Should().Be("map");
+                xmlDoc.Root!.Name.LocalName.Should().Be("map");
 
                 // Validate root node (TitleFunc uses TitleExpression = "{item.TextFr}")
                 xmlDoc.Root.Element("node")?.Attribute("TEXT")?.Value.Should().Be("Sophismes");
@@ -135,7 +135,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
                 var xmlDoc = XDocument.Parse(mmContent);
                 xmlDoc.Root.Should().NotBeNull();
                 xmlDoc.Root.Element("node").Should().NotBeNull("La map doit contenir au moins un noeud racine.");
-                xmlDoc.Root.Element("node").Elements("node").Should().NotBeEmpty("La map doit contenir des noeuds enfants pour les données d'entrée.");
+                xmlDoc.Root!.Element("node")!.Elements("node").Should().NotBeEmpty("La map doit contenir des noeuds enfants pour les données d'entrée.");
             }
             finally
             {
@@ -173,7 +173,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
                 var xmlDoc = XDocument.Parse(mmContent);
                 xmlDoc.Root.Should().NotBeNull();
                 xmlDoc.Root.Element("node").Should().NotBeNull("the map should contain a root node.");
-                xmlDoc.Root.Element("node").Elements("node").Should().NotBeEmpty("the map should contain child nodes.");
+                xmlDoc.Root!.Element("node")!.Elements("node").Should().NotBeEmpty("the map should contain child nodes.");
 
                 // Verify specific virtue nodes exist
                 mmContent.Should().Contain("Argument pertinent");
@@ -270,7 +270,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
         /// Walks up from the test bin directory to locate the committed Virtues taxonomy CSV
         /// (<c>Cards/Fallacies/Argumentum Virtues - Taxonomy.csv</c>, at the repo root in every checkout).
         /// </summary>
-        private static string FindRepoVirtuesCsv()
+        private static string? FindRepoVirtuesCsv()
         {
             var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
             for (int i = 0; i < 12 && dir != null; i++, dir = dir.Parent)
@@ -299,7 +299,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
             var csvPath = FindRepoVirtuesCsv();
             csvPath.Should().NotBeNull("the committed Virtues taxonomy CSV must be locatable from the test bin dir");
 
-            var virtues = await LoadVirtuesFromPathAsync(csvPath);
+            var virtues = await LoadVirtuesFromPathAsync(csvPath!);
             virtues.Should().NotBeEmpty();
 
             // Apply the production MindMapLocalization for the target language (rewrites the FR-suffixed


### PR DESCRIPTION
## Slice C-2 of #710 nullable-cleanup — MmGenerator XDocument derefs + the #715 CS8603 (4 warnings)

Second sub-lot of **Slice C** (CS86xx nullable-flow). Follows Slice A (#727), Slice B (#728), Slice C-1 (#729).

### Closes the dispatch's explicit ask: "corrige le CS8603 de #715"

`MmGeneratorTests.cs:281` CS8603 is the **96→98 drift** documented in the #726 plan note — introduced by **#715** (commit `699580ab`, the #665 Virtue ar/fa/zh localization fix), which added a `FindRepoVirtuesCsv()` path-finder helper declared `string` (non-nullable) with a `return null;` fallback. This PR fixes all 4 CS86xx in that file, including the #715 one.

### Fixes (4 warnings, all low-risk)

| Line | Code | Fix | Rationale |
|------|------|-----|-----------|
| L86 | CS8602 | `xmlDoc.Root!.Name.LocalName` | `XDocument.Parse` of the test's well-formed `.mm` yields a non-null Root; `!` documents that invariant |
| L138 | CS8602 | `xmlDoc.Root!.Element("node")!.Elements("node")` | Both derefs guarded by the two `NotBeNull` asserts on the preceding lines (L136 Root, L137 node) |
| L176 | CS8602 | `xmlDoc.Root!.Element("node")!.Elements("node")` | Same pattern, guarded by L174+L175 asserts |
| L273/281 | CS8603 | `private static string? FindRepoVirtuesCsv()` | The #715 helper legitimately returns `null` when the Virtues CSV isn't found walking up from the bin dir → `string?` is the honest type. Sole caller (L299) asserts `csvPath.Should().NotBeNull(...)` on L300; `csvPath!` at L302 acknowledges that FluentAssertions guard |

### #715 CS8603 root cause (code=truth)

`git blame` L274-282 = `699580aba` (#715). The helper was added to locate the committed Virtues CSV for the new native-script ar/fa/zh test, declared `string` (non-null) with a `return null;` fallback — a classic CS8630-class mismatch the #710 sweep now catches.

### DoD (measured on this branch, base master `240511c8`)

- `dotnet build` Tests.csproj --no-incremental: **MmGeneratorTests emits 0 CS86xx (4→0)**. **0 errors.**
- `dotnet test --filter MmGeneratorTests`: **11/11 pass** (incl. the 3 ar/fa/zh InlineData #715 cases).
- `dotnet test` (full): **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression.

### CsvHelper safety (#710 §3)

**NOT IN SCOPE.** MmGeneratorTests exercises the mindmap-generation path (`.mm` XML via `XDocument`), not the CsvHelper CSV load path. The mapping-risk suites are untouched.

### Slice C remaining (~15 distinct CS86xx, subsequent sub-lots)

CsvGridConversion, SvgConversion×2, SvgDisambiguation, SvgPostProcessing, OwlE2E, FallacyLinkFallback×3, LoggerMarkup, UtilityExtensions, PKHierarchical, ImageFileGenerator×2, SimpleImageGenerator.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 CsvHelper-mapped type changed.

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice C-2). Independent of #727/#728/#729 (different files; this branch off master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
