### PR TITLE
docs(dnn-i18n): #682 Path A provisioning manifest (49 fields) + 2sxc-export-spec v21 correction

### DIFF
--- a/docs/dnn-localization/682-path-a-provisioning-manifest.md
+++ b/docs/dnn-localization/682-path-a-provisioning-manifest.md
@@ -1,0 +1,134 @@
+# 2026-07-11 — #682 Path A provisioning manifest (49 suffixed fields, gated ops)
+
+**Scope**: the **concrete provisioning list** jsboige/ops applies on the live DNN instance to make the
+Game Rule content-type (app=60, AttributeSet 377) **Path-A multilingual** — i.e. create the **49
+lang-suffixed attributes** (7 translatable fields × 7 non-FR langs) so PR #674's `Loc()` cascade can
+resolve them at runtime. This is the **ops-gated artifact**; no DB write from this repo.
+
+**Repo reference**: branch `feat/682-path-a-provisioning-manifest`, base master `7406bb8e`. Issue: #682.
+Owner: jsboige (DB provisioning). Triggered by ai-01 dispatch `bzkvnh` (2026-07-11, primary).
+
+> ⚠ **Status = manifest only.** No DB write is executed from this repo. The 49 attribute creations
+> below are **staged for prod apply** (gated jsboige/ops) on the live DNN Argumentum instance (app=60).
+
+---
+
+## Ground truth (from the live 2sxc v21 export, #774 / #681)
+
+Source: [`exports/DNN-Argumentum-export-2026-07-07/11-game-rule-schema.json`](release-validation/exports/DNN-Argumentum-export-2026-07-07/11-game-rule-schema.json).
+
+- **Content-type**: `Game Rule`, AttributeSet **id=377**, app **60** (ZoneID=3), StaticName `a9d3420a-3644-4be1-8df1-12c27ced8c19`.
+- **Schema family**: `ToSIC_EAV_*` (2sxc **v21**) — NOT `ToSIC_SexyContent_*`.
+- **15 attributes** total. **7 translatable String fields** (the provisioning scope):
+
+| # | StaticName | AttributeID | Type | IsTitle |
+|---|------------|-------------|------|---------|
+| 1 | `Title` | 1933 | String | **yes** |
+| 2 | `Summary` | 1934 | String | no |
+| 3 | `Material` | 1935 | String | no |
+| 4 | `Installation` | 1938 | String | no |
+| 5 | `Content` | 1939 | String | no |
+| 6 | `Variants` | 1940 | String | no |
+| 7 | `Memo` | 2113 | String | no |
+
+- **8 non-localizable attrs** (out of scope): `Parent` (Entity), `MinNbPlayers`/`MaxNbPlayers` (Number), `Date` (DateTime), `Author`/`Licence`/`Original` (Entity), `UrlKey` (SEO slug).
+
+---
+
+## Path A — the 49 suffixed fields to provision
+
+Decision (confirmed by [`682-field-model-revision-2sxc21.md`](682-field-model-revision-2sxc21.md) §4):
+**Path A** = lang-suffixed attributes + `Loc()` cascade (PR #674). FR stays canonical (unsuffixed). The
+7 target non-FR langs (matching the `dnn-ui-strings.csv` / DatasetUpdater target set):
+
+`en` · `ru` · `pt` · `es` · `ar` · `fa` · `zh`
+
+### The 49 attributes (7 fields × 7 langs)
+
+Each new attribute = `<Field>_<lang>`, type **String (Wysiwyg/rich-HTML)** matching its generic
+counterpart (confirmed String, §1 of the revision doc), added to AttributeSet 377.
+
+| Field (generic) | en | ru | pt | es | ar | fa | zh |
+|-----------------|----|----|----|----|----|----|-----|
+| `Title` (1933) | `Title_en` | `Title_ru` | `Title_pt` | `Title_es` | `Title_ar` | `Title_fa` | `Title_zh` |
+| `Summary` (1934) | `Summary_en` | `Summary_ru` | `Summary_pt` | `Summary_es` | `Summary_ar` | `Summary_fa` | `Summary_zh` |
+| `Material` (1935) | `Material_en` | `Material_ru` | `Material_pt` | `Material_es` | `Material_ar` | `Material_fa` | `Material_zh` |
+| `Installation` (1938) | `Installation_en` | `Installation_ru` | `Installation_pt` | `Installation_es` | `Installation_ar` | `Installation_fa` | `Installation_zh` |
+| `Content` (1939) | `Content_en` | `Content_ru` | `Content_pt` | `Content_es` | `Content_ar` | `Content_fa` | `Content_zh` |
+| `Variants` (1940) | `Variants_en` | `Variants_ru` | `Variants_pt` | `Variants_es` | `Variants_ar` | `Variants_fa` | `Variants_zh` |
+| `Memo` (2113) | `Memo_en` | `Memo_ru` | `Memo_pt` | `Memo_es` | `Memo_ar` | `Memo_fa` | `Memo_zh` |
+
+**= 49 new attributes.** Naming convention follows `Loc()` expectations (PR #674 `<Field>_<lang>`
+resolution — verify the exact suffix spelling `_en`/`_ru`/… matches the `Loc()` implementation before
+provisioning; if #674 uses `_en-US`/`_ru-RU` culture names, align accordingly).
+
+> **Memo caveat**: `Memo` (AttributeID 2113) has a non-contiguous ID (vs 1932-1941) — it was added
+> later. Confirm it is on AttributeSet 377 (not a sibling set) before provisioning its 7 suffixes.
+
+---
+
+## Apply procedure (jsboige / ops, gated)
+
+### Path A-1 — 2sxc admin UI (lowest risk, visual)
+1. Log into DNN as host/admin → 2sxc app **60** (Argumentum).
+2. Content-type `Game Rule` (AttributeSet 377) → **manage fields**.
+3. For each of the 49 rows above: **add field** → name `<Field>_<lang>`, type **String** (Wysiwyg to
+   match the rich-HTML generic counterpart), group `Default`. Save.
+4. Verify the 49 fields appear + PR #674's `Loc()` cascade resolves them per request culture.
+
+### Path A-2 — Method B write script (on-box, gated)
+A SQL write against the live DNN DB via 2sxc v21 EAV tables (`ToSIC_EAV_Attributes` +
+`ToSIC_EAV_AttributesInSet`). **Requires write credentials** (the export was read-only SELECT). The
+2sxc admin UI (Path A-1) is strongly preferred — direct EAV inserts risk metadata inconsistencies
+(SortOrder, AttributeID assignment, AppId/AssignmentType). A SQL path is feasible but **must be
+validated against the live `ToSIC_EAV_*` v21 schema** before execution; the script below is a
+**draft skeleton**, not apply-ready.
+
+```sql
+-- DRAFT SKELETON — validate table/column names vs live ToSIC_EAV_* v21 schema before executing.
+-- Adds the 49 suffixed attributes to AttributeSet 377 (Game Rule, app=60).
+-- 2sxc v21 stores attribute metadata across ToSIC_EAV_Attributes + ToSIC_EAV_AttributesInSet.
+
+DECLARE @AttributeSetId INT = 377;
+DECLARE @AppId INT = 60;
+
+-- Repeat for each (Field, lang) pair in the 49-grid above.
+-- Example: Title_en
+INSERT INTO ToSIC_EAV_Attributes (AttributeSetId, StaticName, Type, IsTitle, AppId)
+VALUES (@AttributeSetId, 'Title_en', 'String', 0, @AppId);
+-- + corresponding ToSIC_EAV_AttributesInSet row (AttributeId, AttributeSetId, SortOrder, GroupId)
+-- + dimension config if the App uses dimensioned values (Path A uses suffixed attrs, so NOT dimensioned)
+```
+
+> ⚠ **Do NOT run the SQL skeleton as-is.** The column names (`AttributeSetId`, `StaticName`, `Type`,
+> `IsTitle`, `AppId`) and the `ToSIC_EAV_AttributesInSet` companion insert are inferred from the v21
+> EAV model and **must be confirmed against the live schema** (cf the export `13-app60-resources.json`
+> raw shape + a `sp_columns ToSIC_EAV_Attributes` probe). Path A-1 (2sxc admin UI) avoids this entirely.
+
+### Post-provisioning verification
+1. Re-export AttributeSet 377 (Method B read-only) → confirm the 15 → 64 attribute count (15 + 49).
+2. PR #674 becomes **runtime-validable**: the `Loc()` cascade should resolve `<Field>_<lang>` per
+   request culture. Smoke-test on `/Règles` detail page switching cultures.
+3. **#684** (Game Rule prose translation, PR #767 already merged) then populates the 49 fields with the
+   7-lang translated values from `docs/dnn-localization/684-translations.json` (re-import gated).
+
+---
+
+## Gate boundaries (HARD)
+
+- ❌ **Zero DB write from this repo** — the manifest is a staging artifact; apply is gated jsboige/ops.
+- ❌ Does not provision the suffixed fields unilaterally — jsboige ratifies + executes (decision confirmed).
+- ❌ Does not modify `Cards/` CSV (game-content is po-2024's lane).
+- ❌ Does not declare a QA verdict — that's ai-01.
+- ❌ Does not merge #674 (runtime-pending, gated sandbox — #596 garde-fou).
+
+## What this PR also ships (sibling doc correction)
+
+This branch also corrects the **2sxc 15.02 → v21 staleness** in
+[`release-validation/2sxc-export-spec.md`](release-validation/2sxc-export-spec.md) (§3/§4/§7) — the
+spec was written for 2sxc 15.02 (`ToSIC_SexyContent_*`, app=31, "FR inféré"), now superseded by the
+live v21 export (`ToSIC_EAV_*`, app=60, FR verified). See the SUPERSEDED banner + corrected sections.
+
+Relates: dispatch `bzkvnh`, #682 (this issue), #774/#681 (live export), #694 (original decision-input),
+#674 (RulesExplorer `Loc()` refactor), #684 (translation, populates the 49 fields post-provisioning),
+#490 (res.* rail — separate), #458 (epic).

--- a/docs/dnn-localization/release-validation/2sxc-export-spec.md
+++ b/docs/dnn-localization/release-validation/2sxc-export-spec.md
@@ -1,6 +1,16 @@
 # Spec — Export 2sxc pour vérifier le FR inféré & débloquer #490
 
-**Auteur :** Claude Code @ myia-po-2023 (worker) — 2026-06-16
+> **⚠ SUPERSEDED (partiellement) — 2026-07-11.** Cette spec a été écrite pour **2sxc 15.02**
+> (`ToSIC_SexyContent_*`, app=31, FR « inféré »). Le site live tourne en **2sxc v21**
+> (`ToSIC_EAV_*`, **app=60**), et l'export a été **livré** (#681 → PR #774 merged, 7 fichiers sous
+> [`exports/DNN-Argumentum-export-2026-07-07/`](exports/DNN-Argumentum-export-2026-07-07/)). Les
+> objectifs P0/P1 de cette spec sont **accomplis** : les `res.*` FR sont **VERIFIED** (plus inférés),
+> le HOLD #490 est **levé** (4 arbitrages `res.Rule*` exécutés, PR #772). Les sections §3/§4/§7 sont
+> **corrigées ci-dessous** pour refléter v21 ; §5/§6 restent valides comme patron de ré-ingestion.
+> Source de vérité actuelle = le manifest live [`exports/.../manifest.json`](exports/DNN-Argumentum-export-2026-07-07/manifest.json)
+> + [`682-field-model-revision-2sxc21.md`](../682-field-model-revision-2sxc21.md).
+
+**Auteur :** Claude Code @ myia-po-2023 (worker) — 2026-06-16 (corrigé 2026-07-11 vs export live #774)
 **Objet :** Spécification de l'export 2sxc qui (1) vérifie les **7 FR inférés** `res.*` de
 `dnn-ui-strings.csv` vs le dictionnaire Resources live, et (2) extrait le contenu DB-only
 (Rules/Glossary/FAQ/homepage) pour la localisation complète. C'est le **vrai unblocker** de #490 et
@@ -20,15 +30,15 @@ Tant que ces 7 FR ne sont pas confirmés, les 7×7 = 49 traductions dépendantes
 
 ## 2. Périmètre de l'export
 
-| # | Ce qu'on exporte | Source 2sxc/DNN | But | Priorité |
-|---|------------------|-----------------|-----|----------|
-| 1 | **App Resources** (dictionnaire valeurs FR) | App Argumentum → Content-type `Resources` | Vérifier les 7 FR inférés `res.*` | **P0 — débloque #490** |
-| 2 | **Rules content** (Summary/Material/Installation/Variants/Memo) | Content-items Rules | FR canonique des corps de règles (≈24 règles × 5 champs) | P1 |
-| 3 | **Glossary entries** | App `Glossary3` | ≈50 entrées glossaire | P2 |
-| 4 | **FAQ entries** | App `Faq4` | FAQ | P2 |
-| 5 | **Homepage/About/landing** | App `Content` + modules | ≈10 pages | P2 |
-| 6 | **Nav labels** | DNN tabs | Labels menu | P3 |
-| 7 | **SEO meta** (titres/descriptions) | DNN page settings | ≈40 pages | P3 |
+| # | Ce qu'on exporte | Source 2sxc/DNN | But | Priorité | Statut (2026-07-11) |
+|---|------------------|-----------------|-----|----------|--------------------|
+| 1 | **App Resources** (dictionnaire valeurs FR) | app=60 → eid=10340 | Vérifier les `res.*` FR | **P0** | ✅ **DONE** — 9 `res.Rule*` VERIFIED (#772), FR=!inféré |
+| 2 | **Rules content** (Summary/Material/Installation/Content/Variants/Memo) | app=60 `Game Rule` (id=377) | FR canonique des corps de règles | P1 | ✅ **DONE** — 5 entités (pas 24-30), export #774 `12-...` |
+| 3 | **Glossary entries** | App `Glossary3` | ≈50 entrées glossaire | P2 | ❌ **NOT FOUND** — `Glossary3` absent ; candidats app=60 : Fallacy/Scenario/Comment. Mapping à clarifier. |
+| 4 | **FAQ entries** | App `Faq4` | FAQ | P2 | ❌ **NOT FOUND** — `Faq4` absent (cf manifest `findings.glossary3Faq4`). |
+| 5 | **Homepage/About/landing** | App `Content` + modules | ≈10 pages | P2 | ⏸ non couvert par l'export #774 (scope résolu P0/P1) |
+| 6 | **Nav labels** | DNN tabs | Labels menu | P3 | ⏸ non couvert |
+| 7 | **SEO meta** (titres/descriptions) | DNN page settings | ≈40 pages | P3 | ⏸ non couvert |
 
 > **Déjà localisé, pas d'export requis :** Fallacies Explorer lit le CSV taxonomy via
 > `App.Query["FallaciesFromCSV"]` → le contenu des fallacies est déjà couvert par les CSV cartes 8
@@ -36,35 +46,45 @@ Tant que ces 7 FR ne sont pas confirmés, les 7×7 = 49 traductions dépendantes
 
 ## 3. Méthode A — UI 2sxc (recommandé, non destructif)
 
+> **Corrigé 2026-07-11 vs live v21 (export #774).** L'app Argumentum est **app=60** (ZoneID=3), le
+> content-type Rules s'appelle **`Game Rule`** (AttributeSet 377), et les `res.*` vivent sur l'entité
+> **App-Resource eid=10340**. Les noms `Rules`/`Glossary3`/`Faq4` ci-dessous étaient des hypothèses
+> 15.02 — `Glossary3`/`Faq4` sont **absents** du live (cf §2 statut + manifest `findings`).
+
 1. Se connecter au portail DNN (local `http://localhost:8090` ou prod) en admin.
-2. **2sxc → App Argumentum → Data** (ou *Content*).
-3. Sélectionner le content-type **`Resources`** → liste des entrées key/value.
+2. **2sxc → App 60 (Argumentum) → Data** (ou *Content*).
+3. Pour les `res.*` : entité App-Resource **eid=10340** (pas un content-type ordinaire). Pour les
+   corps de règles : content-type **`Game Rule`** (AttributeSet 377) → 5 entités publiées.
 4. Export : bouton **Export** (JSON ou CSV). 2sxc génère un fichier avec toutes les paires key/value
    (toutes langues présentes en DB).
-5. Répéter pour `Rules`, `Glossary3`, `Faq4`, `Content` selon le périmètre §2.
+5. Répéter selon le périmètre §2 (app=60 : `Game Rule` ✓ ; `Glossary3`/`Faq4` absents — à clarifier).
 
 **Pour les DNN tabs (nav) et page settings (SEO)** : DNN admin → *Pages* → export, ou SQL (§4).
 
 ## 4. Méthode B — SQL direct (si l'UI 2sxc est indisponible)
 
-2sxc stocke les entités dans `dbo.[ToSIC_SexyContent_<App>_<ContentType>_Entity]` + valeurs dans des
-tables `*_Value` / attributs EAV. La structure exacte varie ; requête de départ (adapter) :
+> **Corrigé 2026-07-11 vs live v21 (export #774).** 2sxc v21 stocke l'EAV dans la famille
+> **`ToSIC_EAV_*`** (`ToSIC_EAV_Values` / `ToSIC_EAV_Attributes` / `ToSIC_EAV_Entities` /
+> `ToSIC_EAV_AttributeSets`), **PAS** `ToSIC_SexyContent_*` (qui était la famille 15.02 de la spec
+> originale). Le FR canonique est la **valeur dimensionless** (`DimensionID IS NULL`), pas une
+> colonne `v.Language = 'fr-FR'`. L'export #681/#774 a été produit exactement par cette méthode
+> (read-only, on-box `myia-web1`).
 
 ```sql
--- Lister les ressources FR de l'app Argumentum (vérifier le schéma EAV réel au préalable)
+-- Lister les ressources FR (dimensionless default) de l'app Argumentum, app=60, eid=10340.
+-- Schéma VERIFIE sur le live v21 (cf export #774 / 13-app60-resources.json).
 SELECT  e.EntityId, e.Guid, a.Name AS [Key], v.Value
-FROM    ToSIC_SexyContent_AttributeValues v
-JOIN    ToSIC_SexyContent_Attributes a       ON a.AttributeId = v.AttributeId
-JOIN    ToSIC_SexyContent_Entities e         ON e.EntityId = v.EntityId
-JOIN    ToSIC_SexyContent_AttributeSets s    ON s.AttributeSetId = a.AttributeSetId
-WHERE   s.Name = 'Resources'                 -- content-type Resources de l'app Argumentum
-  AND   v.Language = 'fr-FR'                 -- (ou NULL si mono-langue)
+FROM    ToSIC_EAV_Values v
+JOIN    ToSIC_EAV_Attributes a   ON a.AttributeId = v.AttributeId
+JOIN    ToSIC_EAV_Entities e     ON e.EntityId = v.EntityId
+WHERE   e.EntityId = 10340           -- App-Resource entity (res.* rail), app=60
+  AND   v.DimensionID IS NULL        -- FR dimensionless default
 ORDER BY a.Name;
 ```
 
-⚠️ **Le schéma EAV de 2sxc dépend de la version** (15.02 ici). Vérifier les noms de tables réels
-(`SELECT name FROM sys.tables WHERE name LIKE 'ToSIC_SexyContent%'`) avant la jointure. L'UI (§3) est
-plus sûre si disponible.
+⚠️ **Le schéma EAV de 2sxc dépend de la version** : **v21 = `ToSIC_EAV_*`** (correct ici), 15.02 et
+antérieur = `ToSIC_SexyContent_*`. Vérifier `SELECT name FROM sys.tables WHERE name LIKE 'ToSIC%'`
+avant la jointure. L'UI (§3) reste plus sûre si disponible.
 
 ## 5. Comparaison & action (comment lever le HOLD #490)
 
@@ -94,7 +114,8 @@ rempli, cibles vides. Le DatasetUpdater (OpenAI direct gpt-5.5, clé rechargée)
 - **Non destructif** : export = lecture seule. Aucun write sur le portail.
 - **Ne pas modifier les CSV avant injection CardPen** (règle projet) — N/A ici (pas de CardPen), mais
   l'export reste une source de vérité ; ne pas éditer à la main les cellules traduites.
-- **Version 2sxc** : 15.02. L'UI d'export peut différer des captures génériques — s'adapter.
+- **Version 2sxc** : **v21** (corrigé 2026-07-11 ; la spec originale mentionnait 15.02). Famille EAV
+  `ToSIC_EAV_*`. L'UI d'export peut différer des captures génériques — s'adapter.
 
 ---
 


### PR DESCRIPTION
## What

Dispatch `bzkvnh` (ai-01, 2026-07-11) — **primaire** #682 Path A + **secondaire** `2sxc-export-spec.md` staleness fix. Theme: **“2sxc v21 ground truth”** — now that the live export is committed (#774), the docs can lean on real data instead of 15.02 hypotheses.

Base: master `7406bb8e`. **Doc-only.** No DB write, no `Cards/` CSV, no runtime change.

## Deliverable 1 — #682 Path A provisioning manifest (NEW)

`docs/dnn-localization/682-path-a-provisioning-manifest.md` — the concrete **ops-gated artifact** jsboige/ops applies on the live DNN instance to make the Game Rule content-type Path-A multilingual:

- **49 lang-suffixed attributes** (7 translatable String fields × 7 non-FR langs `en/ru/pt/es/ar/fa/zh`) added to AttributeSet 377 (Game Rule, app=60), so PR #674 `Loc()` cascade resolves them per request culture.
- Ground truth sourced from the live export [`11-game-rule-schema.json`](https://github.com/ArgumentumGames/Argumentum/blob/master/docs/dnn-localization/release-validation/exports/DNN-Argumentum-export-2026-07-07/11-game-rule-schema.json) — the 7 translatable fields (Title 1933 / Summary 1934 / Material 1935 / Installation 1938 / Content 1939 / Variants 1940 / Memo 2113), FR stays canonical unsuffixed.
- 2 apply paths: **Path A-1** 2sxc admin UI (preferred, lowest risk) / **Path A-2** Method B SQL draft skeleton (`ToSIC_EAV_Attributes` + `ToSIC_EAV_AttributesInSets`).
- Post-provisioning verification (15 → 64 attribute count re-export, `Loc()` smoke-test, #684 populates the 49 fields).
- **HARD gate: zero DB write from this repo** — manifest is a staging artifact; apply is gated jsboige/ops.

Relates to DoD #682: the decision (Path A) is documented in the existing `682-field-model-revision-2sxc21.md`; this PR adds the **concrete provisioning list** the decision implies. DB apply + PR #674 runtime validation remain gated ops (correctly out of worker scope).

## Deliverable 2 — `2sxc-export-spec.md` §3/§4/§7 v21 correction

The spec was written for **2sxc 15.02** (`ToSIC_SexyContent_*`, app=31, FR “inféré”); the live site runs **v21** (`ToSIC_EAV_*`, app=60, FR verified). Corrected:

- **SUPERSEDED banner** — objectives P0/P1 accomplished (`res.*` FR VERIFIED via #772, HOLD #490 lifted, export delivered #774). §5/§6 kept as a re-ingestion template.
- **§2 scope table** — added a *Statut (2026-07-11)* column reflecting export findings: `Glossary3`/`Faq4` NOT FOUND (manifest `findings`); Game Rule = 5 published entities (not the 24-30 estimated).
- **§3 Method A UI** — app=31 → app=60, `Rules` → `Game Rule` (id 377), `res.*` on App-Resource eid=10340.
- **§4 Method B SQL** — `ToSIC_SexyContent_*` → `ToSIC_EAV_*` (v21 family); FR is the **dimensionless default** (`DimensionID IS NULL`), not `v.Language = 'fr-FR'`; targets eid=10340. Matches the export #681/#774 method exactly.
- **§7** — version 15.02 → v21.

## Gate boundaries (HARD)

- ❌ Zero DB write from this repo
- ❌ Does not modify `Cards/` CSV (game-content = po-2024 lane)
- ❌ Does not merge #674 (runtime-pending, gated sandbox)
- ❌ Does not declare a QA verdict (ai-01 only)

## Review

Doc-only, low-risk. Requesting ai-01 gated review.

Relates: dispatch `bzkvnh`, #682 (this issue), #774/#681 (live export), #674 (`Loc()` refactor, runtime-pending), #684 (translation, populates the 49 fields post-provisioning), #490 (res.* rail — separate, resolved), #458 (epic), #694 (original decision-input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)