### PR TITLE
fix(build): remove dysfonctional Microsoft.XmlSerializer.Generator — main project 0-warning (#710)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
+++ b/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.14.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.43.0" />
-    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OWLSharp" Version="4.23.0" />
     <PackageReference Include="OWLSharp.Extensions" Version="4.22.0" />


### PR DESCRIPTION
## What

Removes the dysfonctional `Microsoft.XmlSerializer.Generator` 8.0.0 NuGet package from the main project → **main project build goes from 2 warnings to 0**. Dispatch `3i1ie4` [SECONDAIRE] SGEN/XmlSerializer.

## Diagnosis

The main project emitted 2 `MSB3073`/SGEN warnings on every build:

```
dotnet Microsoft.XmlSerializer.Generator "...Argumentum.AssetConverter.dll" --force --quiet "...sgen.rsp"
La version du package 'Microsoft.XmlSerializer.Generator' n'a pas pu être résolue.
```

`Microsoft.XmlSerializer.Generator` is a **build-time pre-generator** for `System.Xml.Serialization.XmlSerializer`. It needs an `IXmlSerializerDescriptor` configuration to know which types to pre-generate. Grep across the project finds **zero** such descriptor (`XmlSerializerDescriptor` / `[XmlSerializer]` / `IXmlSerializerDescriptor` → 0 matches). The package's build target then tries to invoke itself as a `dotnet tool` and fails to resolve the package version → non-zero exit → `MSB3073`. **The package was already a silent no-op** (no pre-gen assembly produced) while spamming 2 warnings.

The 4 runtime call sites work by reflection without any pre-gen, independent of this package:
- `new XmlSerializer(typeof(FreemindMap))` × 3 (VirtueMindMapDocumentConfig.cs:519, MindMapDocumentConfig.cs:434, FallacyMindMapDocumentConfig.cs:1083)
- `new XmlSerializer(typeof(SexyContentData), new[]{ typeof(Entity) })` (Dnn2sxcConfig.cs:139)

## Fix

Drop the `PackageReference`. `<GenerateSerializationAssemblies>Off</...>` (L.11) stays as the guard that also disables classic .NET SGEN. The package was added in `6edf683c` (MindMap Virtues/Fallacies refactor) — a likely startup-perf attempt that was never wired (no descriptor), so it never worked.

## Validation (empirical)

- `dotnet build` main project: **0 warning / 0 error** (was 2 warnings).
- `dotnet test Argumentum.AssetConverter.Tests`: **587 pass / 1 fail (#133 OWL known-fail) / 5 skip / 593** — baseline intact, 0 regression.

## Discipline

- 0 write `Cards/`, 0 regen, 0 CSV/DB/OWL. Main csproj only (1-line deletion).
- Test counter = empirical `dotnet test`, not a reported figure.
- Net positive: build réellement 0-warning on the main project, tech debt removed (a package that resolved nothing and generated nothing).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
