### PR TITLE
fix(mindmap): regenerate 32 HTML wrappers carrying #831 initial-zoom restoration

### DIFF
--- a/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar.html
+++ b/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar.html
@@ -3920,15 +3920,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar_ext.html
+++ b/Cards/Fallacies/Mindmaps/ar/Argumentation_Virtues_ar_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/ar/Fallacies_ar.html
+++ b/Cards/Fallacies/Mindmaps/ar/Fallacies_ar.html
@@ -16386,15 +16386,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/ar/Fallacies_ar_ext.html
+++ b/Cards/Fallacies/Mindmaps/ar/Fallacies_ar_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en.html
+++ b/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en.html
@@ -3957,15 +3957,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en_ext.html
+++ b/Cards/Fallacies/Mindmaps/en/Argumentation_Virtues_en_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/en/Fallacies_en.html
+++ b/Cards/Fallacies/Mindmaps/en/Fallacies_en.html
@@ -17132,15 +17132,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/en/Fallacies_en_ext.html
+++ b/Cards/Fallacies/Mindmaps/en/Fallacies_en_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es.html
+++ b/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es.html
@@ -3893,15 +3893,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es_ext.html
+++ b/Cards/Fallacies/Mindmaps/es/Argumentation_Virtues_es_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/es/Fallacies_es.html
+++ b/Cards/Fallacies/Mindmaps/es/Fallacies_es.html
@@ -17362,15 +17362,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/es/Fallacies_es_ext.html
+++ b/Cards/Fallacies/Mindmaps/es/Fallacies_es_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa.html
+++ b/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa.html
@@ -3968,15 +3968,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa_ext.html
+++ b/Cards/Fallacies/Mindmaps/fa/Argumentation_Virtues_fa_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/fa/Fallacies_fa.html
+++ b/Cards/Fallacies/Mindmaps/fa/Fallacies_fa.html
@@ -16440,15 +16440,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/fa/Fallacies_fa_ext.html
+++ b/Cards/Fallacies/Mindmaps/fa/Fallacies_fa_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr.html
+++ b/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr.html
@@ -3964,15 +3964,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr_ext.html
+++ b/Cards/Fallacies/Mindmaps/fr/Argumentation_Virtues_fr_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/fr/Fallacies_fr.html
+++ b/Cards/Fallacies/Mindmaps/fr/Fallacies_fr.html
@@ -17401,15 +17401,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/fr/Fallacies_fr_ext.html
+++ b/Cards/Fallacies/Mindmaps/fr/Fallacies_fr_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt.html
+++ b/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt.html
@@ -3936,15 +3936,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt_ext.html
+++ b/Cards/Fallacies/Mindmaps/pt/Argumentation_Virtues_pt_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/pt/Fallacies_pt.html
+++ b/Cards/Fallacies/Mindmaps/pt/Fallacies_pt.html
@@ -17405,15 +17405,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/pt/Fallacies_pt_ext.html
+++ b/Cards/Fallacies/Mindmaps/pt/Fallacies_pt_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru.html
+++ b/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru.html
@@ -3915,15 +3915,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru_ext.html
+++ b/Cards/Fallacies/Mindmaps/ru/Argumentation_Virtues_ru_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/ru/Fallacies_ru.html
+++ b/Cards/Fallacies/Mindmaps/ru/Fallacies_ru.html
@@ -17870,15 +17870,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/ru/Fallacies_ru_ext.html
+++ b/Cards/Fallacies/Mindmaps/ru/Fallacies_ru_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh.html
+++ b/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh.html
@@ -3767,15 +3767,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh_ext.html
+++ b/Cards/Fallacies/Mindmaps/zh/Argumentation_Virtues_zh_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 

--- a/Cards/Fallacies/Mindmaps/zh/Fallacies_zh.html
+++ b/Cards/Fallacies/Mindmaps/zh/Fallacies_zh.html
@@ -15205,15 +15205,36 @@
                     fit: 0,
                     controlIconsEnabled: true,
                     minZoom: 0.15,
-                    maxZoom: 6,
+                    maxZoom: 15,
                     center: 0,
                     //contain: 1,
                     customEventsHandler: eventsHandler
                 });
 
-                //panZoomInstance.resize();
-                //panZoomInstance.fit();
-                //panZoomInstance.center();
+                // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                // au fit complet (comportement svg-pan-zoom inchange).
+                requestAnimationFrame(function () {
+                    try {
+                        var root = document.querySelector('#mindmap svg g.node[id="0"]');
+                        var s0 = panZoomInstance.getSizes();
+                        var targetAbs = s0.height / 2600;
+                        if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                        panZoomInstance.zoom(targetAbs / s0.realZoom);
+                        var s = panZoomInstance.getSizes();
+                        var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                        if (root) {
+                            var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                            var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                            var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                            cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                            cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                        }
+                        panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                    } catch (e) { console.error('initial focus error', e); }
+                });
 
                 // Conservez ici votre logique d'affichage de la modale
             } else {

--- a/Cards/Fallacies/Mindmaps/zh/Fallacies_zh_ext.html
+++ b/Cards/Fallacies/Mindmaps/zh/Fallacies_zh_ext.html
@@ -755,7 +755,7 @@
 
                                 minZoom: 0.15,
 
-                                maxZoom: 6,
+                                maxZoom: 15,
 
                                 center: 0,
 
@@ -772,6 +772,32 @@
                             //panZoomInstance.fit();
 
                             //panZoomInstance.center();
+
+                            // === ZOOM INITIAL LISIBLE : centrer sur la racine (restauration #829) ===
+                            // Carte trop grande : le fit initial montre toute la taxo illisible. On zoome
+                            // pour afficher ~2600 unites-utilisateur de hauteur autour de la racine
+                            // (node id=0) => racine + familles lisibles. Additif : RESET/zoom-out revient
+                            // au fit complet (comportement svg-pan-zoom inchange). SVG dans <object> =>
+                            // le noeud racine se lit sur svgDocument (contentDocument), pas document.
+                            requestAnimationFrame(function () {
+                                try {
+                                    var root = svgDocument.querySelector('g.node[id="0"]');
+                                    var s0 = panZoomInstance.getSizes();
+                                    var targetAbs = s0.height / 2600;
+                                    if (targetAbs < s0.realZoom) targetAbs = s0.realZoom;
+                                    panZoomInstance.zoom(targetAbs / s0.realZoom);
+                                    var s = panZoomInstance.getSizes();
+                                    var cx = s.viewBox.x + s.viewBox.width / 2, cy = s.viewBox.y + s.viewBox.height / 2;
+                                    if (root) {
+                                        var m = (root.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]+([-\d.]+)/);
+                                        var tx = m ? parseFloat(m[1]) : cx, ty = m ? parseFloat(m[2]) : cy;
+                                        var bb = null; try { bb = root.getBBox(); } catch (e) {}
+                                        cx = tx + (bb ? bb.x + bb.width / 2 : 0);
+                                        cy = ty + (bb ? bb.y + bb.height / 2 : 0);
+                                    }
+                                    panZoomInstance.pan({ x: s.width / 2 - cx * s.realZoom, y: s.height / 2 - cy * s.realZoom });
+                                } catch (e) { console.error('initial focus error', e); }
+                            });
 
 
 


### PR DESCRIPTION
## Contexte

PR #831 (merged on master `9dea2986`) introduced the **3-stack fix** for mindmaps in the 2 shared templates `Cards/Fallacies/Mindmaps/{included,external}.html`:

- **zoom initial lisible** centré sur la racine (`maxZoom: 6` → `15` + `requestAnimationFrame` root-focus)
- **svg-pan-zoom v3.6.2** (PR #825)
- **click-to-define** (PR #827)

The 32 wrappers (8 langues × 2 familles × 2 variantes) were last regenerated BEFORE #831 and still carried `maxZoom: 6` + no initial-focus block. This PR propagates the template fix to all 16 wrappers per family.

## Diff scope

- **32 HTML wrappers modified** (only):
  - `Cards/Fallacies/Mindmaps/{fr,en,ru,pt,es,ar,fa,zh}/Fallacies_{lang}.html` (8)
  - `Cards/Fallacies/Mindmaps/{fr,en,ru,pt,es,ar,fa,zh}/Fallacies_{lang}_ext.html` (8)
  - `Cards/Fallacies/Mindmaps/{fr,en,ru,pt,es,ar,fa,zh}/Argumentation_Virtues_{lang}.html` (8)
  - `Cards/Fallacies/Mindmaps/{fr,en,ru,pt,es,ar,fa,zh}/Argumentation_Virtues_{lang}_ext.html` (8)
- **0 SVG content.svg modified** (clean separation: content.svg stable, HTML wrappers carry the rendering logic)
- **0 source code modified**

## Pre/post control (per Issue #830 golden-master checklist, 9 capabilities)

- ✅ `grep "maxZoom: 15,"` → **32/32**
- ✅ `grep "svg-pan-zoom v3.6.2"` → **32/32**
- ✅ `grep "ZOOM INITIAL LISIBLE"` → **32/32**
- ✅ SHA256 vs livraison précédente → **32/32 changed** (anti-harvest-périmé)
- ✅ Fallacies diff = 29 lignes (+25/-4) = bloc zoom initial ciblé
- ⚠ Virtues diff = ~6500 lignes par fichier (LF vs CRLF churn — voir note ci-dessous)

## Note cosmétique (Virtues wrappers LF vs CRLF)

The Virtues wrappers show a ~6500-line delta per file because the regen writer (`File.WriteAllTextAsync` with `System.Text.Encoding.UTF8`) emits LF instead of the previous CRLF. Pure line-ending churn — content is identical, browser-side rendering unaffected (HTML parsers normalize line endings). This is cosmetic and does not affect the zoom restoration.

If a strict CRLF preservation is required for project hygiene, I can do a follow-up patch (open the file in `StreamWriter` with `new UTF8Encoding(false)` + explicit `WriteLine` to enforce `\r\n`). Not blocking the QA verdict.

## Verdict QA = ai-01 UNIQUEMENT

Per Issue #830, the 9 capabilities to validate on the regenerated wrappers (Playwright + vision, ai-01 side):

1. zoom initial lisible (racine centrée + ~11-61 nœuds visibles)
2. centrage racine analytique (`getBBox()`)
3. pan (drag + molette)
4. molette zoom in/out
5. icônes svg-pan-zoom (zoom-in, reset, zoom-out)
6. dblclick sur nœud → agrandit le nœud (mindmap behaviour natif)
7. clic sur nœud → carte correspondante (click-to-define)
8. couleurs famille (8 familles Fallacies + 8 sous-familles Virtues)
9. bornes zoom (`minZoom: 0.15`, `maxZoom: 15`)

Sample set suggested by dispatch (ai-01): FR + 1 RTL (ar/fa) + 1 CJK (zh) + FR Fallacies + FR Virtues. SHA256 ≠ livraison précédente verified ✅.

Refs #830, #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)