### PR TITLE
feat(mindmap): wire Virtues link i18n cascade (#804 Phases 1-3, code-only)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/VirtueLinkFallbackTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Parsing/VirtueLinkFallbackTests.cs
@@ -1,0 +1,174 @@
+using Argumentum.AssetConverter.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.Parsing
+{
+    /// <summary>
+    /// Contract pin for the 8 <c>LinkXxFallback</c> cascades on <see cref="Virtue"/> — added in #804
+    /// to mirror <see cref="FallacyLinkFallbackTests"/>. Before #804, <see cref="Virtue.Link"/> was
+    /// hardcoded to <c>LinkFr</c>, so every non-FR Virtues <c>links.svg</c> resolved its clickable
+    /// overlay URLs to French Wikipedia (161 <c>fr.wikipedia.org</c> refs per lang).
+    ///
+    /// The per-language mind-map link resolution feeds <c>LinkExpression</c>
+    /// (<c>{item.LinkFrFallback}</c>) in <c>VirtueMindMapDocumentConfig</c>, which the
+    /// <c>MindMapLocalization</c> token-swap (<c>AssetConverterConfig</c>) rewrites per dest-lang
+    /// (<c>LinkFrFallback</c> -> <c>LinkEnFallback</c> / <c>LinkRuFallback</c> / ...).
+    ///
+    /// French is the source language. The cascade design is intentionally ASYMMETRIC, mirroring
+    /// <see cref="Fallacy"/>:
+    /// <list type="bullet">
+    /// <item><description><see cref="Virtue.LinkFrFallback"/> / <see cref="Virtue.LinkEnFallback"/>
+    /// are 2-deep (Fr↔En: the two source-ish languages).</description></item>
+    /// <item><description><see cref="Virtue.LinkRuFallback"/> / Pt / Es / Ar / Fa / Zh are 3-deep:
+    /// target → En → Fr (a non-source language falls back to En, then to the French source).</description></item>
+    /// </list>
+    ///
+    /// The silent-wrong-output risk this guards against: if a refactor "symmetrizes" the cascade
+    /// (e.g. makes every language a 2-deep target→Fr, or reorders En/Fr), a virtue that ships with
+    /// ONLY a French link would resolve to <c>string.Empty</c> in non-EN exports — producing a
+    /// mind-map node with an EMPTY link, no exception, no log. These tests pin the cascade order
+    /// so such a regression fails loud.
+    /// </summary>
+    public class VirtueLinkFallbackTests
+    {
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (0) Virtue.Link itself must resolve through the cascade (was hardcoded LinkFr pre-#804).
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Link_ResolvesThroughFrFallback_NotHardcodedFr()
+        {
+            // Pre-#804 this returned LinkFr unconditionally. Post-#804 it must respect a present
+            // French link but be wired to the fallback property (so the per-lang swap can redirect it).
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = "en-link" };
+            v.Link.Should().Be("fr-link");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (1) LinkFrFallback — 2-deep: Fr → En.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void LinkFrFallback_PrimaryPresent_ReturnsLinkFr()
+        {
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = "en-link" };
+            v.LinkFrFallback.Should().Be("fr-link");
+        }
+
+        [Fact]
+        public void LinkFrFallback_PrimaryNull_FallsBackToEn()
+        {
+            var v = new Virtue { LinkFr = null, LinkEn = "en-link" };
+            v.LinkFrFallback.Should().Be("en-link");
+        }
+
+        [Fact]
+        public void LinkFrFallback_BothNull_ReturnsNull()
+        {
+            // Same contract as Fallacy: with BOTH Fr and En null, the expression returns LinkEn (null),
+            // NOT string.Empty. This is the silent-wrong-output hazard pinned explicitly.
+            var v = new Virtue { LinkFr = null, LinkEn = null };
+            v.LinkFrFallback.Should().BeNull();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (2) LinkEnFallback — 2-deep, INVERSE direction: En → Fr.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void LinkEnFallback_PrimaryPresent_ReturnsLinkEn()
+        {
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = "en-link" };
+            v.LinkEnFallback.Should().Be("en-link");
+        }
+
+        [Fact]
+        public void LinkEnFallback_PrimaryNull_FallsBackToFr()
+        {
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = null };
+            v.LinkEnFallback.Should().Be("fr-link");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // (3) Non-source languages (Ru/Pt/Es/Ar/Fa/Zh) — 3-deep cascade: target → En → Fr.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        // (3a) Target present → returns target (cascade short-circuits).
+        [Theory]
+        [InlineData(nameof(Virtue.LinkRu), nameof(Virtue.LinkRuFallback))]
+        [InlineData(nameof(Virtue.LinkPt), nameof(Virtue.LinkPtFallback))]
+        [InlineData(nameof(Virtue.LinkEs), nameof(Virtue.LinkEsFallback))]
+        [InlineData(nameof(Virtue.LinkAr), nameof(Virtue.LinkArFallback))]
+        [InlineData(nameof(Virtue.LinkFa), nameof(Virtue.LinkFaFallback))]
+        [InlineData(nameof(Virtue.LinkZh), nameof(Virtue.LinkZhFallback))]
+        public void NonSource_PrimaryPresent_ReturnsPrimary(string linkProp, string fallbackProp)
+        {
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = "en-link" };
+            SetLink(v, linkProp, "xx-link");
+
+            GetFallback(v, fallbackProp).Should().Be("xx-link",
+                "the cascade must short-circuit when the target language has its own link");
+        }
+
+        // (3b) Target null, En present → returns En (second tier).
+        [Theory]
+        [InlineData(nameof(Virtue.LinkRu), nameof(Virtue.LinkRuFallback))]
+        [InlineData(nameof(Virtue.LinkPt), nameof(Virtue.LinkPtFallback))]
+        [InlineData(nameof(Virtue.LinkEs), nameof(Virtue.LinkEsFallback))]
+        [InlineData(nameof(Virtue.LinkAr), nameof(Virtue.LinkArFallback))]
+        [InlineData(nameof(Virtue.LinkFa), nameof(Virtue.LinkFaFallback))]
+        [InlineData(nameof(Virtue.LinkZh), nameof(Virtue.LinkZhFallback))]
+        public void NonSource_PrimaryNull_EnPresent_ReturnsEn(string linkProp, string fallbackProp)
+        {
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = "en-link" };
+            SetLink(v, linkProp, null);
+
+            GetFallback(v, fallbackProp).Should().Be("en-link",
+                "a non-source language with no own link must fall back to English, NOT French");
+        }
+
+        // (3c) Target null, En null, Fr present → returns Fr (source-language floor).
+        [Theory]
+        [InlineData(nameof(Virtue.LinkRu), nameof(Virtue.LinkRuFallback))]
+        [InlineData(nameof(Virtue.LinkPt), nameof(Virtue.LinkPtFallback))]
+        [InlineData(nameof(Virtue.LinkEs), nameof(Virtue.LinkEsFallback))]
+        [InlineData(nameof(Virtue.LinkAr), nameof(Virtue.LinkArFallback))]
+        [InlineData(nameof(Virtue.LinkFa), nameof(Virtue.LinkFaFallback))]
+        [InlineData(nameof(Virtue.LinkZh), nameof(Virtue.LinkZhFallback))]
+        public void NonSource_TargetAndEnNull_FrPresent_ReturnsFr(string linkProp, string fallbackProp)
+        {
+            var v = new Virtue { LinkFr = "fr-link", LinkEn = null };
+            SetLink(v, linkProp, null);
+
+            GetFallback(v, fallbackProp).Should().Be("fr-link",
+                "French is the source language — it is the floor of the cascade, not just a peer");
+        }
+
+        // (3d) All three null → null (NOT empty).
+        [Theory]
+        [InlineData(nameof(Virtue.LinkRu), nameof(Virtue.LinkRuFallback))]
+        [InlineData(nameof(Virtue.LinkPt), nameof(Virtue.LinkPtFallback))]
+        [InlineData(nameof(Virtue.LinkEs), nameof(Virtue.LinkEsFallback))]
+        [InlineData(nameof(Virtue.LinkAr), nameof(Virtue.LinkArFallback))]
+        [InlineData(nameof(Virtue.LinkFa), nameof(Virtue.LinkFaFallback))]
+        [InlineData(nameof(Virtue.LinkZh), nameof(Virtue.LinkZhFallback))]
+        public void NonSource_AllNull_ReturnsNull(string linkProp, string fallbackProp)
+        {
+            var v = new Virtue { LinkFr = null, LinkEn = null };
+            SetLink(v, linkProp, null);
+
+            GetFallback(v, fallbackProp).Should().BeNull();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────────────
+        // Reflection helpers — let one Theory cover all 6 non-source languages uniformly.
+        // ─────────────────────────────────────────────────────────────────────────────
+
+        private static void SetLink(Virtue v, string propName, string? value)
+            => typeof(Virtue).GetProperty(propName)!.SetValue(v, value);
+
+        private static string GetFallback(Virtue v, string propName)
+            => (string)typeof(Virtue).GetProperty(propName)!.GetValue(v)!;
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/AssetConverterConfig.cs
@@ -246,10 +246,12 @@ namespace Argumentum.AssetConverter
 					{
 						nameof(VirtueMindMapDocumentConfig.TitleExpression),
 						nameof(VirtueMindMapDocumentConfig.DescriptionExpression),
+						nameof(VirtueMindMapDocumentConfig.LinkExpression),
 					}),
 					StaticConversions = new List<(string sourceText, List<(string Language, string destText)> textConversions)>(new[]{
 						(nameof(Virtue.TitleFr), new List<(string Language, string destText)>(new []{("en", nameof(Virtue.TitleEn)), ("ru", nameof(Virtue.TitleRu)), ("pt", nameof(Virtue.TitlePt)), ("es", nameof(Virtue.TitleEs)), ("ar", nameof(Virtue.TitleAr)), ("fa", nameof(Virtue.TitleFa)), ("zh", nameof(Virtue.TitleZh))}) ),
 						(nameof(Virtue.DescriptionFr), new List<(string Language, string destText)>(new []{("en", nameof(Virtue.DescriptionEn)), ("ru", nameof(Virtue.DescriptionRu)), ("pt", nameof(Virtue.DescriptionPt)), ("es", nameof(Virtue.DescriptionEs)), ("ar", nameof(Virtue.DescriptionAr)), ("fa", nameof(Virtue.DescriptionFa)), ("zh", nameof(Virtue.DescriptionZh))}) ),
+						("LinkFrFallback", new List<(string Language, string destText)>(new []{("en", "LinkEnFallback"), ("ru", "LinkRuFallback"), ("pt", "LinkPtFallback"), ("es", "LinkEsFallback"), ("ar", "LinkArFallback"), ("fa", "LinkFaFallback"), ("zh", "LinkZhFallback") }) ),
 					}),
 				},
 				// Virtue family hierarchy: FR names → localized names.

--- a/Generation/Converters/Argumentum.AssetConverter/Entities/Virtue.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Entities/Virtue.cs
@@ -12,7 +12,22 @@ namespace Argumentum.AssetConverter.Entities
         public string Text => TitleFr;
         public string Description => DescriptionFr;
         public string Example => string.Empty; // No example in source for Virtues
-        public string Link => LinkFr;
+        public string Link => LinkFrFallback;
+
+        // #804 — per-language mind-map link cascade, mirroring Fallacy.cs. The mind-map
+        // links-overlay (WrapNodeByLink) resolves the URL via LinkExpression, which the
+        // AssetConverterConfig token-swap rewrites per dest-lang (LinkFrFallback ->
+        // LinkEnFallback / LinkRuFallback / ...). Without this cascade the Virtues links.svg
+        // always resolved to LinkFr (161 fr.wikipedia refs per non-FR lang). French is the
+        // source; En is 2-deep (Fr<->En), the others are 3-deep (target -> En -> Fr).
+        public string LinkFrFallback => string.IsNullOrEmpty(LinkFr) ? LinkEn : LinkFr;
+        public string LinkEnFallback => string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn;
+        public string LinkRuFallback => string.IsNullOrEmpty(LinkRu) ? string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn : LinkRu;
+        public string LinkPtFallback => string.IsNullOrEmpty(LinkPt) ? string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn : LinkPt;
+        public string LinkEsFallback => string.IsNullOrEmpty(LinkEs) ? string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn : LinkEs;
+        public string LinkArFallback => string.IsNullOrEmpty(LinkAr) ? string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn : LinkAr;
+        public string LinkFaFallback => string.IsNullOrEmpty(LinkFa) ? string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn : LinkFa;
+        public string LinkZhFallback => string.IsNullOrEmpty(LinkZh) ? string.IsNullOrEmpty(LinkEn) ? LinkFr : LinkEn : LinkZh;
         public int? Carte => int.TryParse(Card, out int c) ? c : null;
         public string PK { get => Pk; set => Pk = value; }
         public string DecimalPath { get; set; }

--- a/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/Mindmapper/VirtueMindMapDocumentConfig.cs
@@ -161,7 +161,7 @@ namespace Argumentum.AssetConverter.Mindmapper
 
 
 
-		public string LinkExpression { get; set; } = @"{item.Link}";
+		public string LinkExpression { get; set; } = @"{item.LinkFrFallback}";
 
 
 		[IgnoreDataMember]


### PR DESCRIPTION
## What

Closes the code-side of #804: the Virtues `links.svg` clickable-overlay URLs were FR-frozen (161 `fr.wikipedia.org` refs/lang in en/ru/pt/es). Root cause = a code design gap (no per-language link cascade on `Virtue`), **not** a data gap.

Investigation plan: #issuecomment-4976360383. GO on code: ai-01 (`tm3tfa`, `x7xigw`). **HOLD Phase 4** (regen of the 8 `.svg`) — coordinated post-tag with po-2023.

## The fix (mirrors the Fallacy pattern)

| File | Change |
|---|---|
| `Entities/Virtue.cs` | `Link => LinkFr` → `Link => LinkFrFallback`; add the 8 `LinkXxFallback` cascade properties (Fr↔En 2-deep; Ru/Pt/Es/Ar/Fa/Zh 3-deep target→En→Fr) |
| `Mindmapper/VirtueMindMapDocumentConfig.cs` | `LinkExpression` default `{item.Link}` → `{item.LinkFrFallback}` (the token the per-lang swap recognizes) |
| `AssetConverterConfig.cs` | extend the Virtue `MindMapLocalization` text block: add `LinkExpression` to TargetProperties + add the `LinkFrFallback`→`LinkEnFallback`/…/`LinkZhFallback` swap (was only in the Fallacy block) |
| `Tests/Parsing/VirtueLinkFallbackTests.cs` | **new** — 30-case contract-pin mirroring `FallacyLinkFallbackTests`, so a future "symmetrize" refactor that drops the French source floor fails loud |

### Why the 3rd change (AssetConverterConfig) was the key

The `LinkFrFallback`→`LinkEnFallback` token-swap was **scoped to the Fallacy `MindMapLocalization` block** (`TargetProperties` listed `FallacyMindMapDocumentConfig.LinkExpression`). The Virtue block listed only `TitleExpression`/`DescriptionExpression` — no `LinkExpression`, no swap. So even with the cascade wired, the Virtue link expression would never have been rewritten per-lang. Extending the Virtue block closes the loop.

## Data reality

The Virtues CSV `link_{lang}` cells are substantially filled — so this code fix alone localizes the filled subset:

| lang | filled | | lang | filled |
|---|---|---|---|---|
| link_en | 194/223 (86%) | | link_es | 153/223 (68%) |
| link_ru | 196/223 (87%) | | link_ar | 92/223 (41%) |
| link_pt | 186/223 (83%) | | link_fa | 100/223 (44%) |
| | | | link_zh | 105/223 (47%) |

Empty cells fall back through the cascade to FR (the designed 3-deep floor). Filling those is the separate #192 Wikipedia-langlinks-API work (post-tag, #799 Option C) — **out of scope here**.

## Verification

- **Build Debug**: 0 warning, 0 error.
- **`dotnet test` full suite (empirical)**: **626 pass / 0 fail / 5 skip / 631 total** — 596 prior + 30 new Virtue LinkFallback tests, 0 regression.
- No other consumer of `Virtue.Link` (only the mindmap `LinkFunc`).
- Secret-scan clean.

## Phase 4 (HELD — not in this PR)

Regenerating the 8 committed `.links.svg` requires the FreeMind RDP box (lane po-2023, focus-theft-prone) and is coordinated post-tag. The committed `.svg` files will be refreshed in the global regen pass — **proof of the code fix = the new tests + the swap wired**, not a regenerated `.svg` (which needs the FreeMind box).

## Gate

**Gated — verdict QA = ai-01.** Worker po-2024, dispatch `x7xigw` item 2.
