### PR TITLE
docs(review): broaden v0.9.0 review scope to full package (64 PDF + mindmaps, 8 langs)

### DIFF
--- a/docs/release-review-v0.9.0/CHECKLIST.md
+++ b/docs/release-review-v0.9.0/CHECKLIST.md
@@ -1,35 +1,41 @@
-# Checklist de relecture — Argumentum v0.9.0
+# Checklist de relecture — Argumentum v0.9.0 (paquet complet)
 
-Une ligne par langue. Cochez `[x]` si c'est bon, laissez `[ ]` et ajoutez une note si ça cloche.
-Copiez-collez ce bloc dans l'issue de suivi (ou renvoyez-le à jsboige).
+Cochez `[x]` si c'est bon, laissez `[ ]` + une note si ça cloche.
+Copiez-collez ce bloc dans l'[issue #802](https://github.com/ArgumentumGames/Argumentum/issues/802) (ou renvoyez-le à jsboige).
 
-> Fichier de référence par langue : `Argumentum_TarotCards_<langue>.pdf` (dans la pre-release).
-> Détail de quoi regarder : voir [`README.md`](README.md) §2 et §3.
+> **Périmètre = tout le paquet** : 8 types de PDF × 8 langues + les 2 mindmaps.
+> Détail de quoi regarder par type : voir [`README.md`](README.md) §3.
+> Fichiers : `Argumentum_<Type>_<langue>.pdf` (pre-release) · mindmaps `.svg` (dépôt, dossier de la langue).
 
 ## Relecteur : _______________  (Thomas / Adeline)
 
-| Langue | Cover / p1 OK | Carte dense p51 OK | Recto-verso aligné | Écriture correcte | Note (langue + page + souci) |
-|--------|:---:|:---:|:---:|:---:|------------------------------|
-| 🇫🇷 FR (référence) | [ ] | [ ] | [ ] | [ ] | |
-| 🇬🇧 EN | [ ] | [ ] | [ ] | [ ] | |
-| 🇷🇺 RU (cyrillique) | [ ] | [ ] | [ ] | [ ] | |
-| 🇵🇹 PT (règles p4) | [ ] | [ ] | [ ] | [ ] | |
-| 🇪🇸 ES | [ ] | [ ] | [ ] | [ ] | |
-| 🇸🇦 AR (droite→gauche) | [ ] | [ ] | [ ] | [ ] | |
-| 🇮🇷 FA (droite→gauche) | [ ] | [ ] | [ ] | [ ] | |
-| 🇨🇳 ZH (chinois) | [ ] | [ ] | [ ] | [ ] | |
+Une ligne par langue. Colonnes = familles de livrables. `✓` = OK, `✗` = souci (détaillez en bas).
+
+| Langue | Tarot (Sophismes) | Vertus | Scénarios (Poker) | Print&Play (Tarot+Poker) | Posters (A0/A4/Vignettes) | Mindmaps (Sophismes+Vertus) |
+|--------|:---:|:---:|:---:|:---:|:---:|:---:|
+| 🇫🇷 FR (référence) | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇬🇧 EN | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇷🇺 RU (cyrillique) | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇵🇹 PT | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇪🇸 ES | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇸🇦 AR (droite→gauche) | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇮🇷 FA (droite→gauche) | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| 🇨🇳 ZH (chinois) | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 
 ### Verdict global
 - [ ] **RAS** — tout est bon, on peut publier
 - [ ] **Retouches mineures** (listées ci-dessous, non-bloquantes)
-- [ ] **Bloquant** — un défaut se répète sur plusieurs langues (à corriger avant publication)
+- [ ] **Bloquant** — un défaut se répète sur plusieurs langues/types (à corriger avant publication)
 
-### Remarques libres
-_(écrivez ici tout ce qui ne rentre pas dans le tableau)_
+### Remarques (langue + type + page + souci)
+_(ex. « ZH — Tarot p51 — titre déborde en bas » · « A0 EN — case "Ad Hominem" déborde » · « RU — Vertus — titre tronqué »)_
 
+-
+-
+-
 
 ---
 
-*Rappel : les points listés dans [`README.md`](README.md) §4 (carrés vides selon le lecteur, titre EN
-« Roll of the English Channel » déjà en correction, mnémoniques latins des Vertus, poster A0 lourd) sont
-**connus** — inutile de les signaler.*
+*Rappel : les points listés dans [`README.md`](README.md) §6 (carrés vides selon le lecteur, titre EN
+« Roll of the English Channel » déjà corrigé, mnémoniques latins des Vertus, poster A0 lourd, liens Wikipédia
+FR des mindmaps) sont **connus** — inutile de les signaler.*

--- a/docs/release-review-v0.9.0/README.md
+++ b/docs/release-review-v0.9.0/README.md
@@ -1,107 +1,149 @@
-# Argumentum v0.9.0 — Relecture visuelle (Thomas & Adeline)
+# Argumentum v0.9.0 — Relecture visuelle complète (Thomas & Adeline)
 
-Merci de prêter vos yeux aux visuels du jeu avant la publication de la **v0.9.0** 🙏
-Ce dossier est un **parcours guidé** (~45 min) : *ouvre ceci, vérifie ça, voici ce qui est normal,
-voici ce qu'il ne faut pas signaler*. Pas besoin d'être exhaustif — 6 cartes clés suffisent.
+Merci de prêter vos yeux à **l'ensemble des livrables** du jeu avant la publication de la **v0.9.0** 🙏
+Ce dossier est un **parcours guidé** : *où récupérer chaque document, quoi vérifier, ce qui est normal,
+ce qu'il ne faut pas signaler*.
 
-Le jeu est décliné en **8 langues** : 🇫🇷 FR (référence) · 🇬🇧 EN · 🇷🇺 RU · 🇵🇹 PT · 🇪🇸 ES · 🇸🇦 AR · 🇮🇷 FA · 🇨🇳 ZH.
+⚠️ **Important** : il ne s'agit **pas** que des cartes Tarot. Tout le paquet doit être contrôlé avant le tag :
+**8 types de documents × 8 langues (64 PDF) + les 2 mindmaps** (Sophismes + Vertus).
+
+Langues : 🇫🇷 FR (référence) · 🇬🇧 EN · 🇷🇺 RU · 🇵🇹 PT · 🇪🇸 ES · 🇸🇦 AR · 🇮🇷 FA · 🇨🇳 ZH.
 
 ---
 
-## 1. Où récupérer les PDFs (2 min)
+## 1. Où récupérer les livrables
 
-Les cartes prêtes à imprimer sont en **assets de la pre-release GitHub** :
+### 📄 Les 64 PDF — pre-release GitHub
 
-> 👉 **[Pre-release « v0.9.0 — Visual Review »](https://github.com/ArgumentumGames/Argumentum/releases/tag/v0.9.0-review)**
+> 👉 **[Pre-release « v0.9.0 — Visual Review »](https://github.com/ArgumentumGames/Argumentum/releases/tag/v0.9.0-review)** → section **Assets** en bas de page.
 >
-> 💬 **Issue de suivi (auto-suffisante, à commenter)** : **[#802 Relecture visuelle v0.9.0](https://github.com/ArgumentumGames/Argumentum/issues/802)**
+> 💬 **Issue de suivi (à commenter)** : **[#802](https://github.com/ArgumentumGames/Argumentum/issues/802)**
 
-Pour la première passe, on met en ligne les **`Argumentum_TarotCards_<langue>.pdf`** (les 8 langues) — elles
-couvrent tous les cas délicats (densité, écritures non-latines, covers, cartes de règles). Les autres decks
-(Poker/Scénarios, posters Web A0/A4, Print & Play, Vertus) sont disponibles **sur demande** — dites-le et on
-les ajoute.
+Chaque fichier est nommé `Argumentum_<Type>_<langue>.pdf`. **8 types × 8 langues** :
 
-> ⚠️ **Lecteur PDF** : ouvrez avec un viewer qui embarque les polices CJK + arabe (**Acrobat Reader** ou
-> **SumatraPDF**). Un viewer sans ces polices affiche de faux « carrés vides □ » (*tofu*) qui **ne sont pas**
-> un défaut du fichier (voir §4).
+| # | Type de PDF | Ce que c'est |
+|---|-------------|--------------|
+| 1 | `TarotCards` | **Paquet principal** : cartes Sophismes (Tarot) + cartes Règles + Mémo |
+| 2 | `TarotCards_Virtues` | **Paquet Vertus** (Tarot) — les vertus argumentatives |
+| 3 | `PokerCards` | **Scénarios** de jeu (format Poker) |
+| 4 | `TarotCards_Print&Play_A4` | Version **imprimable maison** du Tarot (A4, recto-verso) |
+| 5 | `PokerCards_Print&Play_A4` | Version **imprimable maison** des Scénarios (A4) |
+| 6 | `Fallacies_Web_A0` | **Poster A0** de la taxonomie des sophismes (grand format) |
+| 7 | `Fallacies_Web_A4` | Poster **A4** de la taxonomie |
+| 8 | `Fallacies_Web_Thumbnails_A4` | **Planche de vignettes** A4 |
+
+### 🧠 Les 2 mindmaps — dans le dépôt (rendu direct dans le navigateur)
+
+Ouvrez le dossier de votre langue puis cliquez les fichiers `.svg` (GitHub les affiche directement) :
+
+> 👉 `https://github.com/ArgumentumGames/Argumentum/tree/master/Cards/Fallacies/Mindmaps/<langue>`
+> (remplacez `<langue>` par `fr`, `en`, `ru`, `pt`, `es`, `ar`, `fa`, `zh`)
+
+- **`Fallacies_<langue>.svg`** → la carte mentale des **sophismes**
+- **`Argumentum_Virtues_MindMap_<langue>.content.svg`** → la carte mentale des **vertus**
+
+> ⚠️ **Lecteur PDF** : ouvrez les PDF avec un viewer qui embarque les polices CJK + arabe
+> (**Acrobat Reader** ou **SumatraPDF**). Un viewer sans ces polices affiche de faux « carrés vides □ »
+> (*tofu*) qui **ne sont pas** un défaut du fichier (voir §5).
 
 ---
 
-## 2. Les 6 arrêts prioritaires (~20 min)
+## 2. Comment se répartir le travail
 
-Pas besoin de tout regarder. Ces 6 cartes couvrent les cas-limites. Si elles sont bonnes, le reste l'est
-(même pipeline, mêmes polices).
+Le paquet est gros (64 PDF). Deux façons de se répartir — au choix :
 
-| # | Fichier | Page | Quoi vérifier | Cas couvert |
-|---|---------|------|---------------|-------------|
-| 1 | `Argumentum_TarotCards_fr.pdf` | p1-2 | cover FR + recto-verso aligné | référence FR |
-| 2 | `Argumentum_TarotCards_pt.pdf` | p4 | titre de la carte de **règles PT** lisible et correct | PT / règles |
-| 3 | `Argumentum_TarotCards_ar.pdf` | p51 (carte dense) | texte **arabe** de droite à gauche, aligné à droite | AR (RTL) |
-| 4 | `Argumentum_TarotCards_fa.pdf` | p51 | **persan** de droite à gauche + lettres persanes (پ چ ژ گ) | FA (RTL) |
-| 5 | `Argumentum_TarotCards_zh.pdf` | p51 | caractères **chinois** rendus, pas de débordement hors cadre | ZH (CJK) |
-| 6 | `Argumentum_TarotCards_ru.pdf` | p1 + une carte dense | **cyrillique** + accents | RU |
+- **Par langue** : chacun prend les langues qu'il peut juger et regarde **tous les types** pour ces langues.
+- **Par type** : l'un prend les cartes (Tarot/Vertus/Poker/Print&Play), l'autre les posters + mindmaps, sur les 8 langues.
 
-**Après ces 6 arrêts** : si tout est visuellement correct, on considère les autres cartes fiables.
-Si un problème → notez la langue + la carte, ce n'est probablement pas une régression globale.
+Pas besoin d'être exhaustif à la carte près : pour chaque type, **2-3 pages suffisent** à juger si le rendu global
+tient (même pipeline, mêmes polices). Signalez ce qui saute aux yeux.
 
 ---
 
-## 3. Non-latin : « normal » vs « cassé »
+## 3. Quoi vérifier, par type de livrable
+
+| Type | À vérifier en priorité | Cas délicat |
+|------|------------------------|-------------|
+| **TarotCards** | cover lisible · cartes **Règles** en premier · recto-verso aligné · densité de texte OK | AR/FA (RTL), ZH (CJK) |
+| **TarotCards_Virtues** | les 8 familles de vertus ont leur **couleur de fond** (pas de carte blanche) · titres non tronqués | RU (titres longs), overflow |
+| **PokerCards** (Scénarios) | texte du scénario complet, pas coupé · noms propres corrects | EN/PT (noms propres FR légitimes : Sherlock, Jeanne d'Arc…) |
+| **Print&Play A4** (Tarot + Poker) | recto-verso **s'aligne au pliage** · marges de découpe présentes | tous |
+| **Poster A0 / A4** | taxonomie lisible · pas de texte qui déborde des cases · couleurs de familles | **overflow** (cases denses) |
+| **Thumbnails A4** | toutes les vignettes présentes · lisibles en petit | — |
+| **Mindmap Sophismes** (SVG) | branches lisibles · libellés traduits (pas de fallback FR) · pas de chevauchement | RU/AR/FA/ZH |
+| **Mindmap Vertus** (SVG) | idem · les 7-8 familles bien distinctes | — |
+
+---
+
+## 4. Les arrêts prioritaires (si vous manquez de temps)
+
+Ces cartes couvrent les cas-limites. Si elles sont bonnes, le reste l'est très probablement.
+
+| # | Fichier | Quoi vérifier |
+|---|---------|---------------|
+| 1 | `TarotCards_fr` p1-2 | référence FR : cover + recto-verso |
+| 2 | `TarotCards_Virtues_fr` | les 8 familles ont bien leur couleur |
+| 3 | `TarotCards_ar` / `_fa` (carte dense) | **arabe / persan** de droite à gauche, aligné à droite |
+| 4 | `TarotCards_zh` (carte dense) | **chinois** rendu, pas de débordement hors cadre |
+| 5 | `TarotCards_ru` (carte dense) | **cyrillique** + titres longs non tronqués |
+| 6 | `Fallacies_Web_A0_fr` | **poster** : aucune case ne déborde |
+| 7 | mindmap `Fallacies_ru.svg` + `_zh.svg` | libellés traduits, pas de chevauchement |
+
+---
+
+## 5. Non-latin : « normal » vs « cassé »
 
 Le principal risque d'une relecture multilingue, c'est le **faux positif** (signaler comme cassé ce qui est
 correct dans une écriture qu'on ne lit pas). Repères :
 
 ### 🇸🇦 Arabe / 🇮🇷 Persan (de droite à gauche)
 - **Normal** : le texte court **de droite à gauche**, aligné à droite. Les **chiffres restent de gauche à
-  droite** dans le flux (standard Unicode, ce n'est pas un bug). AR et FA partagent l'alphabet ; FA ajoute
-  4 lettres (پ چ ژ گ) — vérifier qu'elles s'affichent.
-- **Cassé** (à signaler) : texte de gauche à droite sur une page censée être RTL · carrés vides □ · lettres
-  détachées qui devraient être liées (ligatures cassées).
+  droite** (standard Unicode, pas un bug). FA ajoute 4 lettres (پ چ ژ گ) — vérifier qu'elles s'affichent.
+- **Cassé** (à signaler) : texte de gauche à droite sur une page RTL · carrés vides □ · lettres détachées
+  qui devraient être liées.
 
 ### 🇨🇳 Chinois (CJK)
-- **Normal** : caractères en blocs carrés. Le chinois est **plus large** que le latin → un texte « tassé »
-  ou qui touche le bord n'est pas forcément un bug.
-- **Cassé** (à signaler) : carrés vides □ · demi-caractères · une police latine visible au milieu du chinois ·
-  un vrai **débordement hors du cadre** de la carte.
+- **Normal** : caractères en blocs carrés, **plus larges** que le latin → un texte « tassé » n'est pas un bug.
+- **Cassé** (à signaler) : carrés vides □ · demi-caractères · police latine au milieu du chinois · **débordement hors cadre**.
 
 ### 🇷🇺 Cyrillique
 - **Normal** : alphabet А-Я а-я, accents, ё / й.
-- **Cassé** (à signaler) : carrés vides · lettres latines à la place de cyrilliques qui se ressemblent
-  (un `a` latin au lieu d'un `а` cyrillique).
+- **Cassé** (à signaler) : carrés vides · lettre latine à la place d'une cyrillique qui se ressemble (`a` au lieu de `а`).
 
 ### 🇪🇸 Espagnol / 🇵🇹 Portugais (latin étendu)
 - **Normal** : accents (é è ê, ã õ, ç, ñ, à). PT = brésilien.
-- **Cassé** (à signaler) : accents manquants ou mojibake · un « ? » ou un carré noir à la place d'un accent.
+- **Cassé** (à signaler) : accents manquants ou mojibake · « ? » ou carré noir à la place d'un accent.
 
 ---
 
-## 4. Déjà connu — **ne pas signaler** comme défaut
+## 6. Déjà connu — **ne pas signaler** comme défaut
 
 | Ce que vous pourriez voir | Pourquoi | Action |
 |---------------------------|----------|--------|
-| Carrés vides □ sur du chinois / de l'arabe | police **de votre lecteur**, pas du fichier | ouvrez dans Acrobat/SumatraPDF ; ne pas signaler |
-| Sur une carte de règles EN, un titre bizarre (« Roll of the English Channel ») | mistraduction résiduelle **déjà en cours de correction** | connu, correctif en route — inutile de le remonter |
-| Les mnémoniques latins des cartes Vertus (mots type « bArbArA ») | choix éditorial assumé (latin conservé) | normal |
-| Poster A0 très lourd à ouvrir | 106 Mo, haute résolution d'impression | normal |
+| Carrés vides □ sur du chinois / de l'arabe | police **de votre lecteur**, pas du fichier | ouvrez dans Acrobat/SumatraPDF |
+| Carte de règles EN : titre « Roll of the English Channel » | mistraduction résiduelle **déjà corrigée** en amont | connu — inutile de le remonter |
+| Mnémoniques latins des cartes Vertus (mots type « bArbArA ») | choix éditorial assumé (latin conservé) | normal |
+| Poster A0 très lourd à ouvrir | ~18 Mo/langue, haute résolution d'impression | normal |
+| Mindmap : les liens Wikipédia pointent vers le FR | résidu connu ([#804](https://github.com/ArgumentumGames/Argumentum/issues/804)), invisible à l'impression | connu, post-tag |
 
 ---
 
-## 5. Comment nous remonter vos retours
+## 7. Comment nous remonter vos retours
 
-- **Idéal** : commentez directement sur l'**[issue GitHub de suivi #802](https://github.com/ArgumentumGames/Argumentum/issues/802)**.
-  Une case à cocher par langue + un espace pour vos remarques : voir [`CHECKLIST.md`](CHECKLIST.md).
+- **Idéal** : commentez directement sur l'**[issue #802](https://github.com/ArgumentumGames/Argumentum/issues/802)**.
+  Un tableau à cocher (langue × type de document) est fourni : voir [`CHECKLIST.md`](CHECKLIST.md).
 - **Sinon** : envoyez vos remarques à jsboige (WhatsApp), on les reporte pour vous.
 
-**Format utile pour une remarque** : *langue + fichier + page + ce qui cloche* (une phrase suffit).
-Exemple : « ZH — TarotCards_zh p51 — le titre déborde en bas du cadre ».
+**Format utile** : *langue + type de document + page + ce qui cloche* (une phrase suffit).
+Exemple : « ZH — TarotCards p51 — le titre déborde en bas du cadre » ou « A0 EN — case "Ad Hominem" déborde ».
 
 ---
 
-## 6. Ce qui est déjà validé en interne (pour info, inutile de re-vérifier)
+## 8. Ce qui est déjà validé en interne (pour info)
 
-- ✅ **Contenu 8 langues** (relecture interne, 03/07) : cartes denses, RTL/CJK, covers, règles.
-- ✅ **Colorimétrie CMYK** : 80/80 PDFs en CMYK + profil d'impression SWOP.
-- ✅ **Structure** : les cartes de règles apparaissent en premier · recto-verso aligné · 300 PPI.
+- ✅ **Colorimétrie CMYK** : les PDF sont en CMYK + profil d'impression SWOP.
+- ✅ **Structure** : cartes de règles en premier · recto-verso aligné · 300 PPI.
 - ✅ **Pas de fuite du français** dans les autres langues (structure multilingue intacte).
+- ✅ **Mindmaps** : contenu localisé par langue (rendus distincts, pas de clone du FR).
 
-Votre relecture = le **dernier regard humain** avant le tag. Merci encore 🎴✨
+Votre relecture = le **dernier regard humain** sur l'ensemble du paquet avant le tag. Merci encore 🎴✨


### PR DESCRIPTION
Reviewer materials for Thomas & Adeline (#802) previously scoped only the 8 TarotCards PDFs. Per jsboige, the **full package** must be controlled before the tag.

**Now covered** (README + CHECKLIST rewritten as a language × deliverable-type grid):
- **8 PDF types × 8 languages (64 PDF)** on the pre-release: TarotCards, TarotCards_Virtues, PokerCards, Tarot/Poker Print&Play A4, Fallacies_Web A0/A4/Thumbnails.
- **2 mind maps** (Fallacies + Virtues SVG) per language, viewable in-repo.

Pre-release assets completed to 64/64 in parallel. Issue #802 body + title updated to match.

Refs #802 #134