### PR TITLE
docs(dnn): refresh 2 go-live docs post-execution + fix B1-inversion in turnkey

### DIFF
--- a/docs/dnn/go-live-smoke-test.md
+++ b/docs/dnn/go-live-smoke-test.md
@@ -1,9 +1,22 @@
 # DNN 10.3.2 Go-Live — Smoke-Test Checklist
 
-**Date**: 2026-06-26 · **Author**: po-2023 (dispatched by ai-01 v3, secondary track)
+**Date**: 2026-06-26 (refreshed 2026-07-12 — POST-EXECUTION context) · **Author**: po-2023 (dispatched by ai-01 v3, secondary track)
 **Status**: Actionable checklist — **complements** the [#132 production deployment runbook](../dnn-localization/132-deployment-runbook.md) (PR #594), does NOT duplicate it. Read-only doc, no code.
 **Purpose**: The #132 runbook covers the upgrade wizard + rollback contract. This doc is the **detailed smoke test** run immediately after the wizard completes (Phase 5, step 5 of #132) before exiting maintenance mode — the gate that says "10.3.2 is live and serving".
 **Related**: #132 (deployment runbook), #131 (upgrade arc), #596 (12 Razor14 templates), #597 (4 social-auth connectors), [UPGRADE-ASSESSMENT.md](UPGRADE-ASSESSMENT.md) §5 (eshop), [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md).
+
+> ## 🟢 POST-EXECUTION CONTEXT (refreshed 2026-07-12)
+>
+> The smoke checklist below remains **valid and actionable** for the one step still gated — **prod VPS go-live on
+> myia-web1** (jsboige ops task). What has changed since this doc was written:
+> - The **sandbox-side** smoke (sections A/B on IIS Express :8090) is **already green**: DNN 10.3.2 + 2sxc 21.07 live
+>   in full-IIS at `dnn.argumentum.myia.io` (HTTP 200/~85 KB, 0× "Something went wrong", B2.5 smoke GREEN). So this
+>   checklist is now the **prod replay** of a proven sandbox run, not a first-time gate.
+> - **A2/A3/A5** red-flag `0x80131040` (binding) and `DnnJsInclude` crash are **already resolved** on the live site —
+>   they are retained as regression-watch signals, not open blockers.
+> - Section **B** (12 Razor14 templates) source-migrated in #596; runtime binding validated on the sandbox.
+> - **Release de-coupling**: the v0.9.0 print tag does NOT block on this prod go-live (worker reco, ai-01 concur) —
+>   B4 is a separate jsboige ops task.
 
 ---
 

--- a/docs/dnn/go-live-turnkey-checklist.md
+++ b/docs/dnn/go-live-turnkey-checklist.md
@@ -1,9 +1,39 @@
 # DNN 10.3.2 Go-Live — Turnkey Session Checklist (jsboige's RDP window)
 
-**Date**: 2026-06-26 · **Author**: po-2023 (dispatched by ai-01, secondary track — release COUPLÉE au site, jsboige input 26/06)
+**Date**: 2026-06-26 (refreshed 2026-07-12 — POST-EXECUTION) · **Author**: po-2023 (dispatched by ai-01, secondary track)
 **Status**: **Turnkey navigator.** Organizes the entire #131 arc by **what an RDP session is needed for**, not by technical phase (the [dnn-localization README](../dnn-localization/README.md) already does phase-order). The shortest path from "open RDP" to "site live on 10.3.2". Read-only doc, no code.
 **Purpose**: jsboige coupled v0.9.0 to the DNN go-live (#131/#132). Most of the arc is already done by agents without touching the runtime; a bounded set **requires jsboige's interactive RDP/sandbox session**. This is the checklist that says — when you open that window, here is the exact turnkey sequence and nothing redundant.
 **Related**: [sandbox-bootstrap-runbook.md](sandbox-bootstrap-runbook.md), [go-live-smoke-test.md](go-live-smoke-test.md), [../dnn-localization/README.md](../dnn-localization/README.md) (arc index), #596 (Razor14), #597 (auth), #131/#132.
+
+> ## 🟢 POST-EXECUTION REALITY (refreshed 2026-07-12) — B1-B3 DELIVERED; only prod VPS go-live (B4) remains
+>
+> Since this checklist was written (2026-06-26), the sandbox-side work it organizes has been **executed and delivered**:
+> - **B1 (bin/ repair), B2 (sandbox upgrade + 2sxc 21), B3 (12 Razor14 templates)** — all **DONE**. DNN **10.3.2 + 2sxc
+>   21.07** are live in **full-IIS** at `dnn.argumentum.myia.io` (HTTP 200/~85 KB, 0× "Something went wrong", HTTPS SAN
+>   9D80D4CC exp 2026-09-27). Stopgap `dnn.myia.io` retiré, PortalAlias 1010 droppé. ACME bypass **active in live**
+>   (renew win-acme 2026-08-23). Runtime branch `dnn/sandbox-runtime-1032` (bin/ 330 files). B2.5 smoke GREEN.
+>
+> So the turnkey sequence below is now a **proven replay** — B1-B3 are historical record, **only B4 (prod VPS go-live
+> on myia-web1) is the remaining gated frontier.**
+>
+> ### ⛔ CRITICAL CORRECTION to B1 below — the B1-inversion (do NOT follow B1 as written)
+>
+> B1's step 2-3 instruct: *"fetch the 5 .NET-9 contaminants at 6.0.x"* + *"align binding redirects → 6.0.0.0."* **This
+> is the INVERTED thesis — it was proven WRONG during execution.** Reverting BCL/SDK DLLs to 6.0.0.0 breaks 2sxc 21:
+> 2sxc 21.07 is compiled against `System.Text.Json` **9.0.0.0** / `System.Composition`-SCI **9.0.0.0** /
+> `Microsoft.Extensions.*`-Bcl **8.0.0.0**. Reverting → `JsonOptions` type-init `MissingMethodException` → every 2sxc
+> module renders *"Something went really wrong in view.ascx"*.
+>
+> **The correct B1 action (what actually worked):** deploy the matched BCL stack from the **2sxc 21.07 Install
+> package** (Json 9.0.0.0 / SCI 9.0.0.0 / Bcl 8.0.0.0) + align `<assemblyBinding>` redirects to those versions.
+> Canonical working bin = `tmp/dnn-backups/bin_post_2sxc_realign` (330 files). Authoritative version matrix: MEMORY
+> `reference-dnn-2sxc-net48-bcl-stack` + [`../dnn-localization/682-field-model-revision-2sxc21.md`](../dnn-localization/682-field-model-revision-2sxc21.md).
+> The same correction is applied to [`132-deployment-runbook.md`](../dnn-localization/132-deployment-runbook.md) §5.5(a).
+> **Read B1 below as historical-prep-with-a-known-error; the correction supersedes it.**
+>
+> ### Release de-coupling
+> The 26/06 framing "release COUPLÉE au site" is **revised**: the DNN prod go-live (B4) is a **jsboige ops VPS task,
+> de-coupled from the v0.9.0 print release** (worker reco, ai-01 concur). The tag v0.9.0 does not block on B4.
 
 ---
 


### PR DESCRIPTION
## Context

Continuation of the DNN runbook refresh (companion to PR #792, same dispatch `2lnzsb` secondary "scope/refresh les runbooks"). The 2 **operational** go-live docs in `docs/dnn/` were written 2026-06-26 as PRE-execution navigators. Since then the sandbox + full-IIS migration was delivered. One carries a **dangerous error** that would bite a future executor.

## What landed (docs-only, 2 files, +45/-2)

### `go-live-turnkey-checklist.md` — POST-EXEC banner + ⛔ CRITICAL B1 correction

- **B1-B3 DELIVERED**, only prod VPS go-live (B4) remains. DNN 10.3.2 + 2sxc 21.07 live in full-IIS at `dnn.argumentum.myia.io` (HTTP 200/~85 KB, 0× "Something went wrong", HTTPS SAN exp 2026-09-27, ACME bypass active).
- **The dangerous part — B1 step 2-3 instructs the WRONG action.** As written, it says *"fetch the 5 .NET-9 contaminants at 6.0.x"* + *"align binding redirects → 6.0.0.0."* **This is the INVERTED thesis**, proven WRONG during execution:
  > Reverting BCL/SDK DLLs to 6.0.0.0 breaks 2sxc 21. 2sxc 21.07 is compiled against `System.Text.Json` **9.0.0.0** / `System.Composition`-SCI **9.0.0.0** / Bcl **8.0.0.0**. Reverting → `JsonOptions` type-init `MissingMethodException` → every 2sxc module *"Something went really wrong in view.ascx"*.
- **Correct B1 action documented** (what actually worked): deploy matched BCL stack from the 2sxc 21.07 Install package + align `<assemblyBinding>` redirects. Canonical working bin = `tmp/dnn-backups/bin_post_2sxc_realign` (330 files). Pointer to MEMORY `reference-dnn-2sxc-net48-bcl-stack` + `682-field-model-revision-2sxc21.md`.
- Release de-coupling noted: B4 (prod VPS go-live) = jsboige ops task, **not blocking the v0.9.0 print tag**.

### `go-live-smoke-test.md` — POST-EXEC context banner

Checklist remains valid/actionable for the remaining gated step (prod VPS go-live). Sandbox smoke already green (sections A/B proven on the live site); A2/A3/A5 red-flags retained as regression-watch signals, not open blockers. Section B templates source-migrated #596.

## Why this is real work (not fabrication)

These are **operational docs a future jsboige/VPS-executor would run from**. The B1 step as written would, on execution, break 2sxc 21 — a concrete, documented failure mode (the B1 incident already happened). Leaving it un-corrected is the actual bug. This PR supersedes the wrong instruction and marks B1-B3 as historical record.

The same B1-inversion lesson is corrected in `132-deployment-runbook.md` §5.5(a) — that's companion PR **#792** (3 runbooks). This PR closes the **second doc** that encoded the error.

## Verification

- Link target `docs/dnn-localization/682-field-model-revision-2sxc21.md` exists (`ls` confirmed).
- Secret-scan: clean (0 hits, no `sk-`, no API key patterns).
- Banners cross-reference live state from MEMORY §DNN (verified 2026-07-12).
- diff scope: +45/-2 docs-only, no `.cs`, no `Cards/`, no DB.

## Gate

- ✅ Docs-only (no code, no CSV, no DB, no live mutation)
- ✅ po-2023 lane (`docs/dnn/` operational go-live docs)
- ✅ No secret in diff
- ⏸ Gated ai-01 review before merge (worker never self-merges)

Relates: dispatch `2lnzsb` secondary, #131/#132 (DNN), PR #792 (companion runbook refresh), MEMORY `reference-dnn-2sxc-net48-bcl-stack` (B1-inversion).

Co-Authored-By: Claude-Code <noreply@anthropic.com>