### PR TITLE
docs(dnn-i18n): resolve 2sxc-export-spec §2 #3/#4 (Glossary3/Faq4) from #774 export

### DIFF
--- a/docs/dnn-localization/release-validation/2sxc-export-spec.md
+++ b/docs/dnn-localization/release-validation/2sxc-export-spec.md
@@ -34,8 +34,8 @@ Tant que ces 7 FR ne sont pas confirmés, les 7×7 = 49 traductions dépendantes
 |---|------------------|-----------------|-----|----------|--------------------|
 | 1 | **App Resources** (dictionnaire valeurs FR) | app=60 → eid=10340 | Vérifier les `res.*` FR | **P0** | ✅ **DONE** — 9 `res.Rule*` VERIFIED (#772), FR=!inféré |
 | 2 | **Rules content** (Summary/Material/Installation/Content/Variants/Memo) | app=60 `Game Rule` (id=377) | FR canonique des corps de règles | P1 | ✅ **DONE** — 5 entités (pas 24-30), export #774 `12-...` |
-| 3 | **Glossary entries** | App `Glossary3` | ≈50 entrées glossaire | P2 | ❌ **NOT FOUND** — `Glossary3` absent ; candidats app=60 : Fallacy/Scenario/Comment. Mapping à clarifier. |
-| 4 | **FAQ entries** | App `Faq4` | FAQ | P2 | ❌ **NOT FOUND** — `Faq4` absent (cf manifest `findings.glossary3Faq4`). |
+| 3 | **Glossary entries** | App `Glossary3` | ≈50 entrées glossaire | P2 | ✅ **RESOLVED — no 2sxc export needed.** `Glossary3` n'existe pas comme content-type app=60 (export #774 `10-...` liste 13 types, aucun glossary). Le glossaire des fallacies **EST la taxonomy Fallacies** (content-type `Fallacy` id=376), servie via le **CSV cartes 8 langues** + `App.Query["FallaciesFromCSV"]` (déjà localisé, cf note ci-dessous). Aucune extraction 2sxc requise. |
+| 4 | **FAQ entries** | App `Faq4` | FAQ | P2 | ⚠ **DEFERRED jsboige — no app=60 Faq content-type.** `Faq4` absent des 13 types app=60. Cross-app : `Question` (app=18/38) non confirmé comme la FAQ Argumentum (manifest `findings.glossary3Faq4`). **Action jsboige** : confirmer si une section FAQ existe sur le site (et dans quelle app 2sxc) avant tout export. Si pas de FAQ → ligne sans objet. |
 | 5 | **Homepage/About/landing** | App `Content` + modules | ≈10 pages | P2 | ⏸ non couvert par l'export #774 (scope résolu P0/P1) |
 | 6 | **Nav labels** | DNN tabs | Labels menu | P3 | ⏸ non couvert |
 | 7 | **SEO meta** (titres/descriptions) | DNN page settings | ≈40 pages | P3 | ⏸ non couvert |
@@ -43,6 +43,10 @@ Tant que ces 7 FR ne sont pas confirmés, les 7×7 = 49 traductions dépendantes
 > **Déjà localisé, pas d'export requis :** Fallacies Explorer lit le CSV taxonomy via
 > `App.Query["FallaciesFromCSV"]` → le contenu des fallacies est déjà couvert par les CSV cartes 8
 > langues. (✅ Le template est culture-aware depuis PR #464 — bug §4 résolu, pas d'export requis pour l'Explorer.)
+>
+> **Résolution §2 #3 (2026-07-12) :** c'est aussi pourquoi `Glossary3` n'existe pas — le « glossaire »
+> des fallacies **est** la taxonomy Fallacies (content-type id=376), pas une entité 2sxc séparée. La
+> localisation du glossaire = la localisation des CSV cartes (déjà 8 langues), pas un export 2sxc.
 
 ## 3. Méthode A — UI 2sxc (recommandé, non destructif)
 


### PR DESCRIPTION
## What

Closes the 2 open “à clarifier” rows in [`2sxc-export-spec.md`](https://github.com/ArgumentumGames/Argumentum/blob/master/docs/dnn-localization/release-validation/2sxc-export-spec.md) §2, using the live v21 export (**#774**, already on master) as ground truth. **Doc-only.** No DB write, no `Cards/` edit.

These rows were flagged as open questions when I wrote the spec’s SUPERSEDED refresh in #777. With the export now committed, they are resolvable. Closing them before jsboige/ops consumes the spec for the gated #682 apply.

## §2 #3 — Glossary entries: ✅ RESOLVED (no 2sxc export needed)

`Glossary3` does **not** exist as an app=60 content-type — the export `10-app60-content-types.json` lists 13 types (Album, App-Resources, Argumentum Settings, Comment, Contributor, **Fallacy (376)**, Game Rule (377), ImageMetadata, License, Scenario (380), Scenario Category (381), …), none named Glossary. The fallacies glossary **IS** the Fallacies taxonomy (content-type `Fallacy` id=376), served via the **8-language CSV cards** + `App.Query["FallaciesFromCSV"]` — already localized (culture-aware since PR #464). The “Glossary3” name was a 2sxc-15.02 hypothesis; the glossary was never a separate 2sxc entity set. **No export required.**

## §2 #4 — FAQ entries: ⚠ DEFERRED jsboige

`Faq4` absent from the 13 app=60 content-types. The manifest `findings.glossary3Faq4` notes a cross-app candidate `Question` (app=18/38), unconfirmed as the Argumentum FAQ. **Action jsboige**: confirm whether a FAQ section exists on the site (and in which 2sxc app) before any export. If there is no FAQ → the row is moot.

## Verification

- `git show origin/master:docs/.../10-app60-content-types.json` → 13 content-types enumerated (proof in PR diff context).
- `manifest.json` `findings.glossary3Faq4` → cross-app candidates documented.

## Gate boundaries

- ❌ No DB write · ❌ No `Cards/` edit (po-2024 lane) · ❌ No runtime change · ❌ No visual verdict (ai-01 lane).
- Doc-only (6 insertions / 2 deletions, 1 file).

## Review

Low-risk doc cleanup, in-lane (DNN `docs/dnn-localization/`). Requesting ai-01 gated review. Relates: #777 (spec v21 refresh where the rows were flagged), #774 (export = ground truth), #457 (localization epic), #682 (the gated apply this spec feeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)