### PR TITLE
test(tests): nullable-cleanup Slice C-4 — ImageGeneration cluster (#710, x0ykyn)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/ImageGeneration/ImageFileGeneratorTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/ImageGeneration/ImageFileGeneratorTests.cs
@@ -62,7 +62,7 @@ namespace Argumentum.AssetConverter.Tests.ImageGeneration
         private void CreateFakeImageFile(AssetConverterConfig config, string language, string cardSetName, DocumentConfig docConfig, string imageName)
         {
             var fakeImagePath = ImageHelper.GetImageFileName(config, docConfig, language, cardSetName, imageName);
-            Directory.CreateDirectory(Path.GetDirectoryName(fakeImagePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(fakeImagePath)!);
             // Crée une image PNG valide de 1x1 pixel au lieu d'un fichier vide.
             using (var image = new MagickImage(MagickColors.Transparent, 1, 1))
             {
@@ -163,7 +163,7 @@ namespace Argumentum.AssetConverter.Tests.ImageGeneration
             harvestDictionary.TryAdd(("FailingSet", "en"), () => harvest);
             
             // Act
-            ConcurrentDictionary<(CardSetDocumentConfig document, string language), List<CardImages>> result = null;
+            ConcurrentDictionary<(CardSetDocumentConfig document, string language), List<CardImages>> result = null!;
             Action act = () => result = sut.GenerateDocumentImages(harvestDictionary);
 
             // Assert

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/ImageGeneration/SimpleImageGeneratorTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/ImageGeneration/SimpleImageGeneratorTests.cs
@@ -38,9 +38,10 @@ namespace Argumentum.AssetConverter.Tests.ImageGeneration
                 }
             };
             var config = JsonSerializer.Deserialize<AssetConverterConfig>(jsonString, options);
+            config.Should().NotBeNull("the committed Assets/SimpleImageGenerator/test-config.json must deserialize to an AssetConverterConfig");
             
             // Override the output dir to our test-specific one
-            config.BaseTargetDirectoryName = TestOutputDirectory;
+            config!.BaseTargetDirectoryName = TestOutputDirectory;
 
             return config;
         }


### PR DESCRIPTION
## Slice C-4 of #710 nullable-cleanup — ImageGeneration cluster (3 warnings)

Fourth sub-lot of **Slice C** (CS86xx nullable-flow). Follows Slice A (#727), B (#728), C-1 (#729), C-2 (#730), C-3 (#731).

### Scope — all 3 remaining CS86xx in `ImageGeneration/` (2 files)

None is a CsvHelper-mapped entity or exercises the CSV load path.

| File | Line | Code | Fix | Rationale |
|------|------|------|-----|-----------|
| `ImageFileGeneratorTests.cs` | L65 | CS8604 | `Path.GetDirectoryName(fakeImagePath)!` | `GetDirectoryName` returns `string?`; the fake-image path is built by `ImageHelper` from a known config → dir part is non-null. `!` documents that invariant |
| `ImageFileGeneratorTests.cs` | L166 | CS8600 | `result = null!` | Closure-capture pattern: declared null, assigned inside `Action act = () => result = sut.GenerateDocumentImages(...)`, then `result.Should().NotBeNull()` at L172 before use. `null!` is the honest initializer |
| `SimpleImageGeneratorTests.cs` | L40-43 | CS8602 | `config.Should().NotBeNull(...)` + `config!.BaseTargetDirectoryName` | `JsonSerializer.Deserialize` returns `AssetConverterConfig?`. FluentAssertions guard + `!` (committed test-config.json must deserialize). 0 residual CS8603 at `return config;` |

### DoD (measured on this branch, base master `240511c8`)

- `dotnet build` Tests.csproj --no-incremental: **the 2 target files emit 0 CS86xx (3→0)**. **0 errors.**
- `dotnet test --filter ImageGeneration`: **8/8 pass**. 0 regression.
- `dotnet test` (full): **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression.

### CsvHelper safety (#710 §3)

**NOT IN SCOPE.** Neither file is a CsvHelper-mapped entity or exercises the CSV load path.

### Slice C remaining (~8 distinct CS86xx, subsequent sub-lots)

CsvGridConversion, OwlE2E, FallacyLinkFallback×3, LoggerMarkup, UtilityExtensions, PKHierarchical.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 CsvHelper-mapped type changed.

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice C-4). Independent of #727/#728/#729/#730/#731 (different files; this branch off master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
