### PR TITLE
test(tests): nullable-cleanup Slice C-3 — MindmapGeneration SVG cluster (#710, x0ykyn)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgConversionIntegrationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgConversionIntegrationTests.cs
@@ -57,7 +57,8 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
 
             // Act
             var method = typeof(FallacyMindMapDocumentConfig).GetMethod("TryAutomateSvgConversion", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(string), typeof(string), typeof(AssetConverterConfig), typeof(bool) }, null);
-            var result = (bool)method.Invoke(_generator, new object[] { mmPath, svgPath, _config, false });
+            Assert.NotNull(method);
+            var result = (bool)method!.Invoke(_generator, new object[] { mmPath, svgPath, _config, false })!;
 
             // Assert
             Assert.True(result, "L'exécution du processus de conversion SVG doit réussir.");

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgDisambiguationContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgDisambiguationContractTests.cs
@@ -34,7 +34,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
         private static readonly XNamespace Svg = "http://www.w3.org/2000/svg";
 
         // Minimal <g> with one <text> child — the shape CollectPossibleSvgNodes scans for.
-        private static XElement G(string text, string id = null)
+        private static XElement G(string text, string? id = null)
         {
             var g = new XElement(Svg + "g");
             if (id != null) g.SetAttributeValue("id", id);

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgPostProcessingTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/MindmapGeneration/SvgPostProcessingTests.cs
@@ -30,7 +30,7 @@ namespace Argumentum.AssetConverter.Tests.MindmapGeneration
             var processedSvgContent = FallacyMindMapDocumentConfig.GetSvgContent(processedSvgDocs.Values.First());
 
             // Assert
-            var snapshotDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "snapshots");
+            var snapshotDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "snapshots");
             var snapshotFile = Path.Combine(snapshotDirectory, "sample_fallacy_map.snapshot.svg");
             
             // Auto-generate snapshot if it doesn't exist (first run)


### PR DESCRIPTION
## Slice C-3 of #710 nullable-cleanup — MindmapGeneration SVG cluster (4 warnings)

Third sub-lot of **Slice C** (CS86xx nullable-flow). Follows Slice A (#727), B (#728), C-1 (#729), C-2 (#730).

### Scope — all 4 remaining CS86xx in the MindmapGeneration SVG cluster (3 files)

This cluster sits in CLAUDE.md **"Known Fragile Area #1 — SVG disambiguation"** territory, so each fix is the most conservative honest annotation, **not a logic change**.

| File | Line | Code | Fix | Rationale |
|------|------|------|-----|-----------|
| `SvgConversionIntegrationTests.cs` | L59-60 | CS8602 + CS8605 | `Assert.NotNull(method)` + `method!.Invoke(...)!` | `GetMethod`→`MethodInfo?`, `Invoke`→`object?`. Test is **`[Fact(Skip=...)]`** — the #719 Magick.NET skip, root-caused OBSOLETE by #722 (path replaced by FreeMind GUI + Batik). Skipped test never runs; annotation just satisfies the compiler. **No behavioral change** |
| `SvgDisambiguationContractTests.cs` | L37 | CS8625 | `G(string text, string? id = null)` | Body already null-checks (`if (id != null)`) before `SetAttributeValue` → `string?` is the honest type. Fixture callers pass null to build `<g>` without an id — intentional |
| `SvgPostProcessingTests.cs` | L33 | CS8604 | `Path.GetDirectoryName(...Location)!` | `GetDirectoryName` returns `string?`; in a running test the assembly location is non-null → `!` documents that invariant |

### DoD (measured on this branch, base master `240511c8`)

- `dotnet build` Tests.csproj --no-incremental: **the 3 target files emit 0 CS86xx (4→0)**. **0 errors.**
- `dotnet test --filter MindmapGeneration`: **85 pass / 1 skip** (the Magick test, expected). 0 regression.
- `dotnet test` (full): **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression.

### CsvHelper safety (#710 §3)

**NOT IN SCOPE.** None of these files is a CsvHelper-mapped entity or exercises the CSV load path. The mapping-risk suites are untouched.

### Slice C remaining (~11 distinct CS86xx, subsequent sub-lots)

CsvGridConversion, ImageFileGenerator×2, SimpleImageGenerator, OwlE2E, FallacyLinkFallback×3, LoggerMarkup, UtilityExtensions, PKHierarchical.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 CsvHelper-mapped type changed. 0 logic change in the SVG fragile area (annotation-only).

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice C-3). Independent of #727/#728/#729/#730 (different files; this branch off master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
