### PR TITLE
chore(hygiene): add _csv_note marker on stale-csv CardPen templates (HOLD post-tag, #812)

### DIFF
--- a/Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json
+++ b/Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "Famille_camelCase",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='FallaciesTaxonomy' (see Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Fallacies/Argumentum_Fallacies_Face_3_fr.json
+++ b/Cards/Fallacies/Argumentum_Fallacies_Face_3_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "Famille_camelCase",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='FallaciesTaxonomy' (see Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json
+++ b/Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "Famille_camelCase",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='FallaciesTaxonomy' (see Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Fallacies/Argumentum_Fallacies_Face_fr.json
+++ b/Cards/Fallacies/Argumentum_Fallacies_Face_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "Famille_camelCase",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='FallaciesTaxonomy' (see Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Fallacies/Argumentum_Virtues_Face_fr.json
+++ b/Cards/Fallacies/Argumentum_Virtues_Face_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "family_fr_camelcase",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='VirtuesTaxonomy' (see Cards\\Fallacies\\Argumentum Virtues - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Memo/Argumentum_Memo_Back_fr.json
+++ b/Cards/Memo/Argumentum_Memo_Back_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "",
     "rscount": 200,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='FallaciesTaxonomy (carte filter)' (see Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Memo/Argumentum_Memo_Face_fr.json
+++ b/Cards/Memo/Argumentum_Memo_Face_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "Famille_camelCase",
     "rscount": 200,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='FallaciesTaxonomy (carte filter)' (see Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Rules/Argumentum_Rules_fr.json
+++ b/Cards/Rules/Argumentum_Rules_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='Rules' (see Cards\\Rules\\Argumentum Rules - Cards.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Scenarii/Argumentum_Scenarii_Back_fr.json
+++ b/Cards/Scenarii/Argumentum_Scenarii_Back_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "",
     "rscount": 14,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='Scenarii' (see Cards\\Scenarii\\Argumentum Scenarii - Cards.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/Cards/Scenarii/Argumentum_Scenarii_Face_fr.json
+++ b/Cards/Scenarii/Argumentum_Scenarii_Face_fr.json
@@ -33,5 +33,6 @@
     "cardClass": "",
     "rscount": 1,
     "rsstyle": "bunch",
-    "cindices": ""
+    "cindices": "",
+    "_csv_note": "STALE — overridden at runtime by DataSet='Scenarii' (see Cards\\Scenarii\\Argumentum Scenarii - Cards.csv). Embedded `csv` is a snapshot from template creation (PR #813 audit, #812 fix). CardPen reads `csv`/`mustache`/`css`; this key is ignored."
 }

--- a/tools/812-csv-note-marker-apply.py
+++ b/tools/812-csv-note-marker-apply.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Apply _csv_note marker to 10 HIGH-stale CardPen templates (issue #812).
+
+For each template JSON, inserts one top-level key `_csv_note` whose value
+explains that the embedded `csv` is a snapshot (overridden at runtime by
+the CSV source via HarvestManager.cs:342). Ignored by CardPen (which reads
+`csv`/`mustache`/`css`). Add-only, no diff beyond the new key.
+
+Safety:
+- UTF-8 no-BOM preserved (templates are no-BOM, verified)
+- CRLF preserved (CardPen / PapaParse expects CRLF, templates use CRLF)
+- Atomic write (read all → modify → write all)
+- JSON validity verified post-write via json.loads
+- Idempotent: skip if `_csv_note` already present
+"""
+import json, sys, os
+
+# Path → DataSet description (CSV source render truth)
+TARGETS = [
+    ("Cards/Rules/Argumentum_Rules_fr.json",
+     "Rules",
+     "Cards\\Rules\\Argumentum Rules - Cards.csv"),
+    ("Cards/Fallacies/Argumentum_Fallacies_Face_fr.json",
+     "FallaciesTaxonomy",
+     "Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv"),
+    ("Cards/Fallacies/Argumentum_Virtues_Face_fr.json",
+     "VirtuesTaxonomy",
+     "Cards\\Fallacies\\Argumentum Virtues - Taxonomy.csv"),
+    ("Cards/Scenarii/Argumentum_Scenarii_Face_fr.json",
+     "Scenarii",
+     "Cards\\Scenarii\\Argumentum Scenarii - Cards.csv"),
+    ("Cards/Scenarii/Argumentum_Scenarii_Back_fr.json",
+     "Scenarii",
+     "Cards\\Scenarii\\Argumentum Scenarii - Cards.csv"),
+    ("Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json",
+     "FallaciesTaxonomy",
+     "Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv"),
+    ("Cards/Fallacies/Argumentum_Fallacies_Face_3_fr.json",
+     "FallaciesTaxonomy",
+     "Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv"),
+    ("Cards/Memo/Argumentum_Memo_Face_fr.json",
+     "FallaciesTaxonomy (carte filter)",
+     "Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv"),
+    ("Cards/Memo/Argumentum_Memo_Back_fr.json",
+     "FallaciesTaxonomy (carte filter)",
+     "Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv"),
+    ("Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json",
+     "FallaciesTaxonomy",
+     "Cards\\Fallacies\\Argumentum Fallacies - Taxonomy.csv"),
+]
+
+
+def detect_eol(raw: bytes) -> str:
+    return "\r\n" if b"\r\n" in raw else "\n"
+
+
+def add_csv_note(path: str, dataset: str, csv_src: str, dry_run: bool = False) -> str:
+    with open(path, "rb") as f:
+        raw = f.read()
+    bom = raw[:3] == b"\xef\xbb\xbf"
+    eol = detect_eol(raw)
+    text = raw.decode("utf-8-sig")  # strips BOM if any
+
+    if "_csv_note" in text:
+        return "SKIP (already present)"
+
+    d = json.loads(text)
+    if "_csv_note" in d:
+        return "SKIP (already present in dict)"
+
+    note = (f"STALE — overridden at runtime by DataSet='{dataset}' "
+            f"(see {csv_src}). Embedded `csv` is a snapshot from template "
+            f"creation (PR #813 audit, #812 fix). CardPen reads `csv`/"
+            f"`mustache`/`css`; this key is ignored.")
+    d["_csv_note"] = note
+
+    # Serialize preserving 4-space indent + eol (Python json.dumps default LF)
+    new_text = json.dumps(d, indent=4, ensure_ascii=False)
+    if eol == "\r\n":
+        new_text = new_text.replace("\n", "\r\n")
+
+    out_bytes = new_text.encode("utf-8")
+    if bom:
+        out_bytes = b"\xef\xbb\xbf" + out_bytes
+
+    # Sanity: must remain valid JSON
+    json.loads(new_text)
+
+    if not dry_run:
+        with open(path, "wb") as f:
+            f.write(out_bytes)
+
+    return f"OK ({len(raw)} → {len(out_bytes)} bytes)"
+
+
+def main():
+    dry = "--dry-run" in sys.argv
+    print(f"=== Apply _csv_note marker ({len(TARGETS)} templates) {'[DRY RUN]' if dry else ''} ===")
+    print()
+    for path, dataset, csv_src in TARGETS:
+        if not os.path.exists(path):
+            print(f"{path} | MISSING")
+            continue
+        result = add_csv_note(path, dataset, csv_src, dry_run=dry)
+        print(f"{path} | {result}")
+    print()
+    if dry:
+        print("Re-run without --dry-run to apply.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# chore(hygiene): add `_csv_note` marker on stale-csv CardPen templates (HOLD post-tag, #812)

## What

Add subtractif `_csv_note` marker on 10 CardPen templates flagged HIGH in PR #813 audit. **1 line per template**, **0 test change**, **no prod write**.

## Why

PR #813 audit (`docs/investigations/2026-07-16-audit-template-stale-csv.md`) established that 20/27 CardPen templates carry an embedded `csv` field that is overridden at runtime by `HarvestManager.cs:342` (which injects the CSV source if the CardSet has a non-null `DataSet`).

Re-syncing the embedded `csv` from the CSV source would generate a +5000-line diff (Fallacies alone: +1239 rows, +50 cols) and would be re-overridden on the next regen. The audit recommended a **subtractif** marker instead.

This PR implements that recommendation by adding a `_csv_note` top-level JSON key whose value documents which `DataSet` and CSV source actually drives the render. CardPen reads `csv` / `mustache` / `css` only, so `_csv_note` is **ignored at render time**.

## Scope (10 templates, all Face / Back with DataSet bound)

| Template | DataSet | CSV source (render truth) |
|---|---|---|
| `Cards/Rules/Argumentum_Rules_fr.json` | `Rules` | `Cards\Rules\Argumentum Rules - Cards.csv` |
| `Cards/Fallacies/Argumentum_Fallacies_Face_fr.json` | `FallaciesTaxonomy` | `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv` |
| `Cards/Fallacies/Argumentum_Fallacies_Face_2_fr.json` | `FallaciesTaxonomy` | idem |
| `Cards/Fallacies/Argumentum_Fallacies_Face_3_fr.json` | `FallaciesTaxonomy` | idem |
| `Cards/Fallacies/Argumentum_Fallacies_Face_Web_fr.json` | `FallaciesTaxonomy` | idem |
| `Cards/Fallacies/Argumentum_Virtues_Face_fr.json` | `VirtuesTaxonomy` | `Cards\Fallacies\Argumentum Virtues - Taxonomy.csv` |
| `Cards/Scenarii/Argumentum_Scenarii_Face_fr.json` | `Scenarii` | `Cards\Scenarii\Argumentum Scenarii - Cards.csv` |
| `Cards/Scenarii/Argumentum_Scenarii_Back_fr.json` | `Scenarii` | idem |
| `Cards/Memo/Argumentum_Memo_Face_fr.json` | `FallaciesTaxonomy (carte filter)` | `Cards\Fallacies\Argumentum Fallacies - Taxonomy.csv` |
| `Cards/Memo/Argumentum_Memo_Back_fr.json` | `FallaciesTaxonomy (carte filter)` | idem |

**Not touched (already N/A in audit):** `Argumentum_Fallacies_Back_fr.json` × 6 CardSets — `DataSet = None`, embedded `csv` IS the render truth. Marker would be misleading.

## Diff

```
 11 files changed, 133 insertions(+), 10 deletions(-)
 - 10 template JSON files: +20 -10 (1 line + comma each)
 - 1 new tool: tools/812-csv-note-marker-apply.py (123 insertions, 0 deletions)
```

The +123 for the tool is its source; the per-template diff is purely `,"_csv_note": "..."` after the last existing key.

## Verification (subtractif check)

- **JSON validity:** each post-write file re-parses via `json.loads()` without error.
- **Encoding:** every template remains UTF-8 no-BOM, CRLF.
- **CardPen impact:** zero. `_csv_note` is added as a new top-level key; CardPen reads only `csv` / `mustache` / `css` (verified `HarvestManager.cs` only writes `CardSetDocument.csv = csvContent`).
- **C# build:** `dotnet build Argumentum Converters.sln` → 0 warnings, 0 errors.
- **Audit re-run:** re-running `tools/812-template-stale-csv-audit.py` keeps reporting HIGH (the stale `csv` is still there by design), but a future agent can grep `_csv_note` to know whether the drift is acknowledged.

## Out of scope (NOT this PR)

- ⛔ **Resync of embedded `csv`** from CSV source (rejected — see #813 + this PR's rationale).
- ⛔ **Add markers to `Fallacies_Back_fr.json`** (6 variants). `DataSet = None` → template is the source of truth, marker would be misleading.
- ⛔ **Audit reclassification message.** The audit tool could be updated later to recognize `_csv_note` and report `risk-REVIEWED` instead of `risk-HIGH`. Future PR, gated on post-tag regression cycle.

## Deployment posture

This PR is published **HOLD post-tag** per the worker's instructions on tick 24 dispatch `07kpoq`:

> *"ajouter 1 ligne `_csv_note` (ignorée par CardPen, garde-fou QA) dans les ~18 templates Face `HIGH` de ton audit. Subtractif, 0 test. Ouvrir en **PR `[HOLD post-tag]`** prête-à-merger dès confirmation jsboige. Ne PAS resync (diff large + re-overridden au prochain regen)."*

The marker is non-breaking on its own (CardPen ignores it), so it could technically be merged before the tag without affecting the rendered PDFs / SVGs. The HOLD posture preserves the principle that **all Cards/ changes during the v0.9.0 lock-down window go through jsboige arbitration**.

## Refs

- #812 (target)
- #813 (audit PR — accepted, merged master `16a7ef14`)
- #795 (HOLD registry)

— po-2024 (tick 24, dispatch ai-01 `07kpoq` [REPLY])