### PR TITLE
test(tests): nullable-cleanup Slice C-final — 5 singletons, Slice C complete (#710, x0ykyn)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/GSheetSync/CsvGridConversionContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/GSheetSync/CsvGridConversionContractTests.cs
@@ -173,7 +173,7 @@ namespace Argumentum.AssetConverter.Tests.GSheetSync
             // not as the literal text "null", and must not throw.
             var grid = new List<IList<object>>
             {
-                new List<object> { "a", null, "c" },
+                new List<object> { "a", null!, "c" },
             };
 
             var csv = Service.GridToCsv(grid);

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlE2EGenerationValidationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlE2EGenerationValidationTests.cs
@@ -57,7 +57,7 @@ namespace Argumentum.AssetConverter.Tests.Ontology
 
         private static OwlAdapter RealOntology => _realOntology.Value;
 
-        private static string ResolveRepoFile(string repoRelativePath)
+        private static string? ResolveRepoFile(string repoRelativePath)
         {
             var relative = repoRelativePath.Replace('/', Path.DirectorySeparatorChar);
             for (var d = AppContext.BaseDirectory; d != null; d = Path.GetDirectoryName(d))

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Utility/LoggerMarkupSafetyTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Utility/LoggerMarkupSafetyTests.cs
@@ -55,7 +55,7 @@ namespace Argumentum.AssetConverter.Tests.Utility
             // Exact shape emitted by HarvestManager's #614 resilience path.
             var message = "[HARVEST-FAILURE] Card set 'FallaciesTarot' / 'fr' failed and was skipped: boom";
 
-            string output = null;
+            string output = null!;
             var act = () => { output = CaptureConsole(() => Logger.Log(message, MessageType.Problem)); };
 
             act.Should().NotThrow("a bracketed failure marker must not be parsed as Spectre style markup (#630)");

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Utility/UtilityExtensionsLayoutTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Utility/UtilityExtensionsLayoutTests.cs
@@ -139,7 +139,7 @@ namespace Argumentum.AssetConverter.Tests.Utility
             // The implementation guards with IsNullOrWhiteSpace and returns false before parsing.
             // Pinned separately (null is not a valid Theory string argument) so the null path is
             // still covered — a regression that removed the null guard would NullReferenceException.
-            ((string)null).PathIsUrl().Should().BeFalse("null path must not be treated as a URL");
+            ((string)null!).PathIsUrl().Should().BeFalse("null path must not be treated as a URL");
         }
 
         [Fact]

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PKHierarchicalGroupingTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/PKHierarchicalGroupingTests.cs
@@ -23,7 +23,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 
         private static HashSet<string> CoveredPks(List<List<Dictionary<string, object>>> groups) =>
             groups.SelectMany(group => group)
-                .Select(record => record["path"].ToString())
+                .Select(record => record["path"].ToString()!)
                 .ToHashSet();
 
         [Fact]


### PR DESCRIPTION
## Slice C-final of #710 nullable-cleanup — 5 singletons, Slice C complete

Final sub-lot of **Slice C** (CS86xx nullable-flow). Follows Slice A (#727), B (#728), C-1 (#729), C-2 (#730), C-3 (#731), C-4 (#732), C-5 (#733).

### This PR completes Slice C

All 32 distinct CS86xx in `Tests/` are addressed across the 7 sub-lots C-1..C-final. Once all 8 slice PRs (#727-733 + this) are merged, `Tests/` goes from **98 raw (49 distinct) CS warnings → 0**. The `#715` drift (CS8603, 96→98, documented in #726) is closed at C-2.

### The 5 singletons (one per file, 5 different areas)

| File | Line | Code | Fix | Rationale |
|------|------|------|-----|-----------|
| `CsvGridConversionContractTests.cs` | L176 | CS8625 | `new List<object> { "a", null!, "c" }` | Null cell is **intentional** (test "GridToCsv_NullCells_BecomeEmptyStrings", pins the `cell?.ToString() ?? ""` guard). Honest suppression |
| `OwlE2EGenerationValidationTests.cs` | L60 | CS8603 | `private static string? ResolveRepoFile(...)` | Path-finder legitimately returns null when ontology file not found (same idiom as #715). Sole caller null-checks + throws at L48-54 |
| `LoggerMarkupSafetyTests.cs` | L58 | CS8600 | `string output = null!;` | Closure-capture pattern (assigned in lambda L59, asserted L62). Honest initializer |
| `UtilityExtensionsLayoutTests.cs` | L142 | CS8600 | `((string)null!).PathIsUrl()` | Null is **intentional** (test "PathIsUrl_Returns_False_For_Null", pins the null-guard). `null!` documents intent |
| `PKHierarchicalGroupingTests.cs` | L25 | CS8619 | `.Select(record => record["path"].ToString()!)` | Path key always set by `BuildRecords`; ToString on boxed string is non-null. `!` for `ToHashSet<string>()` |

### DoD (measured on this branch, base master `240511c8`)

- `dotnet build` Tests.csproj --no-incremental: **the 5 target files emit 0 CS86xx (5→0)**. **0 errors.**
- `dotnet test` (targeted GSheetSync+Ontology+Utility+PKHierarchical): **52 pass / 1 fail** (OWL #133 permanent known-fail, pre-existing — **not a regression**; the 3 OTHER OwlE2E tests pass).
- `dotnet test` (full): **587 pass / 1 fail (OWL #133) / 5 skip (#719)**. 0 regression.

### CsvHelper safety (#710 §3)

**NOT IN SCOPE.** None of these 5 files is a CsvHelper-mapped entity or exercises the CSV load path (GSheet grid round-trip, OWL ontology load via OwlAdapter, Logger markup, path utility, PK grouping reflection).

### #710 plan status (once all 8 slice PRs merged)

| Slice | PR | Codes | Count |
|-------|-----|-------|-------|
| A | #727 | CS0108 + CS0219 | 6 raw |
| B | #728 | CS8618 | 20 raw (10 distinct) |
| C-1 | #729 | CS86xx (WebBasedGenerator) | 13 |
| C-2 | #730 | CS86xx (MmGenerator) + **#715 drift** | 4 |
| C-3 | #731 | CS86xx (MindmapGeneration SVG) | 4 |
| C-4 | #732 | CS86xx (ImageGeneration) | 3 |
| C-5 | #733 | CS86xx (FallacyLinkFallback) | 3 |
| **C-final** | **this** | CS86xx (5 singletons) | 5 |
| | | **Total** | **98 raw → 0** |

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 CsvHelper-mapped type changed.

Base `240511c8`. Dispatch `x0ykyn` PRIMARY (Slice C-final — **Slice C complete**). Independent of #727/#728/#729/#730/#731/#732/#733 (different files; this branch off master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
