### PR TITLE
test(ontology): #133 refresh obsolete OWL2XML assertion — inScheme survives (596/0)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlE2EGenerationValidationTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlE2EGenerationValidationTests.cs
@@ -17,7 +17,7 @@ namespace Argumentum.AssetConverter.Tests.Ontology
     /// IN-MEMORY path).
     ///
     /// HISTORY (the bug this file originally pinned, now fixed): OWLSharp's OWL2XML serializer/reader
-    /// drops <c>rdf:type</c> from the reloaded annotation stream (rdf:type==0, skos:inScheme==0 among
+    /// drops <c>rdf:type</c> from the reloaded annotation stream (rdf:type==0 among
     /// <c>AnnotationAxioms</c> after reload). The OwlAdapter readers located concepts/schemes by
     /// scanning <c>AnnotationAxioms</c> for <c>rdf:type</c>, so on any LOADED file they returned empty →
     /// <c>ValidateMultilingualAnnotations</c> / <c>ValidateAIFMappings</c> hit their
@@ -79,15 +79,20 @@ namespace Argumentum.AssetConverter.Tests.Ontology
         }
 
         // ─────────────────────────────────────────────────────────────────────────────
-        // (1) The serializer drop is REAL and UNFIXED BY DESIGN (read-path-only fix).
-        //     rdf:type==0 and skos:inScheme==0 among the reloaded AnnotationAxioms — OWLSharp's
-        //     OWL2XML round-trip drops/absorbs both. This stays true after the fix: the readers no
-        //     longer depend on them, but the drop itself is not patched (out of scope: write/serialize).
-        //     Contrast: prefLabel (literal-valued) survives — the loss is predicate-selective.
+        // (1) The serializer drop is PARTIAL — rdf:type is dropped, skos:inScheme now SURVIVES.
+        //     OWLSharp's OWL2XML round-trip still drops rdf:type (rdf:type==0 among the reloaded
+        //     AnnotationAxioms), but as of the committed argumentum.owl (145 AIF-typed, regenerated
+        //     2026-07-12 #787) skos:inScheme SURVIVES the round-trip (1408 assertions, one per concept).
+        //     Earlier this test asserted both were dropped; that was true of the in-memory build path
+        //     but is OBSOLETE for the committed file. The read-path fix (test 2) is unaffected — it
+        //     keys on prefLabel/hasTopConcept, which survive regardless. The rdf:type drop stays real
+        //     and is left in place (out of scope: write/serialize); only the obsolete inScheme==0
+        //     assertion is corrected here. (Anti-greenwashing: inScheme==1408 was verified empirically
+        //     by a temporary probe on the reloaded AnnotationAxioms, not by grepping the raw file.)
         // ─────────────────────────────────────────────────────────────────────────────
 
         [Fact]
-        public void LoadedOntology_RdfTypeAndInScheme_DroppedByOwl2XmlRoundTrip()
+        public void LoadedOntology_RdfTypeDropped_InSchemeSurvives_Owl2XmlRoundTrip()
         {
             int rdfType = CountAnnotations("/rdf-syntax-ns#type");
             int inScheme = CountAnnotations("skos/core#inScheme");
@@ -99,9 +104,11 @@ namespace Argumentum.AssetConverter.Tests.Ontology
                 "drop is REAL and left in place by the read-path fix — the readers now locate concepts via " +
                 "surviving prefLabel annotations instead (see test 2), so the drop is benign, not patched.");
 
-            inScheme.Should().Be(0,
-                "skos:inScheme is also absent from the reloaded AnnotationAxioms (absorbed elsewhere by the " +
-                "reader) — a read-path fix cannot rely on it either; the fix uses prefLabel + hasTopConcept.");
+            inScheme.Should().BeGreaterThan(0,
+                "skos:inScheme SURVIVES the OWL2XML round-trip on the committed argumentum.owl (1408 assertions, " +
+                "one per concept) — empirically verified on the reloaded AnnotationAxioms. The earlier assertion " +
+                "(inScheme==0) was true of the in-memory build path but OBSOLETE for the committed file. " +
+                "Either way the read-path fix keys on prefLabel+hasTopConcept, so this correction is hygiene only.");
 
             prefLabel.Should().BeGreaterThan(0,
                 "contrast: prefLabel (literal-valued) DOES survive the round-trip — the serialization loss is " +


### PR DESCRIPTION
## #133 test-hygiene — refresh obsolete OWL2XML assertion (inScheme survives) → **596 pass / 0 fail**

**Worker** po-2024 · **Base** master `5c6b3bce` · **GO** ai-01 dispatch `xbd53d` (primaire). **Test-only, gated review ai-01.**

### 🎯 Problème
Le known-fail `LoadedOntology_RdfTypeAndInScheme_DroppedByOwl2XmlRoundTrip` assertait **rdf:type==0 ET inScheme==0** sur les AnnotationAxioms reloaded. Mon cert #133 (#790) a montré que l'assertion `inScheme==0` est **obsolète** : inScheme survie maintenant au round-trip (1408). À refresh honnêtement (garde-fou anti-greenwashing : ne PAS forcer si inScheme ne survit pas réellement).

### ✅ Vérification honnête avant changement (anti-greenwashing)
Probe temporaire (compté sur les **reloaded AnnotationAxioms**, pas un grep raw file — supprimé, jamais committé) :
```
PROBE rdf:type=0  inScheme=1408  prefLabel=2816  broadMatch=57
```
→ `inScheme=1408` est **réel et stable** sur l'OWL committé (regén #787). Le `rdf:type=0` est **toujours réel** (limite OWLSharp, laissée en place par le fix read-path). Donc le test peut être rendu vert **honnêtement** en splitant l'assertion.

### Changements (test-only, 1 file +17/-10)
- **Renommage** : `LoadedOntology_RdfTypeAndInScheme_Dropped…` → `LoadedOntology_RdfTypeDropped_InSchemeSurvives_…` (reflète la réalité split).
- **Assertion inScheme** : `Be(0)` → `BeGreaterThan(0)` + because-clause documentant que l'ancienne assertion était vraie du path in-memory mais **OBSOLÈTE** pour le fichier committé, et que le fix read-path key sur prefLabel+hasTopConcept de toute façon (hygiene only).
- **Assertion rdf:type** : `Be(0)` **gardée verbatim** — le drop est réel, laissé en place par design.
- Header classe + commentaire §1 mis à jour (retrait du claim stale "skos:inScheme==0").

### ✅ Résultat empirique (code=truth, `dotnet test`)
```
OwlE2EGenerationValidationTests: 5/5 PASS (was 4/1)
Full suite: 596 pass / 0 fail / 5 skip (601 total)   ← was 595/1/5
```
Le dernier rouge documenté est clear. **OWSLSharp bug partiellement résolu** : rdf:type reste droppé (résiduel, documenté dans l'assertion gardée), inScheme survit. Le survivor-fallback reader (test 2) reste en place et indépendant.

### Fichiers
- `Generation/Converters/Argumentum.AssetConverter.Tests/Ontology/OwlE2EGenerationValidationTests.cs` — rename + assertion refresh (+17/-10).

### Gate boundaries
- ✅ Test-only · ✅ **0 write prod CSV** (`Cards/` intact) · ✅ **0 prod code change**.
- ✅ Anti-greenwashing : inScheme==1408 vérifié empiriquement via probe sur reloaded AnnotationAxioms AVANT le changement d'assertion (pas un grep raw).
- ✅ Suite complète 596/0 vérifiée (pas juste le fichier e2e).
- ✅ Secret-scan : 0 hit.
- ❌ Pas de self-merge — verdict QA = ai-01.

🤖 Worker po-2024 — #133 test-hygiene livré (596/0 honnête).
