### PR TITLE
chore(hygiene): gitignore root tmp/ scratch dir (#858 align)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,9 @@ docs/taxonomy/141-aif-candidates-fullscale.json
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Root tmp/ scratch dir — local regenerable working files (AIF #141/#498 datasets,
+#  run logs, audit samples). ~1.3 MB; regenerable from committed scripts (e.g.
+#  docs/taxonomy/141-aif-fullscale.py, tools/498-*.py). Machine-specific scratch,
+#  never source — root-anchored (/tmp/) so a legit nested tmp/ elsewhere is unaffected.
+/tmp/


### PR DESCRIPTION
## What

Adds a root-anchored `/tmp/` entry to `.gitignore`.

## Why

Root `tmp/` was untracked-but-not-ignored, risking accidental commit of ~1.3 MB of regenerable local working files:

- `141-aif-fullscale.jsonl` (1.1 MB), `141-aif-candidates-sample.json`, `141-aif-sample.json`
- `498-extract.json`, `498_phase2_dataset.json`, `498_phase3_dataset.json`
- run logs (`141-aif-fullscale.log`, `415-audit-run.txt`), manifests

Flagged by po-2023 (tick 40) as an accidental-commit hazard. The `.gitignore` already documents these as "tmp/regenerable" (L262 comment) and handles the largest sidecar per-file (`docs/taxonomy/141-aif-candidates-fullscale.json`), but the `tmp/` directory itself was not covered.

## Scope

- Root-anchored `/tmp/` — only the root scratch dir is ignored; a legitimate nested `tmp/` elsewhere in the tree is unaffected.
- All content under `tmp/` is regenerable from committed scripts (`docs/taxonomy/141-aif-fullscale.py`, `tools/498-*.py`). No source lost.

## Verification

- `git check-ignore -v tmp/` → `.gitignore:278:/tmp/  tmp/` ✅
- `tmp/` removed from `git status` untracked list ✅
- Only `.gitignore` staged (the local `.vscode/settings.json` Peacock theme and `.mcp.json` are unrelated, left out) ✅

## Alignment

Follows #858 (gitignore regenerable 141 sidecar + Python bytecode) — same lane, same hygiene intent (#415 git-weight reduction, accidental-commit surface reduction). Read-only hygiene PR, 0 prod CSV, 0 code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
