### PR TITLE
chore(hygiene): gitignore regenerable 141 sidecar + Python bytecode (#415 align)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,17 @@ DNNPlatform/Install/Module/*.zip
 # Large generated SVGs (regenerable via MindMapper pipeline)
 # Note: small source SVGs in Cards/ are kept
 Generation/Converters/Argumentum.AssetConverter/Mindmapper/*.svg
+
+# #141 AIF full-scale candidate sidecar — regenerable derived data
+# (python docs/taxonomy/141-aif-fullscale.py --finalize regenerates from checkpoint,
+#  no API calls). 1.3 MB; per 141-aif-fullscale-report.md it is a tmp/regenerable
+#  artifact, not source. Referenced by 7 committed docs/scripts that document the
+#  regen path. Aligns #415 (reduce .git weight) — keep local, never commit.
+docs/taxonomy/141-aif-candidates-fullscale.json
+
+# Python bytecode / cache — never commit (standard hygiene). The repo ships Python
+# tooling in tools/, docs/taxonomy/, docs/investigations/scripts/; __pycache__ is
+# machine-specific and churns. Catches the untracked docs/taxonomy/__pycache__/ etc.
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
## What

**Housekeeping micro-PR**, ai-01-directed (Re: ASK tick 90, `msg-7d6ioe`). Gitignores the untracked `docs/taxonomy/141-aif-candidates-fullscale.json` (regenerable derived data) + adds standard Python bytecode hygiene. **0 prod CSV, 0 code, docs/config-only, reversible.**

## (1) 141 sidecar — regenerable, not source

`docs/taxonomy/141-aif-candidates-fullscale.json` (1.3 MB) is **regenerable derived data**. Verified code=truth:
- Written by **`docs/taxonomy/141-aif-fullscale.py`** (committed, #623).
- `python docs/taxonomy/141-aif-fullscale.py --finalize` regenerates from checkpoint (**no API calls**).
- `141-aif-fullscale-report.md` **already documents** it as `❌ tmp/ — regenerable via --finalize` (lines 11, 118) + gives the regen command → **no report edit needed** (note present, no pendulum).

Referenced by 7 committed docs/scripts (all document the regen path). Aligns **#415** (reduce `.git` weight): a regenerable 1.3 MB artifact does not belong in git. **Keep local, never commit.**

## (2) Python bytecode hygiene (included, same commit)

The repo ships Python tooling (`tools/`, `docs/taxonomy/`, `docs/investigations/scripts/`) but had **no `__pycache__`/`*.pyc` ignore pattern** — 2 untracked `__pycache__` dirs present today (real accidental-commit risk as the Python tooling grows). Added standard `__pycache__/` + `*.py[cod]` + `*$py.class`. Not scope creep — same single-purpose hygiene commit.

## Verification

```
$ git check-ignore -v docs/taxonomy/141-aif-candidates-fullscale.json
.gitignore:265:docs/taxonomy/141-aif-candidates-fullscale.json   ✓ ignored
$ git check-ignore -v docs/taxonomy/__pycache__/
.gitignore:270:__pycache__/   ✓ ignored
$ git check-ignore -v tools/foo.pyc
.gitignore:271:*.py[cod]   ✓ ignored
```
False-positive guard: `847-*.csv/md`, `141-aif-fullscale-report.md`, acompte — all **NOT** ignored (source, must stay tracked). ✓

`git status` after: 141 JSON + `__pycache__` gone from untracked; only `.gitignore` (this change) + `.mcp.json`/`tmp/` (out of scope, not my lane) remain.

## Governance

- **0 prod CSV** (T&A freeze). 0 code touched. Config-only, fully reversible (delete the 3 lines).
- Lane: po-2024 (content/hygiene). ai-01 explicitly greenlit ("Micro-PR 5 min OK").
- Did NOT delete the local file (preservation — regen on demand).

## Refs

ai-01 `msg-7d6ioe` (Re: ASK tick 90). #415 (reduce .git weight). #623 (141-aif-fullscale.py). #141 (AIF chantier). Base master `18d16962`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
