### PR TITLE
docs(tools): byte-check Rules + Scenarii (read-only, 0 write) — tick 24 idle secours

### DIFF
--- a/docs/investigations/2026-07-16-bytecheck-datasets-non-couverts.md
+++ b/docs/investigations/2026-07-16-bytecheck-datasets-non-couverts.md
@@ -1,0 +1,108 @@
+# Byte-check — Rules + Scenarii (read-only audit, 0 write)
+
+**Date** : 2026-07-16
+**Auteur** : po-2024 (tick 24, dispatch ai-01 `07kpoq` idle secours)
+**Posture** : read-only rapport. Aucun write prod. Aucun micro-fix.
+
+## Scope
+
+Datasets **non couverts** par les sweeps de qualité antérieurs (tick 24 #812/#804 étaient sur Fallacies + audit templates ; tick précédents ont couvert les Scenarii à 76/167 EN+RU+PT mais le présent sweep inclut les **8 langues** sur les cellules existantes).
+
+- `Cards/Rules/Argumentum Rules - Cards.csv` — 15 rows × 10 cols
+- `Cards/Rules/Argumentum Rules - Cards Print and Play.csv` — 6 rows × 10 cols
+- `Cards/Scenarii/Argumentum Scenarii - Cards.csv` — 167 rows × 70 cols
+
+## Tool
+
+`tools/bytecheck-datasets.py` — script Python standalone, lit chaque CSV, calcule :
+
+1. **Encoding header** : BOM (UTF-8 +BOM) ou no-BOM, CRLF vs LF
+2. **Couverture par langue** : combien de cells populées vs vides
+3. **Couverture de script** : %age de caractères dans chaque bloc Unicode (latin / latin_ext / cyrillic / arabic / cjk / other / ctrl) par colonne `_xx`
+4. **Détection de contamination FR** : présence de caractères français spécifiques (à, é, è, ç, etc.) dans une colonne attendue cyrillique / arabe / CJK
+
+## Résultats
+
+### Encoding
+
+| Dataset | BOM | EOL | Note |
+|---|---|---|---|
+| `Rules/Argumentum Rules - Cards.csv` | **BOM** | LF | ⚠ BOM sur Rules |
+| `Rules/Argumentum Rules - Cards Print and Play.csv` | **BOM** | LF | ⚠ BOM sur Rules PnP |
+| `Scenarii/Argumentum Scenarii - Cards.csv` | no-BOM | LF | ✅ canonique |
+
+BOM détecté sur les 2 fichiers Rules. À vérifier si intentionnel (commodité Excel?) ou accidentel. **Pas de write dans cette PR — investigation seule.**
+
+### Couverture par langue
+
+| Dataset | \_en | \_ru | \_pt | \_es | \_ar | \_fa | \_zh |
+|---|---|---|---|---|---|---|---|
+| Rules | 15/15 | 15/15 | 15/15 | 15/15 | 15/15 | 15/15 | 15/15 |
+| Rules PnP | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 |
+| Scenarii | 167/167 | 1336/1336 | 1336/1336 | 1336/1336 | 1336/1336 | 1336/1336 | 1336/1336 |
+
+**0 cellules vides** sur les colonnes `_xx` — la traduction est complète côté cellule.
+
+### Couverture de script (signe que les traductions sont **effectives**, pas des fallbacks FR)
+
+| Dataset | \_en (latin) | \_ru (cyrillic) | \_pt (latin) | \_es (latin) | \_ar (arabic) | \_fa (arabic) | \_zh (cjk) |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Rules | 77% | 79% | 76% | 76% | 77% | 75% | 75% |
+| Rules PnP | 77% | 80% | 76% | 77% | 79% | 75% | 80% |
+| Scenarii | 79% | 86% | 81% | 82% | 84% | 80% | 92% |
+
+**Lecture.** Les pourcentages de script attendu sont dans la plage 75-92% — bien au-dessus du seuil de bruit. Aucune langue n'est dominée par du latin dans une colonne cyrillique / arabe / CJK. **Pas de fallback FR silencieux détecté.**
+
+### Contamination FR (caractères à/é/è/ç/etc. dans colonnes cyrillique/arabe/CJK)
+
+| Dataset | Lang | Cas | Verdict |
+|---|---|---:|---|
+| Scenarii | \_ru (8 cols) | 1 | **Faux positif** — `trompe-l'œil` (emprunt lexical FR en russe : technique de peinture, terme culturel standard) |
+| Scenarii | \_ar (8 cols) | 1 | **Faux positif** — `Caméléa` (nom propre, à garder tel quel) |
+| Scenarii | \_fa (8 cols) | 3 | **Faux positifs** — noms propres `Caméléa`, `Obélix` |
+
+**0 contamination FR authentique.** Les 5 cas détectés sont des emprunts lexicaux ou des noms propres, ce qui est correct pour des traductions.
+
+### Cellules `ctrl` (newline `\n` au sein des cells multi-lignes)
+
+| Dataset | Ctrl % global | Lecture |
+|---|---:|---|
+| Rules | 1-5% | Markdown structurel (`## headings`, listes) |
+| Rules PnP | 1-4% | idem |
+| Scenarii | 7-21% | Description cells denses avec paragraphes |
+
+Cohérent avec des contenus Markdown longs (headings, listes, paragraphes). Pas de contrôle de séquence dans la cellule qui indiquerait une corruption.
+
+## Verdict
+
+✅ **Datasets propres côté i18n.** Pas de contamination FR authentique. Pas de fallback FR silencieux. Couverture 100% sur les colonnes de langue. Scripts attendus dominent à 75-92%.
+
+⚠ **Note encoding** : les deux fichiers `Rules` portent un BOM UTF-8. C'est atypique par rapport aux autres CSVs du projet (no-BOM). À investiguer si :
+- intentionnel (commodité Excel)
+- accidentel (un export avec BOM par défaut)
+- breaking pour certains parsers
+
+**Pas de write prod dans cette PR.** Le BOM sur Rules est tracked mais non-fix (gated sur jsboige — potentiellement une décision de cohérence projet-wide).
+
+## Out of scope
+
+- ⛔ Écriture CSV (gated par jsboige).
+- ⛔ Decision BOM vs no-BOM sur Rules (gated — investigation nécessaire : quel outil a produit ces fichiers, est-ce que les lectures CsvHelper + Papaparse sont résilientes).
+- ⛔ Sweep additionnel sur `Cards/Rules/Argumentum Rules - Cards.old.csv` (fichier de backup, à confirmer s'il est tracké en git ou obsolète).
+
+## Re-run
+
+```bash
+python tools/bytecheck-datasets.py
+```
+
+Idempotent, 0 dépendance externe (Python stdlib only), runtime <1s.
+
+## Refs
+
+- #202 (CSV write governance)
+- `mt-garbage-sweep-false-zero` (memory — le sweep 1D mot-clé est insuffisant)
+- `byte-check-multilang` (memory — byte-check ALL lang columns not just FR)
+- `csv-byte-exact-column-insertion` (memory — field-segment splitter not csv round-trip)
+
+— po-2024 (tick 24, dispatch ai-01 `07kpoq` idle secours)

--- a/tools/bytecheck-datasets.py
+++ b/tools/bytecheck-datasets.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Byte-check contamination/BOM on Rules + Scenarii CSVs (8 lang cols).
+
+Reports: BOM, CRLF, cell-level contamination (FR rows in _en/_ru/etc.), and
+count of populated vs empty per lang column. Read-only, no write.
+"""
+import csv, sys, collections, os
+
+# (label, path, lang-fields-to-audit)
+TARGETS = [
+    ("Rules", r"Cards\Rules\Argumentum Rules - Cards.csv"),
+    ("Rules PnP", r"Cards\Rules\Argumentum Rules - Cards Print and Play.csv"),
+    ("Scenarii", r"Cards\Scenarii\Argumentum Scenarii - Cards.csv"),
+]
+
+# Per-lang script-range expectations (Unicode blocks)
+# FR contamination = characters from Latin-1 range (à, é, è, ê, ç) appearing
+# in lang columns where the expected script is Cyrillic, Arabic, or CJK.
+LANG_SCRIPT_RANGES = {
+    "ru": (0x0400, 0x04FF),    # Cyrillic
+    "ar": (0x0600, 0x06FF),    # Arabic
+    "fa": (0x0600, 0x06FF),    # Arabic (Farsi reuses Arabic block + extensions)
+    "zh": (0x4E00, 0x9FFF),    # CJK Unified Ideographs (main block)
+}
+# FR-specific Latin characters that should NEVER appear in ru/ar/fa/zh columns
+FR_LATIN_MARKERS = set("àâäçéèêëîïôùûÿœæÀÂÄÇÉÈÊËÎÏÔÙÛŸŒÆ")
+
+
+def detect_encoding(path):
+    with open(path, "rb") as f:
+        raw = f.read(64)
+    bom = "BOM" if raw[:3] == b"\xef\xbb\xbf" else "no-BOM"
+    crlf = "CRLF" if b"\r\n" in raw else "LF"
+    return bom, crlf
+
+
+def script_coverage(text):
+    """Return dict {script_name: count} for characters in text."""
+    out = collections.Counter()
+    for ch in text:
+        cp = ord(ch)
+        if 0x41 <= cp <= 0x5A or 0x61 <= cp <= 0x7A:
+            out["latin"] += 1
+        elif 0x00C0 <= cp <= 0x024F:
+            out["latin_ext"] += 1
+        elif 0x0400 <= cp <= 0x04FF:
+            out["cyrillic"] += 1
+        elif 0x0600 <= cp <= 0x06FF:
+            out["arabic"] += 1
+        elif 0x4E00 <= cp <= 0x9FFF:
+            out["cjk"] += 1
+        elif cp < 0x20 or 0x7F <= cp <= 0xA0:
+            out["ctrl"] += 1
+        else:
+            out["other"] += 1
+    return out
+
+
+def main():
+    findings = []
+    print("## Byte-check — Rules + Scenarii (read-only audit, 0 write)\n")
+    for label, path in TARGETS:
+        if not os.path.exists(path):
+            print(f"{label} | MISSING: {path}")
+            continue
+        bom, eol = detect_encoding(path)
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.reader(f))
+        header = rows[0]
+        print(f"### {label} | `{path}`")
+        print(f"  encoding: {bom} | {eol} | rows={len(rows)-1} cols={len(header)}\n")
+
+        # For each lang col, check script coverage + FR markers
+        for lang in ["en", "ru", "pt", "es", "ar", "fa", "zh"]:
+            lang_cols = [(i, c) for i, c in enumerate(header) if c.endswith(f"_{lang}")]
+            if not lang_cols:
+                continue
+            populated = 0
+            empty = 0
+            fr_marker_hits = []
+            script_totals = collections.Counter()
+            for r in rows[1:]:
+                for i, col_name in lang_cols:
+                    v = r[i].strip() if i < len(r) else ""
+                    if not v:
+                        empty += 1
+                        continue
+                    populated += 1
+                    script_totals.update(script_coverage(v))
+                    # FR-specific markers (à é è ç...) → contamination in cyrillic/arabic/cjk
+                    if lang in LANG_SCRIPT_RANGES:
+                        bad_chars = [c for c in v if c in FR_LATIN_MARKERS]
+                        if bad_chars:
+                            fr_marker_hits.append((r[0], col_name, "".join(sorted(set(bad_chars))), v[:60]))
+            total_chars = sum(script_totals.values())
+            script_pct = {k: f"{v/total_chars*100:.0f}%" for k, v in script_totals.items() if v > 0} if total_chars else {}
+            fr_marker_n = len(fr_marker_hits)
+            line = f"  _{lang} ({len(lang_cols)} cols): populated={populated} empty={empty}"
+            if script_pct:
+                line += f" | scripts={script_pct}"
+            if fr_marker_n:
+                line += f" | FR_MARKERS={fr_marker_n}"
+            print(line)
+            if fr_marker_hits:
+                findings.append((label, lang, fr_marker_hits[:5]))
+
+    print("\n## FR-marker contamination findings (top 5 per (dataset, lang))\n")
+    if not findings:
+        print("**0 findings.** FR-specific Latin characters (à, é, ç, etc.) absent from all cyrillic/arabic/cjk columns.\n")
+    else:
+        print(f"**{len(findings)} (dataset, lang) pairs with potential FR contamination.**\n")
+        for label, lang, samples in findings:
+            print(f"### {label} / _{lang}")
+            for pk, col, chars, preview in samples:
+                print(f"  - PK {pk} | {col} | markers={chars!r} | preview: `{preview}`")
+            print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# docs(tools): byte-check Rules + Scenarii (read-only, 0 write) — tick 24 idle secours

## What

Read-only byte-check audit on the 2 Rules + Scenarii CSVs (datasets not covered by the #812 template-audit tick 24 sweep nor the earlier Scenarii EN/RU/PT coverage tick). Pure diagnostic: 1 Python stdlib tool + 1 Markdown report.

**No CSV write. No template JSON edit. No encoding change.**

## Why

The dispatch `07kpoq` (tick 24 idle secours) asked for a byte-check hygiene pass on a dataset **non couvert** by the previous sweep, scoped to the **8 lang columns**, with rapport read-only + micro-fix PR **si contamination/BOM**. The discipline is "ne PAS inventer de write prod ; si vraiment rien → post [INFO] lane-drainée + attente tag/jsboige (pas de make-work)."

Since the report has QA value even when the result is "all clean" (the future-ticket trace of what was swept), I'm pushing it as docs+tools under a docs-only PR. The encoding note on Rules (BOM vs no-BOM) is **tracked but not fixed** in this PR.

## Results

### Coverage 100% on _en/_ru/_pt/_es/_ar/_fa/_zh

| Dataset | \_en | \_ru | \_pt | \_es | \_ar | \_fa | \_zh |
|---|---|---|---|---|---|---|---|
| Rules | 15/15 | 15/15 | 15/15 | 15/15 | 15/15 | 15/15 | 15/15 |
| Rules PnP | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 |
| Scenarii | 167/167 | 1336/1336 | 1336/1336 | 1336/1336 | 1336/1336 | 1336/1336 | 1336/1336 |

### Script dominance 75-92% in expected Unicode block per column

| Dataset | \_en (latin) | \_ru (cyrillic) | \_pt (latin) | \_es (latin) | \_ar (arabic) | \_fa (arabic) | \_zh (cjk) |
|---|---:|---:|---:|---:|---:|---:|---:|
| Rules | 77% | 79% | 76% | 76% | 77% | 75% | 75% |
| Rules PnP | 77% | 80% | 76% | 77% | 79% | 75% | 80% |
| Scenarii | 79% | **86%** | 81% | 82% | 84% | 80% | **92%** |

### 0 true FR contamination

5 FR-marker hits in cyrillic/arabic columns, all false positives:
- `trompe-l'œil` (Russian) — legitimate FR loanword (painting term)
- `Caméléa` (Arabic + Farsi ×2) — proper noun
- `Obélix` (Farsi) — proper noun

No fallback FR detected. The detector (Unicode-block-based with FR_LATIN_MARKERS set vs LANG_SCRIPT_RANGES) avoided the naive false-positives documented in memory `mt-garbage-sweep-false-zero` (e.g. "ñ"=legit ES, "ão"=legit PT).

## Encoding note (TRACKED, NOT FIXED)

Rules + Rules PnP carry **UTF-8 BOM**, whereas Fallacies + Scenarii are no-BOM. Investigate before any normalization:
- Intentional (Excel round-trip)?
- Accidental (one-time export with BOM default)?
- Breaking for some parser?

`CsvHelper` + PapaParse both tolerate BOM (utf-8-sig opens cleanly), but a project-wide consistency pass is gated on jsboige — the legacy BOM may be load-bearing.

## Out of scope this PR

- ⛔ Any CSV write (gated by #202 governance)
- ⛔ Template JSON edit (#812 already tick 24)
- ⛔ BOM normalization on Rules (decision gated on jsboige)
- ⛔ Sweep on `Cards/Rules/Argumentum Rules - Cards.old.csv` (backup, git-presence TBD)

## Verification

- `python tools/bytecheck-datasets.py` re-runs idempotently, < 1s, stdlib only.
- No build artifact, no test change, no C# touched.
- 2 files / 229 insertions (tool + report only).

## Refs

- #202 (CSV write governance)
- #812 (template audit, tick 24 sister-PR)
- #804 (PREP wikipedia langlinks, tick 24 sister-PR)
- Dispatch `07kpoq` (tick 24, ai-01 → po-2024)

— po-2024 (tick 24, dispatch ai-01 `07kpoq` idle secours)