### PR TITLE
chore(security): #131 Phase D — pre-commit guard against web.config secret leak

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,38 @@
+# Git hooks (Argumentum)
+
+This repo ships shared git hooks in `.githooks/`. To activate them once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## pre-commit — web.config secret guard (`#131` Phase D)
+
+**Why:** `DNNPlatform/web.config` is git-tracked but the committed copy on `master`
+is a **placeholder template** (`Data Source=REPLACE`, `validationKey="REPLACE"`,
+`decryptionKey="REPLACE"` — keys excluded from the repo by design, per `#442`).
+
+At **runtime**, DNN expands these placeholders to real credentials (SQL password +
+machineKey) and rewrites the file in-place. The expanded file then shows as
+modified (`M`) in `git status`, creating a permanent risk of accidentally
+`git add`-ing and committing the real password or machineKey.
+
+**What the hook does:** if `DNNPlatform/web.config` is staged and contains a
+**real** (non-placeholder) secret pattern, the commit is **rejected**:
+
+| Pattern | Blocks when |
+|---|---|
+| `Password=<value>` | value is not `REPLACE` / `<<...>>` / `${...}` |
+| `validationKey="<16+ hex>"` | real machineKey validation key present |
+| `decryptionKey="<16+ hex>"` | real machineKey decryption key present |
+
+The master placeholder template passes (it only contains `REPLACE` tokens).
+
+**This is defense-in-depth**, orthogonal to machineKey rotation (which is a
+server-ops task, `jsboige`-gated). It does **not** modify the template itself.
+
+### Bypass (dangerous)
+
+```bash
+git commit --no-verify   # bypass ONCE — review with a coordinator first
+```

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# pre-commit hook: block accidental commit of real secrets in DNNPlatform/web.config
+#
+# Context (#131 Phase D security hardening):
+#   - DNNPlatform/web.config is git-tracked but carries PLACEHOLDERS on master
+#     (Data Source=REPLACE, validationKey="REPLACE", decryptionKey="REPLACE").
+#   - At runtime, DNN expands these placeholders to real credentials (SQL password,
+#     machineKey). The expanded file then shows as modified ("M") in git status,
+#     creating a permanent risk of accidentally committing the real password/machineKey.
+#
+# This hook is defense-in-depth: if web.config is staged and contains a REAL
+# (non-placeholder) password or machineKey, the commit is REJECTED.
+# It does NOT touch the template itself (master stays intact — load-bearing per #442).
+
+set -euo pipefail
+
+target="DNNPlatform/web.config"
+
+# Only check if web.config is staged.
+if ! git diff --cached --name-only -- "$target" | grep -q .; then
+    exit 0
+fi
+
+content=$(git show ":$target" 2>/dev/null || true)
+
+# Patterns that indicate a REAL secret (not the REPLACE placeholder).
+# Match: Password=<something that is not REPLACE/empty>, validationKey="<hex>", decryptionKey="<hex>"
+real_password=$(printf '%s' "$content" | grep -oiE 'Password=[^;"<> ]+' | grep -viE 'Password=REPLACE|Password=<<|Password=\$\{' || true)
+real_validation=$(printf '%s' "$content" | grep -oiE 'validationKey="[A-F0-9]{16,}"' || true)
+real_decryption=$(printf '%s' "$content" | grep -oiE 'decryptionKey="[A-F0-9]{16,}"' || true)
+
+if [ -n "$real_password" ] || [ -n "$real_validation" ] || [ -n "$real_decryption" ]; then
+    echo "============================================================" >&2
+    echo "  COMMIT BLOCKED: real secret detected in $target" >&2
+    echo "============================================================" >&2
+    echo "" >&2
+    echo "DNNPlatform/web.config is tracked as a PLACEHOLDER template on master." >&2
+    echo "It must keep 'Data Source=REPLACE' and 'validationKey=\"REPLACE\"' placeholders." >&2
+    echo "The runtime expands these to real credentials locally — never commit those." >&2
+    echo "" >&2
+    [ -n "$real_password" ]   && echo "  - Real SQL password pattern found" >&2
+    [ -n "$real_validation" ] && echo "  - Real machineKey validationKey found" >&2
+    [ -n "$real_decryption" ] && echo "  - Real machineKey decryptionKey found" >&2
+    echo "" >&2
+    echo "If this is intentional (e.g. adding a new placeholder pattern), review with" >&2
+    echo "a coordinator (ai-01) before overriding. To bypass ONCE (dangerous):" >&2
+    echo "    git commit --no-verify" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Defense-in-depth against accidental commit of real DNN credentials (#131 Phase D)

Per ai-01 GO (`msg-...v9ktbh`), with guard: **no self-merge** — coordinator reviews before merge (touches DNN deploy config lane).

## Problem
`DNNPlatform/web.config` is **git-tracked** but carries **PLACEHOLDERS** on master (`Data Source=REPLACE`, `validationKey="REPLACE"`, `decryptionKey="REPLACE"` — keys excluded by design per `#442`).

At **runtime**, DNN expands these to real credentials (SQL password + machineKey) and rewrites the file in-place → shows as `M` in git status → **permanent risk** of `git add`-ing the real secret.

## Fix (pre-commit hook)
`.githooks/pre-commit` rejects any staged `web.config` with a **real** (non-placeholder) secret:

| Pattern | Blocks when |
|---|---|
| `Password=<value>` | not `REPLACE` / `<<...>>` / `${...}` |
| `validationKey="<16+ hex>"` | real machineKey present |
| `decryptionKey="<16+ hex>"` | real machineKey present |

Master placeholder template **passes**. Patterns unit-tested ✅ (placeholder passes, real password + real machineKey blocked).

## Guards respected (ai-01 `v9ktbh`)
1. ✅ **Template `#442` (`092bb8f3`) intact** — hook does NOT modify `web.config` itself (no `git rm --cached`, no template edit). Load-bearing template untouched.
2. ✅ **No self-merge** — open for ai-01 review before merge.

## Orthogonality
Orthogonal to **machineKey rotation** (server-ops, `jsboige`-gated `#415`). The `4b0297ee` sandbox branch still carries the exposed machineKey; ai-01 already deleted the 2 stale CLOSED-PR branches, `dnn/sandbox-runtime-1032` remains (not force-purged). Activates per-clone via `git config core.hooksPath .githooks` (see `.githooks/README.md`).

🤖 Worker po-2023 per ai-01 dispatch (security finding `gjldby`)