### PR TITLE
test(tests): warning-zero follow-on #710 — clear 3 xUnit analyzer warnings (5czj9v [2])

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlAdapterRegressionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlAdapterRegressionTests.cs
@@ -303,7 +303,7 @@ namespace Argumentum.AssetConverter.Tests.Ontology
         }
 
         [Fact]
-        public void ToFileAsync_Writes_A_Non_Empty_OWL2XML_File()
+        public async Task ToFileAsync_Writes_A_Non_Empty_OWL2XML_File()
         {
             // Serialization works end-to-end (this is why #133 ships a non-empty ontology despite
             // the readers being broken — the graph is correctly built, only self-retrieval fails).
@@ -316,7 +316,7 @@ namespace Argumentum.AssetConverter.Tests.Ontology
             var tempPath = Path.Combine(Path.GetTempPath(), $"arg_onto_test_{Guid.NewGuid():N}.owl");
             try
             {
-                adapter.ToFileAsync(OWLSharp.OWLEnums.OWLFormats.OWL2XML, tempPath).Wait();
+                await adapter.ToFileAsync(OWLSharp.OWLEnums.OWLFormats.OWL2XML, tempPath);
                 File.Exists(tempPath).Should().BeTrue();
                 var content = File.ReadAllText(tempPath);
                 content.Should().NotBeNullOrEmpty("the serialized ontology must be non-empty");

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/HarvestManagerExpectedImageCountTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/HarvestManagerExpectedImageCountTests.cs
@@ -54,7 +54,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
         [InlineData(10, 3, "BUNCH", 10)]  // case-sensitive: CardPen rsstyle is lowercase; "BUNCH" does NOT group
         [InlineData(10, 3, "Bunch", 10)]  // case-sensitive: mixed-case does NOT group either
         public void ComputeExpectedImageCount_MirrorsCardPenGrouping(
-            int cardCount, int rscount, string rsstyle, int expected)
+            int cardCount, int rscount, string? rsstyle, int expected)
         {
             HarvestManager.ComputeExpectedImageCount(cardCount, rscount, rsstyle)
                 .Should().Be(expected,

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/LocalizedFileNameContractTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/LocalizedFileNameContractTests.cs
@@ -27,7 +27,7 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void EmptyOrNull_ReturnedAsIs(string fileName)
+        public void EmptyOrNull_ReturnedAsIs(string? fileName)
         {
             // The first guard returns the input verbatim, so no language substitution is attempted.
             CardSetLocalization.GetLocalizedFileName(fileName, "fr", "en")


### PR DESCRIPTION
## Tests/ warning-zero follow-on #710 — clear 3 xUnit analyzer warnings

Follow-on to the #710 nullable-cleanup (plan complete via 8 PR #727-#734 merged). Dispatch `5czj9v` **[2] SECONDAIRE**. Clears the 3 residual xUnit-analyzer warnings in `Tests/` (the nullable family hit 0 in #710; these are the remaining non-CS analyzer warnings).

### Fixes (3 distinct, all additive annotation or async — no logic change)

| File | Line | Code | Fix | Rationale |
|------|------|------|-----|-----------|
| `HarvestManagerExpectedImageCountTests.cs` | L56 | xUnit1012 | `string rsstyle` → `string? rsstyle` | Theory has `[InlineData(10,3,null,10)]` (L52) deliberately passing null rsstyle to pin the "null rsstyle = no grouping" branch of `ComputeExpectedImageCount`. Intentional null test input |
| `LocalizedFileNameContractTests.cs` | L30 | xUnit1012 | `string fileName` → `string? fileName` | Theory has `[InlineData(null)]` (L28) pinning the `GetLocalizedFileName` guard clause (null returned as-is). Same intentional-null idiom |
| `OwlAdapterRegressionTests.cs` | L306+L319 | xUnit1031 | `public void` → `public async Task` + `.Wait()` → `await` | xUnit1031 flags blocking `Task.Wait()` in test methods; canonical fix is async/await. Tests OWL2XML serialization to temp file (no sync-context → no deadlock risk either way). Test name unchanged |

### DoD (measured on this branch, base master `9ed2e789`)

- `dotnet build` Tests.csproj --no-incremental: **xUnit warnings 3→0**. **0 errors.**
- `dotnet test --filter` (HarvestManagerExpected|LocalizedFileName|OwlAdapterRegression): **41/41 pass**.
- `dotnet test` (full): **587 pass / 1 fail (OWL #133 permanent) / 5 skip (#719)**. 0 regression.

### Residual — irréductible-infra, **hors-scope Tests/ DoD**

**MSB3073 ×1 distinct on the MAIN project** (`Argumentum.AssetConverter.csproj`, NOT Tests): the `Microsoft.XmlSerializer.Generator` PackageReference (L25) `sgen` target exits code 1 at build. This is a **main-project build-infra** warning, not a Tests/ code warning — it appears in the Tests build log only via the Tests→main project dependency.

The DoD scope is "`dotnet build` Tests → 0 warning (ou irréductible documenté)". Suppressing MSB3073 would require touching the main csproj:
- **Out of scope** for this tests-only lane (main project is zero-CS-warning stable per #587).
- The SGEN package may be load-bearing for `ExtendedXmlSerializer` — disabling it blindly risks a runtime regression.
- **Follow-up**: separate main-project investigation to decide suppress (`<XmlSerializerGenerator...>` off) vs document as irréductible-infra. Not bundled here.

### Non-goals

- 0 write under `Cards/`. 0 production / card-rendering code changed. Tests-only.
- 0 main-project csproj change (MSB3073 follow-up is a separate investigation).

Base `9ed2e789`. Dispatch `5czj9v` [2] SECONDAIRE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude-Code <noreply@anthropic.com>
