### PR TITLE
fix(mindmap): restore click-to-define card colors, centering, size (Fallacies+Virtues)

### DIFF
--- a/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar.html
+++ b/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3701,42 +3775,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3775,7 +3813,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3802,12 +3839,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar_ext.html
+++ b/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ar/Fallacies_ar.html
+++ b/Cards/Fallacies/Mindmaps/ar/Fallacies_ar.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -16167,42 +16241,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -16241,7 +16279,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -16268,12 +16305,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ar/Fallacies_ar_ext.html
+++ b/Cards/Fallacies/Mindmaps/ar/Fallacies_ar_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en.html
+++ b/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3738,42 +3812,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3812,7 +3850,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3839,12 +3876,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en_ext.html
+++ b/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/en/Fallacies_en.html
+++ b/Cards/Fallacies/Mindmaps/en/Fallacies_en.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -16913,42 +16987,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -16987,7 +17025,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -17014,12 +17051,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/en/Fallacies_en_ext.html
+++ b/Cards/Fallacies/Mindmaps/en/Fallacies_en_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es.html
+++ b/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3674,42 +3748,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3748,7 +3786,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3775,12 +3812,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es_ext.html
+++ b/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/es/Fallacies_es.html
+++ b/Cards/Fallacies/Mindmaps/es/Fallacies_es.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -17143,42 +17217,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -17217,7 +17255,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -17244,12 +17281,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/es/Fallacies_es_ext.html
+++ b/Cards/Fallacies/Mindmaps/es/Fallacies_es_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/external.html
+++ b/Cards/Fallacies/Mindmaps/external.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa.html
+++ b/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3749,42 +3823,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3823,7 +3861,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3850,12 +3887,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa_ext.html
+++ b/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fa/Fallacies_fa.html
+++ b/Cards/Fallacies/Mindmaps/fa/Fallacies_fa.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -16221,42 +16295,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -16295,7 +16333,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -16322,12 +16359,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fa/Fallacies_fa_ext.html
+++ b/Cards/Fallacies/Mindmaps/fa/Fallacies_fa_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr.html
+++ b/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3745,42 +3819,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3819,7 +3857,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3846,12 +3883,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr_ext.html
+++ b/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fr/Fallacies_fr.html
+++ b/Cards/Fallacies/Mindmaps/fr/Fallacies_fr.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -17182,42 +17256,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -17256,7 +17294,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -17283,12 +17320,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/fr/Fallacies_fr_ext.html
+++ b/Cards/Fallacies/Mindmaps/fr/Fallacies_fr_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/included.html
+++ b/Cards/Fallacies/Mindmaps/included.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -449,42 +523,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -523,7 +561,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -550,12 +587,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt.html
+++ b/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3717,42 +3791,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3791,7 +3829,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3818,12 +3855,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt_ext.html
+++ b/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/pt/Fallacies_pt.html
+++ b/Cards/Fallacies/Mindmaps/pt/Fallacies_pt.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -17186,42 +17260,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -17260,7 +17298,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -17287,12 +17324,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/pt/Fallacies_pt_ext.html
+++ b/Cards/Fallacies/Mindmaps/pt/Fallacies_pt_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru.html
+++ b/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3696,42 +3770,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3770,7 +3808,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3797,12 +3834,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru_ext.html
+++ b/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ru/Fallacies_ru.html
+++ b/Cards/Fallacies/Mindmaps/ru/Fallacies_ru.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -17651,42 +17725,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -17725,7 +17763,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -17752,12 +17789,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/ru/Fallacies_ru_ext.html
+++ b/Cards/Fallacies/Mindmaps/ru/Fallacies_ru_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh.html
+++ b/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -3548,42 +3622,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -3622,7 +3660,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -3649,12 +3686,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh_ext.html
+++ b/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 

--- a/Cards/Fallacies/Mindmaps/zh/Fallacies_zh.html
+++ b/Cards/Fallacies/Mindmaps/zh/Fallacies_zh.html
@@ -65,56 +65,131 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur + centrage restaurés depuis golden master eb83d113) —
+           applique une couleur de fond même si la classe familyclass (casse variable) ne
+           matche pas une règle card.<famille> spécifique (CSS est case-sensitive). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (sélecteurs à la casse EXACTE de l'attribut
+           familyclass posé par le runtime : Family.Replace(" ","")). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles. Les sélecteurs utilisent la casse EXACTE de
+           l'attribut familyclass posé par le runtime (CSS est case-sensitive). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -133,15 +208,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            width: 50vw;
-            height: 50vh;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -152,9 +228,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -14986,42 +15060,6 @@
             }
         };
 
-        const recalculateOverlayPosition = (targetNode) => {
-            if (targetNode) {
-                const rect = targetNode.getBoundingClientRect();
-                const cardHeight = overlay.offsetHeight;
-                const cardWidth = overlay.offsetWidth;
-
-                const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                const cardTop = rect.top + rect.height;
-
-                // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                const maxLeft = window.innerWidth - cardWidth;
-                const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                const maxTop = window.innerHeight - cardHeight;
-                const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                overlay.style.left = cardLeftPosition + 'px';
-                overlay.style.top = cardTopPosition + 'px';
-            }
-        };
-
-        
-        const resizeOverlay = () => {
-
-            overlay.style.maxWidth = '100vw';
-            overlay.style.maxHeight = '100vh';
-
-            // Recalculate the overlay position when resizing
-            if (isNodeActive) {
-                const activeNode = document.querySelector('.node.active');
-                recalculateOverlayPosition(activeNode);
-            }
-        };
-
-
         const showOverlay = (e) => {
             isNodeActive = true;
 
@@ -15060,7 +15098,6 @@
             }
 
             targetNode.classList.add('active');
-            recalculateOverlayPosition(targetNode);
         };
 
 
@@ -15087,12 +15124,6 @@
                 hideOverlay();
             }
         });
-
-        // Trigger the initial resize
-        resizeOverlay();
-
-        window.addEventListener('resize', resizeOverlay);
-        window.addEventListener('orientationchange', resizeOverlay);
 
             //Zoom
 

--- a/Cards/Fallacies/Mindmaps/zh/Fallacies_zh_ext.html
+++ b/Cards/Fallacies/Mindmaps/zh/Fallacies_zh_ext.html
@@ -73,56 +73,127 @@
         /* Couleurs */
         /* -------------------------------------------------------------------------------- */
 
-        card.insuffisance {
+        /* Défaut (fallback couleur restauré depuis golden master eb83d113). */
+        card {
             --color-background: #811da3;
             --color-text-1: #601362;
             --color-text-2: #8f5991;
             --color-text-3: #a173a2;
         }
 
-        card.influence {
+        /* Fallacies — 8 familles (casse EXACTE de l'attribut familyclass runtime). */
+        card.Insuffisance {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Influence {
             --color-background: #ff66eb;
             --color-text-1: #b3009b;
             --color-text-2: #cc00b1;
             --color-text-3: #e566d4;
         }
 
-        card.erreurMathématique {
+        card.Erreurmathématique {
             --color-background: #08af93;
             --color-text-1: #14555b;
             --color-text-2: #5a888c;
             --color-text-3: #749a9e;
         }
 
-        card.erreurDeRaisonnement {
+        card.Erreurderaisonnement {
             --color-background: #8dc801;
             --color-text-1: #476205;
             --color-text-2: #7e9150;
             --color-text-3: #92a26b;
         }
 
-        card.abusDeLangage {
+        card.Abusdelangage {
             --color-background: #0054a4;
             --color-text-1: #0c2861;
             --color-text-2: #546890;
             --color-text-3: #6f80a1;
         }
 
-        card.tricherie {
+        card.Tricherie {
             --color-background: #ffc307ff;
             --color-text-1: #9e7800ff;
             --color-text-2: #c49500ff;
             --color-text-3: #d6b755ff;
         }
 
-        card.obstruction {
+        card.Obstruction {
             --color-background: #dc0f0a;
             --color-text-1: #960a07;
             --color-text-2: #b55351;
             --color-text-3: #c16e6c;
         }
 
+        card.Argumentfallacieux {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
+        /* Virtues — 8 familles (casse exacte de l'attribut familyclass runtime). */
+        card.Raisonnementvalide {
+            --color-background: #8dc801;
+            --color-text-1: #476205;
+            --color-text-2: #7e9150;
+            --color-text-3: #92a26b;
+        }
+
+        card.Échangeenrichissant {
+            --color-background: #dc0f0a;
+            --color-text-1: #960a07;
+            --color-text-2: #b55351;
+            --color-text-3: #c16e6c;
+        }
+
+        card.Argumentpertinent {
+            --color-background: #811da3;
+            --color-text-1: #601362;
+            --color-text-2: #8f5991;
+            --color-text-3: #a173a2;
+        }
+
+        card.Honnêtetéintellectuelle {
+            --color-background: #ffc307ff;
+            --color-text-1: #9e7800ff;
+            --color-text-2: #c49500ff;
+            --color-text-3: #d6b755ff;
+        }
+
+        card.Présentationintègre {
+            --color-background: #ff66eb;
+            --color-text-1: #b3009b;
+            --color-text-2: #cc00b1;
+            --color-text-3: #e566d4;
+        }
+
+        card.Rigueurmathématique {
+            --color-background: #08af93;
+            --color-text-1: #14555b;
+            --color-text-2: #5a888c;
+            --color-text-3: #749a9e;
+        }
+
+        card.Langageexact {
+            --color-background: #0054a4;
+            --color-text-1: #0c2861;
+            --color-text-2: #546890;
+            --color-text-3: #6f80a1;
+        }
+
+        card.Argumentvalable {
+            --color-background: #555555;
+            --color-text-1: #2a2a2a;
+            --color-text-2: #6e6e6e;
+            --color-text-3: #888888;
+        }
 
         card .famille {
             color: var(--color-text-1);
@@ -141,15 +212,16 @@
         /* -------------------------------------------------------------------------------- */
 
         card {
-            position: fixed;
-            z-index: 100;
-            font-size: 80%;
-            font-family: 'Bebas Neue', sans-serif;
             background-color: white;
-            width: 50vw;
-            height: 50vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Bebas Neue', sans-serif;
+            left: 50%;
+            position: fixed;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: 300px;
+            z-index: 100;
         }
 
         bleed {
@@ -160,9 +232,7 @@
 
         safe {
             background-color: #fff;
-            position: static;
-            /* Different Safe Padding */
-            /*padding: 1.2vh 2.5vh 1.5vh 2.5vh;*/
+            position: relative;
         }
 
         .cardName {
@@ -460,41 +530,6 @@
                     }
                 };
 
-                const recalculateOverlayPosition = (targetNode) => {
-                    if (targetNode) {
-                        const rect = targetNode.getBoundingClientRect();
-                        const cardHeight = overlay.offsetHeight;
-                        const cardWidth = overlay.offsetWidth;
-
-                        const cardLeft = rect.left + rect.width / 2 - cardWidth / 2;
-                        const cardTop = rect.top + rect.height;
-
-                        // Calculate the maximum left position to ensure the card stays within the horizontal viewport
-                        const maxLeft = window.innerWidth - cardWidth;
-                        const cardLeftPosition = Math.max(0, Math.min(maxLeft, cardLeft));
-
-                        // Calculate the maximum top position to ensure the card stays within the vertical viewport
-                        const maxTop = window.innerHeight - cardHeight;
-                        const cardTopPosition = Math.max(0, Math.min(maxTop, cardTop));
-
-                        overlay.style.left = cardLeftPosition + 'px';
-                        overlay.style.top = cardTopPosition + 'px';
-                    }
-                };
-
-
-                const resizeOverlay = () => {
-
-                    overlay.style.maxWidth = '100vw';
-                    overlay.style.maxHeight = '100vh';
-
-                    // Recalculate the overlay position when resizing
-                    if (isNodeActive) {
-                        const activeNode = document.querySelector('.node.active');
-                        recalculateOverlayPosition(activeNode);
-                    }
-                };
-
                 const showOverlay = (e) => {
                     isNodeActive = true;
 
@@ -533,7 +568,6 @@
                     }
 
                     targetNode.classList.add('active');
-                    recalculateOverlayPosition(targetNode);
                 };
 
 
@@ -560,12 +594,6 @@
                         hideOverlay();
                     }
                 });
-
-                // Trigger the initial resize
-                resizeOverlay();
-
-                window.addEventListener('resize', resizeOverlay);
-                window.addEventListener('orientationchange', resizeOverlay);
 
                         //Zoom
 


### PR DESCRIPTION
See commit 88cfd9e5. Restores golden master card{} CSS (fallback color + centering + 300px width), removes the JS positioning added by #271-274/#312, aligns 8 Fallacies + 8 Virtues selectors to exact runtime familyclass casing (Family.Replace(" ","")), adds 8 Virtues colors (CLAUDE.md). Playwright: 8/8 Fallacies + 8/8 Virtues families resolve to real --color-background, svg-pan-zoom #826 intact, card centered/300px. 92/92 Mindmap tests PASS, 0 secret. Awaits jsboige visual + po-2023 redeploy.