### PR TITLE
docs(investigations): #812 audit — stale embedded `csv` in Face templates (read-only)

### DIFF
--- a/docs/investigations/2026-07-16-audit-template-stale-csv.md
+++ b/docs/investigations/2026-07-16-audit-template-stale-csv.md
@@ -1,0 +1,339 @@
+# Audit templates CardPen — `csv` embeddé stale vs CSV source (#812)
+
+**Generated** : 2026-07-16 (auto, read-only) — issue #812 dispatch ai-01
+**Base** : master `72c408ec`
+**Method** : code=truth — `HarvestManager.cs:342-363` injecte le CSV source au runtime,
+             écrasant le `csv` embeddé du template pour toute carte Face.
+**Implication** : le `csv` embeddé est mort pour les Faces — un delta = risque **latent**, pas un bug de rendu actuel.
+
+**Rappel** : corrigé via #803/#805 (cette fois sur le bon fichier), puis contredit par généralisation.
+**Statut rendu actuel** : OK (relecture T&A confirme) — seul le `csv` embeddé est stale.
+
+## Synthèse exécutive (lecture po-2024)
+
+**Cartographie complète — 27 templates CardPen × 15 CardSets analysés** (WebBasedGeneratorConfig.cs lignes 105-456) :
+
+- **20/27 HIGH** : tous les **Face** avec CSV source injecté ont un `csv` embeddé structurellement en retard (delta row +76 à +1239, delta col +13 à +68). **Aucune trace de MT-garbage résiduel dans les templates stale** (sauf `Rules` + `RulesPrintAndPlay` = résidu du #803/#805 déjà corrigé). → **Risque rendu = 0**. **Risque latent = structurel** (drift schéma).
+- **0/27 MEDIUM/LOW/NONE** : pas de divergence mineure détectée (probablement masquée par le seuillage row_delta>5 dans `classify`).
+- **7/27 N/A** : les **Backs** (`DataSet=None`) rendent depuis le template = source de vérité, donc rien à comparer.
+
+**Pourquoi le delta row est si grand ?** Parce que les CSV sources ont grandi entre la création des templates et aujourd'hui :
+- Fallacies Taxonomy `54→104 cols` : ajout AIF (#498, 4 nouvelles colonnes), ajout i18n 7 langues (#183 + #210), +`link_*` (#192), +`simple_name`/`political_example` (#202 pending).
+- Scenarii Cards `29→70 cols` : même raison + ajouts post-#795.
+- Virtues Taxonomy `13→81 cols` : PR #218/#236/#246/#290/#295 + cascade #808.
+
+→ Le `csv` embeddé est **un snapshot d'époque**, pas une donnée corrompue. C'est précisément ce que la généralisation tick 22 annonçait : la clé est morte, pas nuisible.
+
+## Décision par défaut (subtractif — règle « no pendulum »)
+
+**Marqueur `_csv_note` plutôt que resync.** Justification :
+
+1. **Resync = diff large + risque drift** : régénérer `csv` embeddé depuis le CSV source = +1239 lignes et +50 colonnes pour Fallacies = PR à 5000+ lignes, difficile à review, et le contenu sera re-overridden au prochain regen. Effort non-rentable.
+2. **Marqueur = subtractif** : ajouter `CardSetDocument._csv_note: "STALE — overridden at runtime by DataSet='X', see <csv_path>"` — 1 ligne par template Face. **Aucune chance de régression** (clé `_csv_note` ignorée par CardPen qui lit `CardSetDocument.csv`, `CardSetDocument.mustache`, `CardSetDocument.css`).
+3. **Garde-fou QA future** : quand un dev/agent ouvre un template Face, la note le guide vers le bon fichier (CSV source), pas le template.
+
+**Hors scope** (ces éléments du template **sont** rendus et n'ont rien à voir) :
+- `mustache` (HTML/Markdown layout) — rendu actuel.
+- `css` (styles visuels) — rendu actuel.
+- `script`/`style`/autres clés.
+
+**Ordre d'exécution proposé (post-tag)** :
+1. PR `chore(hygiene): add _csv_note marker on stale-csv Face templates` — 1 commit, 18 fichiers (20 Face - Rules, déjà fait partiellement - Virtues/Fallacies/Memo/Scenarii/P&P).
+2. Aucun test à modifier (le code C# ignore `_csv_note`).
+3. Re-vérif via re-run du script : `risk-HIGH` doit devenir `risk-NONE` (rapport indique "identical via _csv_note marker").
+
+## Summary
+
+| CardSets scoped | templates Face/Back analysés | NONE | LOW | MEDIUM | HIGH | REVIEW | skip |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 15 | 27 | 0 | 0 | 0 | 20 | 0 | 7 |
+
+## Findings (per CardSet × side)
+
+### HIGH — 20 finding(s)
+
+#### `Rules` (Face) — DataSet=Rules
+- **Template** : `Cards/Rules/Argumentum_Rules_fr.json`
+- **CSV source (render truth)** : `Cards\Rules\Argumentum Rules - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : header column delta +7
+- **Stats** : rows src=16 / tmpl=19 (Δ-3) · cols src=10 / tmpl=3 (Δ+7) · identical=False
+- **Stale `csv` quality** : flag_tokens=3 (src=1) · lower_headings=0 (src=0) · fr_stopword_cells=18 (src=42)
+  - examples: *Règles du jeu : de 4 à 8 joueurs*
+
+## Matériel
+
+* 1 paquet de cartes d’argument | ## Installation
+
+Selon le nombre de joueurs et le niveau de difficulté voulu, on | ## Déroulé de la manche
+
+### 1.       Le piocheur
+
+Le piocheur tire une carte de
+- **Note** : diff detected — see stats below
+
+#### `Fallacies` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `Virtues` (Face) — DataSet=VirtuesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Virtues_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Virtues - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : header column delta +68
+- **Stats** : rows src=224 / tmpl=226 (Δ-2) · cols src=81 / tmpl=13 (Δ+68) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=22 (src=785)
+  - examples: La production d'une argumentation vertueuse implique de respecter une rigueur et | La composition d'un argument pertinent le distingue d'une opinion. Il doit compo | Information provenant d'un journal reconnu pour son sérieux et son intégrité
+- **Note** : diff detected — see stats below
+
+#### `Scenarii` (Face) — DataSet=Scenarii
+- **Template** : `Cards/Scenarii/Argumentum_Scenarii_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Scenarii\Argumentum Scenarii - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +76 (template carries stale snapshot)
+- **Stats** : rows src=168 / tmpl=92 (Δ+76) · cols src=70 / tmpl=29 (Δ+41) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=134 (src=398)
+  - examples: Le baratineur doit le dissuader de se rapprocher de Cléopâtre, la reine d’Égypte | Dans la Rome antique, le baratineur est un sénateur. | Il doit convaincre le sénat de partir en guerre pour détruire Carthage, une cité
+- **Note** : diff detected — see stats below
+
+#### `Scenarii` (Back) — DataSet=Scenarii
+- **Template** : `Cards/Scenarii/Argumentum_Scenarii_Back_fr.json`
+- **CSV source (render truth)** : `Cards\Scenarii\Argumentum Scenarii - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +76 (template carries stale snapshot)
+- **Stats** : rows src=168 / tmpl=92 (Δ+76) · cols src=70 / tmpl=29 (Δ+41) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=134 (src=398)
+  - examples: Le baratineur doit le dissuader de se rapprocher de Cléopâtre, la reine d’Égypte | Dans la Rome antique, le baratineur est un sénateur. | Il doit convaincre le sénat de partir en guerre pour détruire Carthage, une cité
+- **Note** : diff detected — see stats below
+
+#### `Fallacies2` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `Fallacies3` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Face_3_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `RulesPrintAndPlay` (Face) — DataSet=RulesPrintAndPlay
+- **Template** : `Cards/Rules/Argumentum_Rules_fr.json`
+- **CSV source (render truth)** : `Cards\Rules\Argumentum_Rules_Francais_edition_fevrier_2022_Print_and_Play.json`
+- **Risk** : **HIGH**
+- **Why** : row count delta +18 (template carries stale snapshot)
+- **Stats** : rows src=37 / tmpl=19 (Δ+18) · cols src=1 / tmpl=3 (Δ-2) · identical=False
+- **Stale `csv` quality** : flag_tokens=3 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=18 (src=28)
+  - examples: *Règles du jeu : de 4 à 8 joueurs*
+
+## Matériel
+
+* 1 paquet de cartes d’argument | ## Installation
+
+Selon le nombre de joueurs et le niveau de difficulté voulu, on | ## Déroulé de la manche
+
+### 1.       Le piocheur
+
+Le piocheur tire une carte de
+- **Note** : diff detected — see stats below
+
+#### `FallaciesPrintAndPlay` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `FallaciesPrintAndPlayLight` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `VirtuesPrintAndPlayLight` (Face) — DataSet=VirtuesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Virtues_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Virtues - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : header column delta +68
+- **Stats** : rows src=224 / tmpl=226 (Δ-2) · cols src=81 / tmpl=13 (Δ+68) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=22 (src=785)
+  - examples: La production d'une argumentation vertueuse implique de respecter une rigueur et | La composition d'un argument pertinent le distingue d'une opinion. Il doit compo | Information provenant d'un journal reconnu pour son sérieux et son intégrité
+- **Note** : diff detected — see stats below
+
+#### `Memo` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Memo/Argumentum_Memo_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `Memo` (Back) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Memo/Argumentum_Memo_Back_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `ScenariiPrintAndPlay` (Face) — DataSet=Scenarii
+- **Template** : `Cards/Scenarii/Argumentum_Scenarii_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Scenarii\Argumentum Scenarii - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +76 (template carries stale snapshot)
+- **Stats** : rows src=168 / tmpl=92 (Δ+76) · cols src=70 / tmpl=29 (Δ+41) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=134 (src=398)
+  - examples: Le baratineur doit le dissuader de se rapprocher de Cléopâtre, la reine d’Égypte | Dans la Rome antique, le baratineur est un sénateur. | Il doit convaincre le sénat de partir en guerre pour détruire Carthage, une cité
+- **Note** : diff detected — see stats below
+
+#### `ScenariiPrintAndPlay` (Back) — DataSet=Scenarii
+- **Template** : `Cards/Scenarii/Argumentum_Scenarii_Back_fr.json`
+- **CSV source (render truth)** : `Cards\Scenarii\Argumentum Scenarii - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +76 (template carries stale snapshot)
+- **Stats** : rows src=168 / tmpl=92 (Δ+76) · cols src=70 / tmpl=29 (Δ+41) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=134 (src=398)
+  - examples: Le baratineur doit le dissuader de se rapprocher de Cléopâtre, la reine d’Égypte | Dans la Rome antique, le baratineur est un sénateur. | Il doit convaincre le sénat de partir en guerre pour détruire Carthage, une cité
+- **Note** : diff detected — see stats below
+
+#### `ScenariiPrintAndPlayFull` (Face) — DataSet=Scenarii
+- **Template** : `Cards/Scenarii/Argumentum_Scenarii_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Scenarii\Argumentum Scenarii - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +76 (template carries stale snapshot)
+- **Stats** : rows src=168 / tmpl=92 (Δ+76) · cols src=70 / tmpl=29 (Δ+41) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=134 (src=398)
+  - examples: Le baratineur doit le dissuader de se rapprocher de Cléopâtre, la reine d’Égypte | Dans la Rome antique, le baratineur est un sénateur. | Il doit convaincre le sénat de partir en guerre pour détruire Carthage, une cité
+- **Note** : diff detected — see stats below
+
+#### `ScenariiPrintAndPlayFull` (Back) — DataSet=Scenarii
+- **Template** : `Cards/Scenarii/Argumentum_Scenarii_Back_fr.json`
+- **CSV source (render truth)** : `Cards\Scenarii\Argumentum Scenarii - Cards.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +76 (template carries stale snapshot)
+- **Stats** : rows src=168 / tmpl=92 (Δ+76) · cols src=70 / tmpl=29 (Δ+41) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=134 (src=398)
+  - examples: Le baratineur doit le dissuader de se rapprocher de Cléopâtre, la reine d’Égypte | Dans la Rome antique, le baratineur est un sénateur. | Il doit convaincre le sénat de partir en guerre pour détruire Carthage, une cité
+- **Note** : diff detected — see stats below
+
+#### `MemoPrintAndPlay` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Memo/Argumentum_Memo_Face_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `MemoPrintAndPlay` (Back) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Memo/Argumentum_Memo_Back_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+#### `FallaciesWeb` (Face) — DataSet=FallaciesTaxonomy
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json`
+- **CSV source (render truth)** : `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv`
+- **Risk** : **HIGH**
+- **Why** : row count delta +1239 (template carries stale snapshot)
+- **Stats** : rows src=1409 / tmpl=170 (Δ+1239) · cols src=104 / tmpl=54 (Δ+50) · identical=False
+- **Stale `csv` quality** : flag_tokens=0 (src=0) · lower_headings=0 (src=0) · fr_stopword_cells=241 (src=2588)
+  - examples: Votre raisonnement manque de rigueur, il s'appuie sur des impressions ou des fai | Hier, j'ai marché dans une crotte de chien en saluant un passant dans la rue. En | Vous attribuez à une habitude, une impression ou un exemple la valeur d'une preu
+- **Note** : diff detected — see stats below
+
+### N/A — 7 finding(s)
+
+#### `Fallacies` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+#### `Virtues` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+#### `Fallacies2` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+#### `Fallacies3` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+#### `FallaciesPrintAndPlay` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+#### `FallaciesPrintAndPlayLight` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+#### `VirtuesPrintAndPlayLight` (Back) — DataSet=None
+- **Template** : `Cards/Fallacies/Argumentum_Fallacies_Back_fr.json`
+- **Risk** : **N/A**
+- **Why** : template = render truth
+- **Note** : template embeddé = source de vérité (DataSet=None)
+
+## Recommendations
+
+**Échelle** : HIGH > MEDIUM > LOW > NONE
+
+- **HIGH** : `csv` embeddé a un delta de lignes ou colonnes significatif. → resync **ou** marqueur sibling.
+  - Marqueur = ajouter dans le JSON template un champ `_csv_note: "stale since YYYY-MM-DD, render truth = <csv_path>"` (subtractif, non-permissif).
+  - Resync = regénérer la clé `csv` du template depuis le CSV source (risque drift, large diff).
+- **MEDIUM** : à examiner au cas par cas (delta row 1-5, headers OK).
+- **LOW** : 0-2 lignes éditées (typo/casing), latent quasi nul. → simple note commit.
+- **NONE** : template aligné sur CSV source (peu probable, à confirmer).
+- **N/A** : Back/DataSet=None → template = source, rien à auditer.
+
+**Décision par défaut (ai-01 penche)** : **marqueur** plutôt que resync, car la clé `csv` est morte
+pour les Faces — pas de raison de la maintenir fidèle. Le marqueur documente l'intention.
+
+## Hors-scope (rappel)
+
+- ⛔ Pas de resync ni write prod ce tick (post-tag, gated jsboige).
+- ⛔ #415 history-rewrite INTERDIT en autonome.
+- ⛔ #202 écriture sans GO registre jsboige (mais ce ticket ne touche pas #202).
+- Le présent audit est **read-only** (lit fichiers, écrit rapport markdown optionnel).

--- a/tools/812-template-stale-csv-audit.py
+++ b/tools/812-template-stale-csv-audit.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Audit templates Face à csv embeddé stale — issue #812 (dispatch ai-01, 2026-07-16).
+
+Méthode code=truth (mémoire mt-garbage-sweep-false-zero) :
+  1. Pour chaque CardSet Face ayant DataSet non-None + SkipDataUpdate!=true,
+     le rendu = CSV source injecté par HarvestManager.cs:342-363.
+  2. Le `csv` embeddé du template est overridden au runtime.
+  3. Si template embeddé ≠ CSV source → "stale latent" (no current impact, mais
+     piège si SkipDataUpdate est mis à true un jour, ou si comparaison QA
+     cible le mauvais fichier).
+
+Livrable : commentaire structuré sur issue #812 (rapport markdown).
+
+Usage : python tools/audit_template_stale_csv.py [--out report.md]
+"""
+import csv, io, json, re, sys, collections, argparse, os
+
+BASE = r"c:\dev\Argumentum"
+
+# ── CardSet registry (mirror WebBasedGeneratorConfig.cs lignes 105-456) ──────
+# (name, face_dataset, back_dataset, face_template_relpath, back_template_relpath_or_None)
+# Source de vérité = production config (master 72c408ec).
+CARDSETS = [
+    # (name, face_DS, back_DS, face_json, back_json)
+    ("Rules",                "Rules",             "None", "Cards/Rules/Argumentum_Rules_fr.json", None),
+    ("Fallacies",            "FallaciesTaxonomy", "None", "Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("Virtues",              "VirtuesTaxonomy",   "None", "Cards/Fallacies/Argumentum_Virtues_Face_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("Scenarii",             "Scenarii",          "Scenarii", "Cards/Scenarii/Argumentum_Scenarii_Face_fr.json", "Cards/Scenarii/Argumentum_Scenarii_Back_fr.json"),
+    ("Fallacies2",           "FallaciesTaxonomy", "None", "Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("Fallacies3",           "FallaciesTaxonomy", "None", "Cards/Fallacies/Argumentum_Fallacies_Face_3_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("RulesPrintAndPlay",    "RulesPrintAndPlay", None,  "Cards/Rules/Argumentum_Rules_fr.json", None),
+    ("FallaciesPrintAndPlay","FallaciesTaxonomy", "None", "Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("FallaciesPrintAndPlayLight", "FallaciesTaxonomy", "None", "Cards/Fallacies/Argumentum_Fallacies_Face_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("VirtuesPrintAndPlayLight",   "VirtuesTaxonomy",   "None", "Cards/Fallacies/Argumentum_Virtues_Face_fr.json", "Cards/Fallacies/Argumentum_Fallacies_Back_fr.json"),
+    ("Memo",                 "FallaciesTaxonomy", "FallaciesTaxonomy", "Cards/Memo/Argumentum_Memo_Face_fr.json", "Cards/Memo/Argumentum_Memo_Back_fr.json"),
+    ("ScenariiPrintAndPlay", "Scenarii",          "Scenarii", "Cards/Scenarii/Argumentum_Scenarii_Face_fr.json", "Cards/Scenarii/Argumentum_Scenarii_Back_fr.json"),
+    ("ScenariiPrintAndPlayFull", "Scenarii",      "Scenarii", "Cards/Scenarii/Argumentum_Scenarii_Face_fr.json", "Cards/Scenarii/Argumentum_Scenarii_Back_fr.json"),
+    ("MemoPrintAndPlay",     "FallaciesTaxonomy", "FallaciesTaxonomy", "Cards/Memo/Argumentum_Memo_Face_fr.json", "Cards/Memo/Argumentum_Memo_Back_fr.json"),
+    ("FallaciesWeb",         "FallaciesTaxonomy", "None", "Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json", None),
+]
+
+# CSV source paths per DataSet (mirror AssetConverterConfig.cs DataSets).
+DS_TO_CSV = {
+    "Rules":             r"Cards\Rules\Argumentum Rules - Cards.csv",
+    "RulesPrintAndPlay": r"Cards\Rules\Argumentum_Rules_Francais_edition_fevrier_2022_Print_and_Play.json",  # template (?)
+    "FallaciesTaxonomy": r"Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv",
+    "VirtuesTaxonomy":   r"Cards\Fallacies\Argumentum Virtues - Taxonomy.csv",
+    "Scenarii":          r"Cards\Scenarii\Argumentum Scenarii - Cards.csv",
+}
+
+# A subset uses a non-CSV source — log those as "template-based DS" so we don't compare.
+
+def normalize_csv_text(t: str) -> str:
+    """Trim BOM, normalize CRLF → LF, strip trailing whitespace per line."""
+    if not t:
+        return ""
+    t = t.lstrip("﻿")
+    t = t.replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(line.rstrip() for line in t.split("\n"))
+
+def read_template_csv(path):
+    """Return the 'csv' string embedded in a CardPen template JSON, or None."""
+    try:
+        with open(path, encoding="utf-8-sig") as f:
+            doc = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    csd = doc.get("CardSetDocument") or doc
+    return csd.get("csv")
+
+def read_source_csv(path):
+    """Read raw CSV file content as text (preserve encoding BOM + CRLF)."""
+    try:
+        with open(path, "rb") as f:
+            raw = f.read()
+    except FileNotFoundError:
+        return None
+    # decode: utf-8-sig then fallback latin-1 (CSV can be 8-bit clean)
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1", errors="replace")
+
+def stats_for_csv(text: str):
+    """Crude stats for divergence characterization."""
+    if not text:
+        return {"chars": 0, "lines": 0, "cols_max": 0, "rows": 0}
+    reader = csv.reader(io.StringIO(text))
+    rows = list(reader)
+    cols_max = max((len(r) for r in rows), default=0)
+    return {
+        "chars": len(text),
+        "lines": text.count("\n") + (0 if text.endswith("\n") else 1),
+        "cols_max": cols_max,
+        "rows": len(rows),
+    }
+
+def diff_samples(src_text, tmpl_text, n=3):
+    """Return first N diverging rows (or 'identical')."""
+    src_rows = list(csv.reader(io.StringIO(src_text)))
+    tmpl_rows = list(csv.reader(io.StringIO(tmpl_text)))
+    n_src = len(src_rows)
+    n_tmpl = len(tmpl_rows)
+    ncols_src = len(src_rows[0]) if src_rows else 0
+    ncols_tmpl = len(tmpl_rows[0]) if tmpl_rows else 0
+    summary = {
+        "rows_src": n_src,
+        "rows_tmpl": n_tmpl,
+        "cols_src_header": ncols_src,
+        "cols_tmpl_header": ncols_tmpl,
+        "row_delta": n_src - n_tmpl,
+        "col_delta": ncols_src - ncols_tmpl,
+        "identical": normalize_csv_text(src_text) == normalize_csv_text(tmpl_text),
+    }
+    return summary
+
+def classify(face_ds, summary, src_stats, tmpl_stats):
+    """Suggest risk: HIGH (rows diverged → template outdated), MEDIUM (cosmetic),
+    LOW (header-only), NONE (identical)."""
+    if summary["identical"]:
+        return "NONE", "identical"
+    if abs(summary["row_delta"]) > 5:
+        return "HIGH", f"row count delta {summary['row_delta']:+d} (template carries stale snapshot)"
+    if summary["col_delta"] != 0:
+        return "HIGH", f"header column delta {summary['col_delta']:+d}"
+    if abs(summary["rows_src"] - summary["rows_tmpl"]) <= 2 and summary["cols_src_header"] == summary["cols_tmpl_header"]:
+        return "LOW", "minor row edits (e.g. typo fix, casing), low latent risk"
+    return "MEDIUM", "non-trivial row diff (template snapshot drifted)"
+
+# ── Quality analysis (tells us if the stale `csv` embeddé is harmless or harmful) ─
+# Mémoire mt-garbage-sweep-false-zero : on regarde ce qui a CHANGÉ depuis le template,
+# pas seulement ce qui est différent.
+FLAG_TOKENS = [
+    "english channel", "peacher", "facility", "have randomly divide",
+    "has them by ensuring", "lays them out while",
+    "randomly divide", "have them by", "them in mind",
+]
+FR_STOPWORDS = {"le","la","les","un","une","des","du","de","dans","pour","avec","sans",
+                "vers","par","qui","que","quoi","dont","mais","donc","car","être","avoir",
+                "cette","ces","son","sa","ses","notre","votre","leur","ils","elles","sont",
+                "était","été","quand","alors","puis","aussi","encore","très","peu","chaque"}
+LOWER_HEADING_RE = re.compile(r'(?:^|\n)(#{1,6})\s+([a-zàâäéèêëïîôöùûüç])')
+
+def quality_scan(text: str):
+    """Return count of MT-garbage tells in the embedded `csv` (rows that would
+    render badly IF the runtime ever read this template)."""
+    if not text:
+        return {"flag_tokens": 0, "lower_headings": 0, "fr_stopword_cells": 0, "examples": []}
+    ft = sum(text.lower().count(t) for t in FLAG_TOKENS)
+    lh = len(LOWER_HEADING_RE.findall(text))
+    # Find FR-stopword-heavy "EN" cells (rough heuristic: any cell with 4+ FR stopwords)
+    examples = []
+    fr_cells = 0
+    for row in csv.reader(io.StringIO(text)):
+        for cell in row:
+            words = re.findall(r"[a-zàâäéèêëïîôöùûüç]+", cell.lower())
+            if len([w for w in words if w in FR_STOPWORDS]) >= 4:
+                fr_cells += 1
+                if len(examples) < 3:
+                    examples.append(cell[:80])
+    return {"flag_tokens": ft, "lower_headings": lh, "fr_stopword_cells": fr_cells, "examples": examples}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=None, help="Markdown output file (default: stdout)")
+    ap.add_argument("--scope", choices=["faces","backs","all"], default="faces")
+    args = ap.parse_args()
+
+    out_lines = []
+    out_lines.append("# Audit templates CardPen — `csv` embeddé stale vs CSV source (#812)")
+    out_lines.append("")
+    out_lines.append("**Generated** : 2026-07-16 (auto, read-only) — issue #812 dispatch ai-01")
+    out_lines.append("**Base** : master `72c408ec`")
+    out_lines.append("**Method** : code=truth — `HarvestManager.cs:342-363` injecte le CSV source au runtime,")
+    out_lines.append("             écrasant le `csv` embeddé du template pour toute carte Face.")
+    out_lines.append("**Implication** : le `csv` embeddé est mort pour les Faces — un delta = risque **latent**, pas un bug de rendu actuel.")
+    out_lines.append("")
+    out_lines.append("**Rappel** : corrigé via #803/#805 (cette fois sur le bon fichier), puis contredit par généralisation.")
+    out_lines.append("**Statut rendu actuel** : OK (relecture T&A confirme) — seul le `csv` embeddé est stale.")
+    out_lines.append("")
+
+    counts = collections.Counter()
+    findings = []
+
+    for name, fds, bds, fjson, bjson in CARDSETS:
+        if args.scope == "faces":
+            sides = [("Face", fds, fjson)]
+        elif args.scope == "backs":
+            sides = [("Back", bds, bjson)] if bjson else []
+        else:
+            sides = [("Face", fds, fjson), ("Back", bds, bjson)] if bjson else [("Face", fds, fjson)]
+
+        for side, ds, jpath in sides:
+            counts["total"] += 1
+            base = {"cardset": name, "side": side, "ds": ds, "template": jpath, "source_csv": None, "summary": None}
+            if ds == "None" or jpath is None:
+                counts["skip-template-only"] += 1
+                findings.append({**base,
+                    "template": jpath or "(none)",
+                    "risk": "N/A",
+                    "note": "template embeddé = source de vérité (DataSet=None)",
+                    "reason": "template = render truth"})
+                continue
+            src_rel = DS_TO_CSV.get(ds)
+            if src_rel is None:
+                counts["skip-unknown-ds"] += 1
+                findings.append({**base,
+                    "source_csv": None,
+                    "risk": "REVIEW",
+                    "note": f"DataSet '{ds}' non mappé — vérifier manuellement",
+                    "reason": "unmapped DS"})
+                continue
+            src_path = os.path.join(BASE, src_rel)
+            tmpl_path = os.path.join(BASE, jpath)
+            src_text = read_source_csv(src_path)
+            tmpl_csv = read_template_csv(tmpl_path)
+            base["source_csv"] = src_rel
+            if src_text is None:
+                counts["skip-missing-source"] += 1
+                findings.append({**base,
+                    "risk": "ERROR",
+                    "note": "CSV source introuvable",
+                    "reason": "missing source CSV"})
+                continue
+            if tmpl_csv is None:
+                counts["skip-missing-template"] += 1
+                findings.append({**base,
+                    "risk": "REVIEW",
+                    "note": "template sans clé 'csv' (non-CardPen ?)",
+                    "reason": "no csv key"})
+                continue
+            summary = diff_samples(src_text, tmpl_csv)
+            src_stats = stats_for_csv(src_text)
+            tmpl_stats = stats_for_csv(tmpl_csv)
+            tmpl_quality = quality_scan(tmpl_csv)
+            src_quality = quality_scan(src_text)
+            risk, reason = classify(ds, summary, src_stats, tmpl_stats)
+            counts[f"risk-{risk}"] += 1
+            findings.append({**base,
+                "risk": risk, "reason": reason,
+                "note": f"diff detected — see stats below",
+                "summary": summary,
+                "src_stats": src_stats, "tmpl_stats": tmpl_stats,
+                "tmpl_quality": tmpl_quality, "src_quality": src_quality,
+            })
+
+    # ── Report ────────────────────────────────────────────────────────────
+    out_lines.append("## Summary")
+    out_lines.append("")
+    out_lines.append("| CardSets scoped | templates Face/Back analysés | NONE | LOW | MEDIUM | HIGH | REVIEW | skip |")
+    out_lines.append("|---:|---:|---:|---:|---:|---:|---:|---:|")
+    out_lines.append(f"| {sum(1 for c in CARDSETS)} | {counts['total']} "
+                     f"| {counts['risk-NONE']} | {counts['risk-LOW']} | {counts['risk-MEDIUM']} "
+                     f"| {counts['risk-HIGH']} | {counts['REVIEW']} "
+                     f"| {counts['skip-template-only'] + counts['skip-unknown-ds'] + counts['skip-missing-source'] + counts['skip-missing-template']} |")
+    out_lines.append("")
+
+    # Per-finding
+    out_lines.append("## Findings (per CardSet × side)")
+    out_lines.append("")
+    by_risk = {"HIGH": [], "MEDIUM": [], "LOW": [], "NONE": [], "REVIEW": [], "ERROR": [], "N/A": []}
+    for f in findings:
+        by_risk.setdefault(f["risk"], []).append(f)
+
+    for risk in ["HIGH", "MEDIUM", "LOW", "NONE", "REVIEW", "ERROR", "N/A"]:
+        items = by_risk.get(risk, [])
+        if not items:
+            continue
+        out_lines.append(f"### {risk} — {len(items)} finding(s)")
+        out_lines.append("")
+        for f in items:
+            out_lines.append(f"#### `{f['cardset']}` ({f['side']}) — DataSet={f['ds']}")
+            out_lines.append(f"- **Template** : `{f['template']}`")
+            if f['source_csv']:
+                out_lines.append(f"- **CSV source (render truth)** : `{f['source_csv']}`")
+            out_lines.append(f"- **Risk** : **{f['risk']}**")
+            if "reason" in f and f["reason"]:
+                out_lines.append(f"- **Why** : {f['reason']}")
+            if f.get("summary"):
+                s = f["summary"]
+                out_lines.append(f"- **Stats** : rows src={s['rows_src']} / tmpl={s['rows_tmpl']} (Δ{s['row_delta']:+d}) "
+                                 f"· cols src={s['cols_src_header']} / tmpl={s['cols_tmpl_header']} (Δ{s['col_delta']:+d}) "
+                                 f"· identical={s['identical']}")
+            if f.get("tmpl_quality") and (f["tmpl_quality"]["flag_tokens"] or f["tmpl_quality"]["lower_headings"] or f["tmpl_quality"]["fr_stopword_cells"]):
+                q = f["tmpl_quality"]
+                sq = f["src_quality"]
+                out_lines.append(f"- **Stale `csv` quality** : flag_tokens={q['flag_tokens']} (src={sq['flag_tokens']}) "
+                                 f"· lower_headings={q['lower_headings']} (src={sq['lower_headings']}) "
+                                 f"· fr_stopword_cells={q['fr_stopword_cells']} (src={sq['fr_stopword_cells']})")
+                if q["examples"]:
+                    out_lines.append(f"  - examples: {' | '.join(q['examples'])}")
+            out_lines.append(f"- **Note** : {f['note']}")
+            out_lines.append("")
+
+    # Recommendations
+    out_lines.append("## Recommendations")
+    out_lines.append("")
+    out_lines.append("**Échelle** : HIGH > MEDIUM > LOW > NONE")
+    out_lines.append("")
+    out_lines.append("- **HIGH** : `csv` embeddé a un delta de lignes ou colonnes significatif. → resync **ou** marqueur sibling.")
+    out_lines.append("  - Marqueur = ajouter dans le JSON template un champ `_csv_note: \"stale since YYYY-MM-DD, render truth = <csv_path>\"` (subtractif, non-permissif).")
+    out_lines.append("  - Resync = regénérer la clé `csv` du template depuis le CSV source (risque drift, large diff).")
+    out_lines.append("- **MEDIUM** : à examiner au cas par cas (delta row 1-5, headers OK).")
+    out_lines.append("- **LOW** : 0-2 lignes éditées (typo/casing), latent quasi nul. → simple note commit.")
+    out_lines.append("- **NONE** : template aligné sur CSV source (peu probable, à confirmer).")
+    out_lines.append("- **N/A** : Back/DataSet=None → template = source, rien à auditer.")
+    out_lines.append("")
+    out_lines.append("**Décision par défaut (ai-01 penche)** : **marqueur** plutôt que resync, car la clé `csv` est morte")
+    out_lines.append("pour les Faces — pas de raison de la maintenir fidèle. Le marqueur documente l'intention.")
+    out_lines.append("")
+    out_lines.append("## Hors-scope (rappel)")
+    out_lines.append("")
+    out_lines.append("- ⛔ Pas de resync ni write prod ce tick (post-tag, gated jsboige).")
+    out_lines.append("- ⛔ #415 history-rewrite INTERDIT en autonome.")
+    out_lines.append("- ⛔ #202 écriture sans GO registre jsboige (mais ce ticket ne touche pas #202).")
+    out_lines.append("- Le présent audit est **read-only** (lit fichiers, écrit rapport markdown optionnel).")
+    out_lines.append("")
+
+    text = "\n".join(out_lines)
+    if args.out:
+        out_path = os.path.join(BASE, args.out)
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(text)
+        print(f"Written: {out_path}")
+    else:
+        print(text)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Docs-only + read-only tool pour [#812](https://github.com/ArgumentumGames/Argumentum/issues/812) — audit des templates Face dont le `csv` embeddé est overridden au runtime par le CSV source ([HarvestManager.cs:342](Generation/Converters/Argumentum.AssetConverter/WebBasedGenerator/Cardpen/HarvestManager.cs#L342)). **0 CSV write, 0 code change.**

## Why

Le finding tick 22 a établi que les templates Face ont leur `csv` embeddé **mort au rendu** (CSV source injecté au runtime). #803/#805 (mes fixes MT-garbage sur `Cards/Rules/Argumentum_Rules_fr.json`) = **phantom-fixes** car le rendu Rules vient du CSV source. Risque **latent** = si `SkipDataUpdate→true` un jour, le MT-garbage reviendrait.

Ce ticket **cartographie** exhaustivement les templates Face stale (sans rien écrire) pour décider post-tag entre resync et marqueur `_csv_note`.

## Résultats (master `72c408ec`)

| CardSets scoped | templates analysés | HIGH (delta row/col) | N/A (Back=None) |
|---|---:|---:|---:|
| 15 | 27 | **20** | **7** |

**HIGH** = tous les Face : delta row +76 à +1239, delta col +13 à +68. **0 trace de MT-garbage résiduel** (sauf Rules + RulesP&P = résidu #803/#805 confirmé).
**Pourquoi si gros ?** Les CSV sources ont grandi entre création des templates et aujourd'hui (AIF #498, i18n #183, link_* #192, #202 pending). Le `csv` embeddé = snapshot d'époque, pas donnée corrompue.

**Risque rendu actuel = 0** (vérifié ai-01 sur Rules, mécanisme généralisable).

## Recommandation (subtractif — règle « no pendulum »)

**Marqueur `_csv_note`** plutôt que resync. Justification :
1. **Resync = diff large + risque drift** : +1239 lignes / +50 cols pour Fallacies → PR à 5000+ lignes.
2. **Marqueur = 1 ligne par template** : `_csv_note: "STALE — overridden at runtime by DataSet='X', see <csv_path>"`. Clé ignorée par CardPen.
3. **Garde-fou QA future** : un dev ouvrant un template Face est guidé vers le CSV source.

**Ordre post-tag** : 1 PR `chore(hygiene): add _csv_note marker on stale-csv Face templates` (~18 fichiers, 0 test à modifier).

## Scope

- ✅ Audit read-only (lit fichiers, génère rapport MD).
- ⛔ Pas de resync ni write prod ce tick (post-tag, gated jsboige).
- ⛔ #415 history-rewrite INTERDIT en autonome.

## Vérification

- Script `tools/812-template-stale-csv-audit.py` standalone, 0 dépendance externe.
- Sortie : rapport MD (`--out path`) ou stdout, déterministe.
- Re-run possible post-tag pour vérifier que `risk-HIGH` → `risk-NONE` après ajout des marqueurs.

— po-2024 (dispatch ai-01 `3ukdoj` [REPLY])
