### PR TITLE
feat(dataset-updater): route gpt-5.x via Responses API + reasoning effort (#141)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/DatasetUpdater/PromptResponsesApiTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/DatasetUpdater/PromptResponsesApiTests.cs
@@ -1,0 +1,86 @@
+// The OpenAI.Responses namespace is [Experimental("OPENAI001")] in the SDK. This test asserts the
+// exact effort-level mapping, so it references the enum members directly — hence the suppression.
+#pragma warning disable OPENAI001
+using Argumentum.AssetConverter;
+using FluentAssertions;
+using OpenAI.Responses;
+using Xunit;
+
+namespace Argumentum.AssetConverter.Tests.DatasetUpdater
+{
+    /// <summary>
+    /// Unit cover for the Responses-API path added to <see cref="Prompt"/> (issue #141 re-scope:
+    /// gpt-5.x must route through /v1/responses with a capped reasoning effort — Chat Completions
+    /// burns the budget on hidden reasoning and returns empty Content).
+    ///
+    /// The live <c>SendViaResponses</c> call needs the network, so it is not unit-testable here.
+    /// What IS pure logic and load-bearing is <see cref="Prompt.ParseReasoningEffort"/>: it maps a
+    /// config string to a <see cref="ResponseReasoningEffortLevel"/> and — critically — falls back
+    /// to <c>Low</c> (the intended default for cost-bounded translation runs) for any unrecognised
+    /// value rather than throwing. Throwing here would abort an entire translation campaign on one
+    /// bad config string; that contract is worth pinning.
+    ///
+    /// Also pins that the Prompt Responses knobs (<c>UseResponsesApi</c>, <c>ReasoningEffort</c>)
+    /// default to the legacy path (off / null) so existing gpt-4.1 behaviour is unchanged unless a
+    /// task explicitly opts in — the change is additive and reversible by construction.
+    /// </summary>
+    public class PromptResponsesApiTests
+    {
+        [Theory]
+        [InlineData("minimal")]
+        [InlineData("low")]
+        [InlineData("medium")]
+        [InlineData("high")]
+        public void ParseReasoningEffort_RecognisedLevel_MapsToMatchingMember(string input)
+        {
+            // ParseReasoningEffort must map each canonical token to its matching effort-level
+            // member (compared struct-to-struct, not via ToString, because
+            // ResponseReasoningEffortLevel is a custom struct whose serialized value is lowercase
+            // while nameof()/ToString() disagree on casing).
+            var actual = Prompt.ParseReasoningEffort(input);
+            var expected = input switch
+            {
+                "minimal" => ResponseReasoningEffortLevel.Minimal,
+                "low" => ResponseReasoningEffortLevel.Low,
+                "medium" => ResponseReasoningEffortLevel.Medium,
+                "high" => ResponseReasoningEffortLevel.High,
+                _ => ResponseReasoningEffortLevel.Low,
+            };
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("LOW")]      // upper-case
+        [InlineData("  Low  ")]  // surrounding whitespace
+        [InlineData("low")]      // canonical
+        public void ParseReasoningEffort_IsCaseInsensitiveAndTrimsWhitespace(string input)
+        {
+            Prompt.ParseReasoningEffort(input)
+                .Should().Be(ResponseReasoningEffortLevel.Low);
+        }
+
+        [Theory]
+        [InlineData("ultra")]      // unknown level
+        [InlineData("")]           // empty
+        [InlineData("n/a")]        // junk
+        public void ParseReasoningEffort_UnknownValue_FallsBackToLow_NotThrows(string input)
+        {
+            // The contract: a bad config value must NOT abort a translation campaign. It maps to
+            // Low (the cost-bounded default) rather than throwing.
+            var act = () => Prompt.ParseReasoningEffort(input);
+            act.Should().NotThrow();
+            act().Should().Be(ResponseReasoningEffortLevel.Low);
+        }
+
+        [Fact]
+        public void Prompt_ResponsesApiDefaults_OffAndNull_LegacyPathPreserved()
+        {
+            // A freshly constructed Prompt must NOT opt into the Responses path and must NOT set a
+            // reasoning effort. This guarantees the change is additive: tasks that do not set these
+            // flags keep the existing Chat Completions behaviour byte-for-byte.
+            var prompt = new Prompt();
+            prompt.UseResponsesApi.Should().BeFalse("the Responses path is opt-in only");
+            prompt.ReasoningEffort.Should().BeNull("no reasoning effort is applied unless explicitly configured");
+        }
+    }
+}

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/DatasetUpdaterConfig.cs
@@ -34,6 +34,20 @@ public class DatasetUpdaterConfig
 
 	public string? BaseUrl { get; set; }
 
+	/// <summary>
+	/// When true, route translation calls through the OpenAI Responses API (/v1/responses) instead
+	/// of Chat Completions. Required for reasoning models (gpt-5.x), which return empty Content on
+	/// Chat Completions (budget burnt on hidden reasoning) but produce usable output on
+	/// /v1/responses with <see cref="ReasoningEffort"/> capped. Default false.
+	/// </summary>
+	public bool UseResponsesApi { get; set; }
+
+	/// <summary>
+	/// Reasoning effort for the Responses API ("minimal"|"low"|"medium"|"high"). Recommended "low"
+	/// for gpt-5.x translation tasks. Only effective when <see cref="UseResponsesApi"/> is true.
+	/// </summary>
+	public string ReasoningEffort { get; set; }
+
 	public int? MaxOutputTokens { get; set; }
 
 	public int MaxTokensPerMinute { get; set; } = 70000;
@@ -477,6 +491,8 @@ public class DatasetUpdaterConfig
 					BaseUrl = BaseUrl,
 					MaxOutputTokens = MaxOutputTokens,
 					Model = Model,
+					UseResponsesApi = UseResponsesApi,
+					ReasoningEffort = ReasoningEffort,
 					SystemPrompt = systemPrompt,
 					DialogPrompts = DialogPrompts,
 					UserPrompt = chunk,

--- a/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Prompt.cs
+++ b/Generation/Converters/Argumentum.AssetConverter/DatasetUpdater/Prompt.cs
@@ -1,4 +1,8 @@
 #nullable enable
+// The OpenAI.Responses namespace is [Experimental("OPENAI001")] in the SDK. We adopt it
+// deliberately here (the Responses API is the supported path for reasoning models); this file is
+// the only consumer, so the suppression is scoped to it rather than promoted to the csproj.
+#pragma warning disable OPENAI001
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,6 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenAI.Chat;
+using OpenAI.Responses;
 
 namespace Argumentum.AssetConverter;
 
@@ -21,6 +26,22 @@ public class Prompt
     public string? BaseUrl { get; set; }
 
     public int? MaxOutputTokens { get; set; }
+
+    /// <summary>
+    /// When true, route the call through the OpenAI Responses API (/v1/responses) instead of
+    /// Chat Completions. Required for reasoning models (gpt-5.x): on Chat Completions they burn
+    /// the token budget on hidden reasoning and return an empty Content, whereas /v1/responses
+    /// honours <see cref="ReasoningEffort"/> (=low) and returns usable output. Default false keeps
+    /// the legacy gpt-4.1 path unchanged.
+    /// </summary>
+    public bool UseResponsesApi { get; set; }
+
+    /// <summary>
+    /// Reasoning effort for the Responses API ("minimal"|"low"|"medium"|"high"). Null/empty = omit
+    /// (server default). Use "low" for gpt-5.x translation tasks to cap reasoning-token spend.
+    /// Only effective when <see cref="UseResponsesApi"/> is true.
+    /// </summary>
+    public string? ReasoningEffort { get; set; }
 
     public string SystemPrompt { get; set; } = "";
 
@@ -51,6 +72,30 @@ public class Prompt
         }
     }
 
+    private ResponsesClient? _responsesClient;
+
+    /// <summary>
+    /// Lazy Responses-API client. Shares the underlying <see cref="_openAIClient"/> with
+    /// <see cref="ChatClient"/> (creating it on first use when only the Responses path is taken).
+    /// Unlike ChatClient, the Responses client is model-agnostic: the model is supplied per call
+    /// via <see cref="CreateResponseOptions.Model"/>.
+    /// </summary>
+    public ResponsesClient ResponsesClient
+    {
+        get
+        {
+            if (_responsesClient == null)
+            {
+                _openAIClient ??= !string.IsNullOrEmpty(BaseUrl)
+                    ? new OpenAI.OpenAIClient(new System.ClientModel.ApiKeyCredential(ApiKey),
+                        new OpenAI.OpenAIClientOptions { Endpoint = new Uri(BaseUrl) })
+                    : new OpenAI.OpenAIClient(ApiKey);
+                _responsesClient = _openAIClient.GetResponsesClient();
+            }
+            return _responsesClient;
+        }
+    }
+
     public List<FunctionToolDef> Functions { get; set; } = new();
 
     public string? FunctionName { get; set; }
@@ -69,6 +114,11 @@ public class Prompt
                 }
             }
             Tokenizer(UserPrompt);
+        }
+
+        if (UseResponsesApi)
+        {
+            return await SendViaResponses(cancellationToken, log);
         }
 
         var messages = new List<ChatMessage>
@@ -130,6 +180,115 @@ public class Prompt
         }
 
         return "";
+    }
+
+    /// <summary>
+    /// Responses-API (/v1/responses) call path — mirrors <see cref="Send"/> but routes through
+    /// <see cref="ResponsesClient"/> and, crucially, can set <see cref="ResponseReasoningOptions"/>
+    /// (reasoning effort). This is the supported path for reasoning models (gpt-5.x); the Chat
+    /// Completions path returns empty Content for them because it cannot cap reasoning-token spend.
+    /// Reversible: only taken when <see cref="UseResponsesApi"/> is true (default false).
+    /// </summary>
+    private async Task<string> SendViaResponses(CancellationToken cancellationToken, Action<string> log)
+    {
+        var options = new CreateResponseOptions
+        {
+            Model = Model,
+        };
+
+        if (!string.IsNullOrEmpty(SystemPrompt))
+        {
+            options.InputItems.Add(ResponseItem.CreateSystemMessageItem(SystemPrompt));
+        }
+
+        if (DialogPrompts != null)
+        {
+            foreach (var dialogPrompt in DialogPrompts)
+            {
+                options.InputItems.Add(ResponseItem.CreateUserMessageItem(dialogPrompt.UserPrompt));
+                options.InputItems.Add(ResponseItem.CreateAssistantMessageItem(dialogPrompt.AssistantAnswer));
+            }
+        }
+
+        options.InputItems.Add(ResponseItem.CreateUserMessageItem(UserPrompt));
+
+        if (MaxOutputTokens.HasValue)
+        {
+            options.MaxOutputTokenCount = MaxOutputTokens.Value;
+        }
+
+        if (!string.IsNullOrEmpty(ReasoningEffort))
+        {
+            options.ReasoningOptions = new ResponseReasoningOptions
+            {
+                ReasoningEffortLevel = ParseReasoningEffort(ReasoningEffort),
+            };
+        }
+
+        if (Functions != null && Functions.Count > 0)
+        {
+            foreach (var func in Functions)
+            {
+                options.Tools.Add(new FunctionTool(
+                    func.Name,
+                    BinaryData.FromString(func.ParametersJson),
+                    strictModeEnabled: null)
+                {
+                    FunctionDescription = func.Description,
+                });
+            }
+
+            if (FunctionName != null)
+            {
+                options.ToolChoice = ResponseToolChoice.CreateFunctionChoice(FunctionName);
+            }
+        }
+
+        var response = await ResponsesClient.CreateResponseAsync(options, cancellationToken);
+        var result = response.Value;
+
+        // Function-calling path: execute the requested tools (mirrors the Chat Completions branch
+        // in Send). The Responses API returns each call as a FunctionCallResponseItem.
+        if (result.OutputItems != null)
+        {
+            foreach (var item in result.OutputItems)
+            {
+                if (item is FunctionCallResponseItem functionCall)
+                {
+                    var callResult = CallFunction(functionCall.FunctionName, functionCall.FunctionArguments.ToString());
+                    log($"Function call {functionCall.FunctionName} with arguments {functionCall.FunctionArguments}");
+                }
+            }
+        }
+
+        var outputText = result.GetOutputText();
+        if (!string.IsNullOrEmpty(outputText))
+        {
+            if (Tokenizer != null)
+            {
+                Tokenizer(outputText);
+            }
+            return outputText;
+        }
+
+        return "";
+    }
+
+    /// <summary>
+    /// Maps a config string to a <see cref="ResponseReasoningEffortLevel"/>. Unknown values fall
+    /// back to Low (the intended default for cost-bounded translation runs) rather than throwing —
+    /// a bad config value should not abort an entire translation campaign.
+    /// </summary>
+    internal static ResponseReasoningEffortLevel ParseReasoningEffort(string effort)
+    {
+        return effort.Trim().ToLowerInvariant() switch
+        {
+            "minimal" => ResponseReasoningEffortLevel.Minimal,
+            "low" => ResponseReasoningEffortLevel.Low,
+            "medium" => ResponseReasoningEffortLevel.Medium,
+            "high" => ResponseReasoningEffortLevel.High,
+            _ => ResponseReasoningEffortLevel.Low,
+        };
     }
 
     private string CallFunction(string functionName, string argumentsJson)


### PR DESCRIPTION
## What

**#141 re-scope executed** (po-2024, ai-01 coordinator GO `msg-q9uhmf`) — route the DatasetUpdater translation loop through the OpenAI **Responses API (/v1/responses)** with capped **reasoning effort**, so reasoning models (gpt-5.x) return usable output instead of empty Content.

## Why (the gap, verified)

`Prompt.cs` called `CompleteChatAsync` (Chat Completions). For gpt-5.x, Chat Completions burns the token budget on **hidden reasoning** and returns **empty Content** (`:132` → `""`) — the documented failure mode. The dashboard's own API metric records the intended config:

> gpt-5.5 /v1/responses, reasoning:{effort:"low"}, max_output_tokens=7000

**The code contradicted the intended config.** This is the mine under the next gpt-5.5 translation campaign.

## Why #141 as originally written was superseded

Read-before-acting (empirical) found the original premise null:
- **91 non-card nodes (depth 1-3) = 100% complete** (`desc_*`+`text_*` × 8 langs, 0 empty). Nothing to enrich.
- **SDK already modernized** (PR #210, OpenAI 2.10.0). "Modernize" scope = resolved.

So writing a non-card enrichment script = filler. The **real** residual gap is the /v1/responses routing — generic across all 48 task configs, not non-card-specific. ai-01 corroborated via the dashboard metric and re-scoped (coordinator decision, not gated jsboige).

## Changes (additive + reversible)

| File | Change |
|------|--------|
| `Prompt.cs` | `UseResponsesApi` + `ReasoningEffort` props; lazy `ResponsesClient` (shares the `OpenAIClient`); `SendViaResponses` — input via `options.InputItems`, `ResponseReasoningOptions` (effort), function tools + tool-choice, `FunctionCallResponseItem` processing, `GetOutputText`. `#pragma disable OPENAI001` (`OpenAI.Responses` is `[Experimental]`). |
| `DatasetUpdaterConfig.cs` | `UseResponsesApi` + `ReasoningEffort` config (default **off/null** → legacy gpt-4.1 path unchanged unless a task opts in). Wired into the `Prompt` ctor in `DoChatGPTCall`. |
| `PromptResponsesApiTests.cs` (new) | `ParseReasoningEffort` mapping (case-insensitive, unknown→Low fallback, **no throw** — a bad config must not abort a campaign) + Responses knobs default off (legacy path preserved). |

Function-calling carried over (all gpt-5.5 tasks are `UseFunctionCalling=true`).

## Tests

- **637 pass / 0 fail / 5 skip / 642 total** (full AssetConverter suite, .NET 9).
- The **13 `RecordsUpdaterContractTests` stay GREEN** (`RecordsUpdater` untouched).
- 11 new tests pin the effort-mapping contract + the opt-in default.
- Build zero-warning.

## Governance / scope

- **DatasetUpdater stays `Enabled=false`** → 0 run live, **0 prod CSV** (T&A freeze respected). Tested plumbing, not a campaign.
- Reversible by construction (`UseResponsesApi` default false).
- Coordinator decision (dette technique code), not gated jsboige. This PR body serves as the durable record of the #141 re-scope (no separate #141 comment needed).

## To activate (future, post-T&A)

Set `UseResponsesApi=true` + `ReasoningEffort="low"` on the gpt-5.5 task configs in `DatasetUpdaterRootConfig` — left at default (off) in this PR to keep it pure plumbing.

Relates #141 #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
