### PR TITLE
test(tests): nullable-cleanup Slice C-5 — FallacyLinkFallback SetLink null (#710, x0ykyn)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/FallacyLinkFallbackTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/FallacyLinkFallbackTests.cs
@@ -158,7 +158,7 @@ namespace Argumentum.AssetConverter.Tests.Parsing
         // Reflection helpers — let one Theory cover all 6 non-source languages uniformly.
         // ─────────────────────────────────────────────────────────────────────────────
 
-        private static void SetLink(Fallacy f, string propName, string value)
+        private static void SetLink(Fallacy f, string propName, string? value)
             => typeof(Fallacy).GetProperty(propName)!.SetValue(f, value);
 
         private static string GetFallback(Fallacy f, string propName)


### PR DESCRIPTION
## Slice C-5 of #710 nullable-cleanup — FallacyLinkFallback `SetLink` null (3 warnings)

Fifth sub-lot of **Slice C** (CS86xx nullable-flow). Follows Slice A (#727), B (#728), C-1 (#729), C-2 (#730), C-3 (#731), C-4 (#732).

### Single-signature fix — 3 CS8625 (L115/135/152) all from one helper

All three stem from `SetLink(f, linkProp, null)` where the helper was declared:
```csharp
private static void SetLink(Fallacy f, string propName, string value)
    => typeof(Fallacy).GetProperty(propName)!.SetValue(f, value);
```

The `null` is **intentional** — the FallacyLinkFallback suite deliberately clears a non-source language link to exercise the mind-map link fallback cascade (non-source null → EN → FR source-floor → null floor). `string? value` is the honest param type; the body `SetValue(f, value)` accepts `object` so null is runtime-legal.

This is the fragile-area link-fallback contract pinned by this suite (CLAUDE.md mind-map localization). The annotation **changes nothing about the cascade behavior** — only the declared parameter type. Direct confirmation: all **29 FallacyLinkFallback tests pass unchanged**.

### DoD (measured on this branch, base master `240511c8`)

- `dotnet build` Tests.csproj --no-incremental: **FallacyLinkFallback emits 0 CS86xx (3→0)**. **0 errors.**
- `dotnet test --filter FallacyLinkFallback`: **29/29 pass**.
- `dotnet test` (full): **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression.

### CsvHelper safety (#710 §3)

**NOT IN SCOPE.** FallacyLinkFallback exercises the link-fallback cascade via reflection on `Fallacy` entities, not the CsvHelper CSV load path.

### Slice C remaining (~5 distinct CS86xx, final lot)

5 singletons across 5 files: CsvGridConversion, OwlE2E, LoggerMarkup, UtilityExtensions, PKHierarchical — to be bundled into a final C-final lot.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 CsvHelper-mapped type changed. 0 cascade-logic change (annotation-only).

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice C-5). Independent of #727/#728/#729/#730/#731/#732 (different files; this branch off master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
