### PR TITLE
fix(mindmap): restore readable initial zoom centered on root (#830)

### DIFF
--- a/Cards/Fallacies/Mindmaps/external.html
+++ b/Cards/Fallacies/Mindmaps/external.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/included.html
+++ b/Cards/Fallacies/Mindmaps/included.html
@@ -668,15 +668,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {


### PR DESCRIPTION
## Problème (régression zoom initial)

Les mind-maps déployées (`www.argumentum.games/{fallacies,virtues}_<lang>.html`) se chargeaient **entièrement dézoomées** — toute la taxonomie visible, illisible, impossible d'identifier la carte sans zoomer/scroller longuement. Le bon comportement « zoom par défaut sur quelques nœuds » avait disparu.

**Cause racine** (diagnostic par *mesure comportementale*, pas diff de code) : la config C# (`FallacyMindMapCreatorConfig.cs` / `VirtueMindMapCreatorConfig.cs`) force `SvgWidth="96vw"`, `SvgHeight="93vh"`, `SvgViewBox` complet sur le `<svg>`. Avec des dimensions viewport-relatives + viewBox complet + `preserveAspectRatio` par défaut, le navigateur *fit-to-viewport* **avant** que svg-pan-zoom n'agisse — écrasant le `fit:0`. Introduite juillet 2025 (`6edf683c`). **Un diff textuel du template ne pouvait pas l'attraper** : la config svg-pan-zoom était identique. → d'où #830 (golden-master comportemental).

## Fix (additif, dans les 2 templates partagés)

`Cards/Fallacies/Mindmaps/included.html` (SVG embarqué) + `external.html` (SVG en `<object>`) — utilisés par **les 2 familles** (Fallacy + Virtue), **8 langues**.

1. `maxZoom: 6 → 15` — amplitude pour cadrer proprement la racine **et** lire les feuilles.
2. Après init, `requestAnimationFrame` : zoom pour afficher ~2600 unités-utilisateur de hauteur autour de la **racine** (nœud id=0), puis centrage **analytique** via `getBBox()` (insensible à l'état CTM du pan-zoom → un seul `pan()`, pas de saut, agnostique à la langue).
3. `included.html` lit la racine sur `document` ; `external.html` sur `svgDocument` (contentDocument de l'`<object>`).

**Non-destructif** : RESET / zoom-out max = **fit complet** (comportement svg-pan-zoom natif inchangé). Aucune capacité retirée — seul le cadrage initial est ajouté (leçon #825 : pas d'ersatz).

## Validation

- Playwright local, **2 familles** : FR racine « Argument fallacieux » centrée + 11 nœuds lisibles ; Virtue racine « Argument valable » centrée + 61 nœuds lisibles.
- CRLF préservés, UTF-8 no-BOM (vérifié byte-à-byte).

## Reste à faire (hors PR, tracké)

- [ ] Régénérer les 16 wrappers (2 familles × 8 langues, variantes included + _ext) — lane po-2023 (régén lourde). **NB** : le path Release pull les templates depuis `raw/master` → **merger cette PR d'abord**.
- [ ] Redéploiement web1 (origine `www.argumentum.games`).
- [ ] Verdict QA final ai-01 (Playwright + vision) sur le site live, selon la checklist **#830** (9 capacités mesurées).

Closes nothing directly — la régression est corrigée à la source (templates) ; la livraison live est séquencée ci-dessus. Refs #830, #825.
