### PR TITLE
docs(release): #134 refresh v5 dossier validation — colonnes AIF relationnelles #753/#754/#755 + master 81a9e4e6

### DIFF
--- a/docs/RELEASE-VALIDATION-v0.9.0.md
+++ b/docs/RELEASE-VALIDATION-v0.9.0.md
@@ -1,9 +1,11 @@
 # Argumentum v0.9.0 — Dossier de validation release
 
-**Date** : 2026-07-05 (refresh v4.1 : refresh cohérence tag — master `d90ce613`, tests empiriques 578/584, aligné CHANGELOG #689). Refresh v4 (2026-07-04) : bundle v3 80 PDFs CMYK + verdicts #140/#632 RENDUS PASS.
-**Statut** : ASSETS VALIDÉS (verdict Release ai-01 = PASS géométrie/contenu + verdict #140 multilingue 8 langues RENDU + verdict #632 colorimétrique CMYK RENDU) — en attente d'arbitrages jsboige (SVG #636, mnémoniques #654, couplage go-live DNN) puis tag
-**Branche** : `docs/release-validation-v090-refresh-80pdfs`
-**Master de référence** : `d90ce613` (build zéro-warning CS+NU, **tests 578 pass / 1 known-fail #133 / 5 skip / 584 total** [empirique `dotnet test` 2026-07-05, po-2024 #689 + re-vérifié ce tick], Magick.NET 14.14.0). **Refresh v4** : bundle **v3** régénéré 2026-07-03 sur `27442add` = **80 PDFs** (10 types × 8 langues, expansion P&P #648-650) PNG-lossless puis **80/80 convertis CMYK** via post-process Ghostscript (#632/#652). Bundle GDrive `review-v0.9.0-RELEASE-bundle-v3-2026-07-03/` (6.5 GB : 80 PDFs CMYK + 7 samples + `CMYK_COLOR_PROOF.txt`).
+**Date** : 2026-07-09 (refresh **v5** : intégration colonnes AIF relationnelles #753/#754/#755 + master `81a9e4e6` + tests empiriques 594/600). Refresh v4.1 (2026-07-05) : master `d90ce613`, aligné CHANGELOG #689. Refresh v4 (2026-07-04) : bundle v3 80 PDFs CMYK + verdicts #140/#632 RENDUS PASS.
+**Statut** : ASSETS VALIDÉS (verdict Release ai-01 = PASS géométrie/contenu + verdict #140 multilingue 8 langues RENDU + verdict #632 colorimétrique CMYK RENDU) — en attente d'arbitrages jsboige (SVG #636, mnémoniques #654, couplage go-live DNN) puis tag. **Tag toujours non posé** (`git tag` vide au 2026-07-09).
+**Branche** : `docs/release-validation-v5-aif-refresh`
+**Master de référence** : `81a9e4e6` (build zéro-warning CS+NU, **tests 594 pass / 1 known-fail #133 / 5 skip / 600 total** [empirique `dotnet test` 2026-07-09, po-2023 ce tick — +16 tests vs v4.1 (578)], Magick.NET 14.14.0). **Refresh v4** : bundle **v3** régénéré 2026-07-03 sur `27442add` = **80 PDFs** (10 types × 8 langues, expansion P&P #648-650) PNG-lossless puis **80/80 convertis CMYK** via post-process Ghostscript (#632/#652). Bundle GDrive `review-v0.9.0-RELEASE-bundle-v3-2026-07-03/` (6.5 GB : 80 PDFs CMYK + 7 samples + `CMYK_COLOR_PROOF.txt`).
+
+> **Delta v5 (post-05/07)** : 4 PRs merged sur master entre `d90ce613` et `81a9e4e6` — **#753** (Fallacies AIF : 2 colonnes relationnelles `AIF_attackType`/`AIF_attackedNode`, 46/1408 remplis), **#754** (mirror Virtues script), **#755** (mirror Virtues exécuté, 222/223 remplis), **#756** (audit sérialisation read-only). Détail inventaire §3.1bis. Aucun impact assets rendus (CSV metadata-only, 0 impact CardPen/harvest/PDF) → verdicts #140/#632 inchangés, bundle v3 reste le bundle de référence.
 
 ---
 
@@ -45,6 +47,21 @@
 **Hygiène CSV close ce cycle** : corruption encodage `%C3→A13` systémique dans templates JSON réparée (#579 Fallacies, #581 Memo, #584 4 templates Fallacies live). Audit complet : `docs/investigations/2026-06-23-prod-csv-hygiene-audit.md`.
 
 > **Source des counts** (pointeur, review NanoClaw) : Fallacies 1408 nœuds + Virtues 223 nœuds + Scenarii 167 records proviennent de l'analyse taxonomy consolidée — issues #335 (Fallacies closure), #499 Phase 1 spec (`docs/taxonomy/499-virtues-prod-write-spec.md`, 223 rows × 66 cols ground-truth), et commits Scenarii `7ed970a3`/`2a1b86bf`/`0dc838fb` (167/167 vérifiés cell-by-cell `7206f2f9`). Comptes non re-dérivés ce jour (cf §1 méthode).
+
+### 3.1bis Colonnes AIF relationnelles — Fallacies + Virtues (✅ livré v5, PRs #753/#754/#755)
+
+**Nouvel artefact de données (delta v5)** : le chantier AIF #498/#499 a sérialisé la décomposition argumentative I/RA/CA dans **2 nouvelles colonnes CSV** (`AIF_attackType` + `AIF_attackedNode`) sur les **deux taxonomies**, avec un **contrat partagé anti-drift**. Metadata-only (couche additive, 0 impact rendu carte / CardPen / harvest / PDF → verdicts #140/#632 inchangés).
+
+| Taxonomie | Colonnes | Coverage | PR | Master commit | Byte-check ai-01 |
+|-----------|----------|----------|----|---------------|-------------------|
+| **Fallacies** (1408 nœuds) | `AIF_attackType` (idx 96) + `AIF_attackedNode` (idx 97) | **46/1408** remplis : 44 undercut/RA + 2 undermine/I, **0 rebut**, 17 fail-loud vides | #753 | `d4fde74d` | ✅ 143 616 checks → 0 mismatch |
+| **Virtues** (223 nœuds) | `AIF_attackType` (idx 79) + `AIF_attackedNode` (idx 80) | **222/223** remplis : 206 undercut/RA + 13 undermine/I + 3 rebut/CA ; 1 root (pk 0) vide | #755 | `3b68393a` | ✅ 17 617 checks → 0 mismatch |
+
+- **Discipline #677 tenue** : 0 fabrication de tokens. Cellules vides = fail-loud si pas de CQ (corpus question) natif (17 Fallacies).
+- **Règle déterministe** (plan #750 v2) : défaut `undercut`/`RA-node` ; override `undermine`/`I-node` si oppose {889,804} ; override `rebut`/`CA-node` si oppose {340}. Distribution Virtues = 206/13/3 (exacte, re-confirmée programmatiquement).
+- **Contrat partagé** : les 2 taxonomies utilisent les mêmes noms d'en-têtes + vocab canonique → mirror anti-drift.
+- **Impact release** : aucun sur les assets rendus (CSV = métadonnée OWL/EPITA, pas consommée par le pipeline de rendu). L'OWL peut être régénéré pour embarquer ces colonnes (post-tag, #133 scope).
+- ⚠️ **#756** (audit sérialisation read-only, `81a9e4e6`) : diagnostic qui **backs l'ASK ai-01** sur la couverture Fill Fallacies. Ne modifie aucune donnée — documente le delta entre 46 modelés et la cible de couverture.
 
 ### 3.2 MindMap SVGs — 8 langues (✅ livré, PR #565)
 

--- a/docs/RELEASE-VERIFICATION-INDEX-v0.9.0.md
+++ b/docs/RELEASE-VERIFICATION-INDEX-v0.9.0.md
@@ -4,7 +4,7 @@
 release** avant de poser le tag v0.9.0 (#134). Un seul point d'entrée → un lien + une ligne
 « à vérifier » par doc.
 
-**Master de référence** : `7590dfb8` (post batch-merges cycle-3 : #672/#673/#675/#676/#680). Tous
+**Master de référence** : `81a9e4e6` (refresh v5 2026-07-09 : intégration colonnes AIF #753/#754/#755 + tests empiriques 594/600). Précédent : `7590dfb8` (cycle-3 : #672/#673/#675/#676/#680). Tous
 les docs listés ci-dessous sont **sur master** (vérifiables maintenant). Le tag est techniquement
 débloqué (verdicts #140 contenu + #632 CMYK = PASS rendus) — il attend les arbitrages jsboige
 (§« Décisions restantes »).
@@ -19,7 +19,7 @@ débloqué (verdicts #140 contenu + #632 CMYK = PASS rendus) — il attend les a
 
 | Doc | À vérifier |
 |-----|------------|
-| [RELEASE-VALIDATION-v0.9.0.md](RELEASE-VALIDATION-v0.9.0.md) | **Dossier de validation v4 (refresh)** — 80 PDFs CMYK, verdicts #140/#632 RENDUS PASS. **2 appels à décision** : (a) SVG Virtues `.content.svg` FR-frozen (#636/#654, non-bloquant géométrie), (b) titre PT « Roll of the English Channel » (§3.6, fix prep po-2024 gated). Confirme si l'un ou l'autre bloque le tag. |
+| [RELEASE-VALIDATION-v0.9.0.md](RELEASE-VALIDATION-v0.9.0.md) | **Dossier de validation v5 (refresh 2026-07-09)** — 80 PDFs CMYK, verdicts #140/#632 RENDUS PASS, **+ §3.1bis : colonnes AIF relationnelles Fallacies+Virtues (#753/#754/#755, metadata-only, 0 impact rendu)**. Master `81a9e4e6`, tests 594/600 empiriques. **2 appels à décision** : (a) SVG Virtues `.content.svg` FR-frozen (#636/#654, non-bloquant géométrie), (b) titre PT « Roll of the English Channel » (§3.6, fix prep po-2024 gated). Confirme si l'un ou l'autre bloque le tag. |
 
 ---
 


### PR DESCRIPTION
Refresh **v5** of the release validation dossier (2026-07-09, po-2023 worker). Integrates the 4 PRs merged between `d90ce613` and `81a9e4e6` — notably the AIF relational columns chantier.

## What changed (docs-only, 2 files)

### `docs/RELEASE-VALIDATION-v0.9.0.md`
- **Header** refreshed: master `81a9e4e6`, tests **594 pass / 1 known-fail #133 / 5 skip / 600 total** (empirical `dotnet test` 2026-07-09, **+16 vs v4.1's 578**), tag still unposéd.
- **§3.1bis added** (new artifact inventory): **AIF relational columns** on both taxonomies —
  - Fallacies (#753, `d4fde74d`): `AIF_attackType`/`AIF_attackedNode` (idx 96/97), 46/1408 filled (44 undercut/RA + 2 undermine/I, 0 rebut), 17 fail-loud vides (#677 tenue).
  - Virtues (#755, `3b68393a`): same 2 cols (idx 79/80), 222/223 filled (206 undercut/RA + 13 undermine/I + 3 rebut/CA), 1 root vide.
  - Règle déterministe (plan #750 v2) + contrat partagé anti-drift + byte-check ai-01 (143 616 + 17 617 checks → 0 mismatch).
- **Delta v5 callout** (blockquote) summarizing the post-05/07 merges.

### `docs/RELEASE-VERIFICATION-INDEX-v0.9.0.md`
- §1 TAG GATE line updated: points to v5 + delta AIF + fresh test count.
- Master ref updated `7590dfb8` → `81a9e4e6`.

## Key invariant
AIF columns are **CSV metadata-only** (additive layer, 0 impact on card rendering / CardPen / harvest / PDF) → verdicts **#140** (content 8 langues) and **#632** (CMYK) **unchanged**, bundle v3 remains the reference bundle.

## Discipline
- ✅ Docs-only. No prod code. No DB write. No CSV prod mutation.
- ✅ Test count verified empirically this tick (not reported).
- ✅ Master ref + tag status verified (`git tag` vide au 2026-07-09).
- ❌ MD060 table-style warnings left untouched (pre-existing style across the whole doc; fixing would create inconsistency, not polish).

Gated review ai-01 + presentation jsboige (validates visuels sem. du 13/07).

🤖 Worker po-2023

Co-Authored-By: Claude <noreply@anthropic.com>