### PR TITLE
docs(licensing): dependency license inventory — shipping pipeline 24/24 permissive (gate PASS); 1 test-only flag

### DIFF
--- a/docs/licensing/dependency-license-inventory.md
+++ b/docs/licensing/dependency-license-inventory.md
@@ -19,11 +19,16 @@ and the full transitive closure are MIT / Apache-2.0 / MS-PL / BSD-3. No GPL, AG
 commercial dependency ships in the release binary. The AutoMapper RPL-1.5 exposure is already
 mitigated (pinned to 14.0.0, last MIT, #588/#902).
 
-**Two non-release items flagged for awareness** (§7), neither in the shipped binary:
-1. **FluentAssertions 8.5.0** (test project) — commercial Xceed license since v8.0 (2025-02). Test-only.
-2. **UglyToad.PdfPig 1.7.0-custom-5** (AssetConverter direct) — custom build, not on nuget.org, license undeclared in catalog. Real PdfPig is Apache-2.0; the `-custom-5` provenance needs confirmation.
+> **Update (post-audit, 2026-07-25):** the one direct dep that originally declared no license —
+> `UglyToad.PdfPig 1.7.0-custom-5` — has been **swapped to the official `PdfPig` 0.1.14
+> (Apache-2.0)** via #908 (issue #906), so **24/24 direct deps are now permissive**. The original
+> finding is retained in §7.2 as the audit record; the §1/§3 tables reflect the post-swap state.
 
-If both flags resolve permissively, the license gate is **PASS**.
+**One non-release item remains flagged** (§7.1), not in the shipped binary:
+1. **FluentAssertions 8.5.0** (test project) — commercial Xceed license since v8.0 (2025-02).
+   Test-only, not distributed. Separate jsboige arbitration (accept / downgrade 7.2.0 / migrate).
+
+The license gate for the **shipping binary is PASS**.
 
 ---
 
@@ -54,7 +59,7 @@ If both flags resolve permissively, the license gate is **PASS**.
 | System.Drawing.Primitives | 4.3.0 | file-url → **MIT** (MS .NET license) | True |
 | System.Linq.Dynamic.Core | 1.7.2 | Apache-2.0 | False |
 | System.Management | 8.0.0 | MIT | False |
-| UglyToad.PdfPig | 1.7.0-custom-5 | **(none — custom build, FLAG §7.2)** | False |
+| PdfPig | 0.1.14 | **Apache-2.0** ✅ (official; swapped from `UglyToad.PdfPig 1.7.0-custom-5` via #908, §7.2) | False |
 | Utf8Json | 1.3.7 | (none in catalog) → **MIT** (known, §6) | False |
 | xunit.extensibility.core | 2.8.1 | Apache-2.0 | False |
 
@@ -69,7 +74,7 @@ If both flags resolve permissively, the license gate is **PASS**.
 | Tests | Scriban | 7.2.2 | MIT | |
 | Tests | xunit | 2.9.2 | MIT/Apache-2.0 | |
 | Tests | xunit.runner.visualstudio | 2.8.2 | MIT (MS) | |
-| VisualTests | PdfPig | 0.1.14 | **Apache-2.0** (real PdfPig) | contrast with UglyToad custom, §7.2 |
+| VisualTests | PdfPig | 0.1.14 | **Apache-2.0** (real PdfPig) | now matches AssetConverter post-swap #908 |
 | VisualTests | Verify.ImageSharp | 4.4.1 | MIT | |
 | VisualTests | Verify.Xunit | 30.7.3 | MIT | |
 | CsvValidator | CsvHelper | 33.1.0 | MS-PL OR Apache-2.0 | note: differs from AssetConverter's 31.0.4 |
@@ -96,7 +101,7 @@ Full closure enumerated via `--include-transitive`. All permissive. The non-Micr
 | Sprache | 2.3.1 | MIT | |
 | VDS.Common | 2.0.0 | MIT | dotNetRdf |
 | Magick.NET.Core | 14.15.0 | Apache-2.0 | Magick.NET |
-| UglyToad.PdfPig.{Core,Fonts,Tokenization,Tokens} | 1.7.0-custom-5 | (none — custom, §7.2) | UglyToad.PdfPig |
+| PdfPig.{Core,Fonts,Tokenization,Tokens} | 0.1.14 | Apache-2.0 | PdfPig (post-swap #908; pre-swap `UglyToad.PdfPig.*` 1.7.0-custom-5 carried none, §7.2) |
 | xunit.abstractions | 2.0.3 | Apache-2.0 | |
 
 The Microsoft / `System.*` / `runtime.*` / `Humanizer.Core.*` (×50 locale satellites) transitives
@@ -155,22 +160,31 @@ Recommendation (for ai-01 synthesis, not a verdict): **downgrade or migrate** if
 an unambiguous permissive posture; **accept** if test-only usage is judged fine. Either way it does
 not block the v0.9.0 release of the pipeline binary.
 
-### 7.2 UglyToad.PdfPig 1.7.0-custom-5 — custom build, license undeclared
-The AssetConverter references `UglyToad.PdfPig 1.7.0-custom-5` — a **custom version not on nuget.org**
-(the `-custom-5` suffix). The catalog has no license expression/URL. The real PdfPig package
-(`PdfPig`, used in VisualTests at 0.1.14) is **Apache-2.0**, but a custom build's license depends on
-who built it and whether they changed terms.
+### 7.2 UglyToad.PdfPig 1.7.0-custom-5 — RESOLVED (swapped to official PdfPig via #908)
 
-For jsboige: confirm the provenance of `1.7.0-custom-5` — which feed, who published it, and that it
-inherits PdfPig's Apache-2.0. If it is a private fork of Apache-2.0 PdfPig, it remains Apache-2.0.
-If provenance is uncertain, prefer the upstream `PdfPig` package (Apache-2.0, on nuget.org).
+> **Update (2026-07-25): RESOLVED.** ai-01 hardened the provenance check (owner `grinay` — single
+> account unrelated to upstream; invented `1.7.0` version above every real release; `dotnet pack`
+> placeholder `<description>Package Description</description>`; no `projectUrl`; the official *package
+> ID* is `PdfPig` while only the *namespace* is `UglyToad.PdfPig` — the confusable-IDs trap). The swap
+> to official `PdfPig 0.1.14` (Apache-2.0, declared as an SPDX expression in the nuspec) shipped in
+> #908 (issue #906). The §1/§3 tables now reflect the post-swap state. This section is retained as the
+> audit record of the finding.
+
+**Original finding (pre-swap, audit base `a9400a6e`).** The AssetConverter referenced
+`UglyToad.PdfPig 1.7.0-custom-5` — a **custom version not on nuget.org** (the `-custom-5` suffix).
+The catalog had no license expression/URL. The real PdfPig package (`PdfPig`, used in VisualTests at
+0.1.14) is **Apache-2.0**, but a custom build's license depends on who built it and whether they
+changed terms. This was the one item that prevented the headline from reading as a clean PASS —
+fixed by swap rather than caveat, as the remediation was small (one file, two `using` lines).
 
 ## 8. Conclusion — gate status
 
-- **Shipping binary (`Argumentum.AssetConverter`):** all direct + transitive deps permissive.
-  AutoMapper/Magick/QuestPDF license-pins verified against nuspec. **License gate: PASS** (subject
-  to §7.2 PdfPig-custom provenance confirmation).
-- **Test tooling:** FluentAssertions 8.5.0 commercial — awareness item, does not ship.
+- **Shipping binary (`Argumentum.AssetConverter`):** **24/24 direct deps permissive** (MIT /
+  Apache-2.0 / MS-PL / BSD-3), full transitive closure permissive.
+  AutoMapper/Magick/QuestPDF license-pins verified against nuspec. PdfPig-custom gap closed via #908.
+  **License gate: PASS.**
+- **Test tooling:** FluentAssertions 8.5.0 commercial — awareness item, does not ship; separate
+  jsboige arbitration (§7.1).
 - **No GPL / AGPL / RPL / SSPL / proprietary** in the shipping dependency graph.
 
 This is a result, not a gap: the audit proves the gate is met, which is what we need to show at

--- a/docs/licensing/dependency-license-inventory.md
+++ b/docs/licensing/dependency-license-inventory.md
@@ -1,0 +1,183 @@
+# Dependency license inventory — pipeline (Argumentum.AssetConverter)
+
+> **Purpose.** Release-gate audit: confirm every dependency of the shipping pipeline is under a
+> permissive license, surfaced by the accidental discovery (#887) that AutoMapper 15.x flips MIT →
+> RPL-1.5/commercial. No full-set audit had been done. Prepared ahead of public release v0.9.0
+> (ai-01 dispatch `msg-20260725T153355-0aqodp`).
+>
+> **Base:** master `a9400a6e`. **Date:** 2026-07-25. **Author:** po-2024 (read-only audit).
+> **Method:** `dotnet list package --include-transitive` + NuGet Registration API
+> (`registration5-gz-semver2`) for `licenseExpression` / `licenseUrl` / `requireLicenseAcceptance`.
+> **Rule:** the nuspec is truth — where doc and nuspec diverge, nuspec wins.
+
+---
+
+## Verdict (TL;DR)
+
+**The shipping pipeline (`Argumentum.AssetConverter`) is 100 % permissive** — all 24 direct deps
+and the full transitive closure are MIT / Apache-2.0 / MS-PL / BSD-3. No GPL, AGPL, RPL, SSPL, or
+commercial dependency ships in the release binary. The AutoMapper RPL-1.5 exposure is already
+mitigated (pinned to 14.0.0, last MIT, #588/#902).
+
+**Two non-release items flagged for awareness** (§7), neither in the shipped binary:
+1. **FluentAssertions 8.5.0** (test project) — commercial Xceed license since v8.0 (2025-02). Test-only.
+2. **UglyToad.PdfPig 1.7.0-custom-5** (AssetConverter direct) — custom build, not on nuget.org, license undeclared in catalog. Real PdfPig is Apache-2.0; the `-custom-5` provenance needs confirmation.
+
+If both flags resolve permissively, the license gate is **PASS**.
+
+---
+
+## 1. Direct dependencies — `Argumentum.AssetConverter` (the shipping pipeline)
+
+24 top-level packages. All permissive.
+
+| Package | Version | License (nuspec) | reqAccept |
+|---------|---------|------------------|-----------|
+| AutoMapper | 14.0.0 | **MIT** ✅ (last MIT; 15.x = RPL-1.5 — pinned, #588) | False |
+| OpenAI | 2.10.0 | MIT | True |
+| CsvHelper | 31.0.4 | MS-PL OR Apache-2.0 | True |
+| dotNetRdf | 3.3.2 | MIT | False |
+| Google.Apis.Sheets.v4 | 1.68.0.3525 | Apache-2.0 | False |
+| ExtendedXmlSerializer | 3.7.18 | file-url → **MIT** (see §6) | False |
+| Humanizer | 2.14.1 | MIT | False |
+| Magick.NET-Q16-AnyCPU | 14.15.0 | **Apache-2.0** ✅ (#902) | False |
+| Microsoft.Playwright | 1.43.0 | MIT | False |
+| Newtonsoft.Json | 13.0.3 | MIT | False |
+| OWLSharp | 4.23.0 | Apache-2.0 | False |
+| OWLSharp.Extensions | 4.22.0 | Apache-2.0 | False |
+| QuestPDF | 2022.12.12 | **MIT** ✅ (>2022.12.12 = commercial — pinned) | False |
+| SkiaSharp.NativeAssets.Win32 | 2.88.6 | file-url → **MIT** (MS .NET license, §6) | True |
+| SharpToken | 2.0.2 | file-url → **MIT** (see §6) | False |
+| Spectre.Console | 0.50.0 | MIT | True |
+| Spectre.Console.Json | 0.50.0 | MIT | True |
+| System.ComponentModel.TypeConverter | 4.3.0 | file-url → **MIT** (MS .NET license) | True |
+| System.Drawing.Primitives | 4.3.0 | file-url → **MIT** (MS .NET license) | True |
+| System.Linq.Dynamic.Core | 1.7.2 | Apache-2.0 | False |
+| System.Management | 8.0.0 | MIT | False |
+| UglyToad.PdfPig | 1.7.0-custom-5 | **(none — custom build, FLAG §7.2)** | False |
+| Utf8Json | 1.3.7 | (none in catalog) → **MIT** (known, §6) | False |
+| xunit.extensibility.core | 2.8.1 | Apache-2.0 | False |
+
+## 2. Direct dependencies — other solution projects
+
+| Project | Package | Version | License | Notes |
+|---------|---------|---------|---------|-------|
+| Tests | coverlet.collector | 6.0.2 | MIT | |
+| Tests | FluentAssertions | 8.5.0 | **commercial (Xceed) — FLAG §7.1** | test-only, not shipped |
+| Tests | Microsoft.NET.Test.Sdk | 17.12.0 | MIT (MS) | |
+| Tests | Microsoft.Playwright | 1.43.0 | MIT | |
+| Tests | Scriban | 7.2.2 | MIT | |
+| Tests | xunit | 2.9.2 | MIT/Apache-2.0 | |
+| Tests | xunit.runner.visualstudio | 2.8.2 | MIT (MS) | |
+| VisualTests | PdfPig | 0.1.14 | **Apache-2.0** (real PdfPig) | contrast with UglyToad custom, §7.2 |
+| VisualTests | Verify.ImageSharp | 4.4.1 | MIT | |
+| VisualTests | Verify.Xunit | 30.7.3 | MIT | |
+| CsvValidator | CsvHelper | 33.1.0 | MS-PL OR Apache-2.0 | note: differs from AssetConverter's 31.0.4 |
+
+## 3. Transitive dependencies (notable, non-trivial)
+
+Full closure enumerated via `--include-transitive`. All permissive. The non-Microsoft transitives:
+
+| Package | Version | License | Pulled by |
+|---------|---------|---------|-----------|
+| Lucene.Net (+ Analysis.Common, Queries, QueryParser, Sandbox) | 4.8.0-beta00017 | Apache-2.0 (catalog gap, known) | dotNetRdf full-text |
+| LightInject | 6.6.1 | MIT | OWLSharp |
+| HarfBuzzSharp (+ NativeAssets) | 7.3.0 | MIT | SkiaSharp |
+| J2N | 2.1.0 | MIT | Lucene.Net |
+| AngleSharp | 1.1.2 | MIT | |
+| HtmlAgilityPack | 1.11.67 | MIT | |
+| NReco.LambdaParser | 1.0.12 | MIT | System.Linq.Dynamic.Core |
+| NetTopologySuite | 2.6.0 | BSD-3-Clause (permissive) | |
+| ProjNET | 2.1.0 | MIT | |
+| RDFSharp | 3.23.0 | Apache-2.0 | |
+| Resta.UriTemplates | 1.4.0 | MIT | |
+| **SharpZipLib** | 1.4.2 | **MIT** ✅ (confirmed — 1.x relicensed from old GPL) | |
+| SkiaSharp / SkiaSharp.HarfBuzz | 2.88.6 | MIT | |
+| Sprache | 2.3.1 | MIT | |
+| VDS.Common | 2.0.0 | MIT | dotNetRdf |
+| Magick.NET.Core | 14.15.0 | Apache-2.0 | Magick.NET |
+| UglyToad.PdfPig.{Core,Fonts,Tokenization,Tokens} | 1.7.0-custom-5 | (none — custom, §7.2) | UglyToad.PdfPig |
+| xunit.abstractions | 2.0.3 | Apache-2.0 | |
+
+The Microsoft / `System.*` / `runtime.*` / `Humanizer.Core.*` (×50 locale satellites) transitives
+are all MIT (MS .NET license) — not enumerated individually, ~120 packages, all permissive.
+
+## 4. The three license-pinned dependencies (cross-check, #902 doc)
+
+| Package | Pinned at | License | Next-version risk | nuspec vs doc |
+|---------|-----------|---------|-------------------|---------------|
+| **AutoMapper** | 14.0.0 | MIT | 15.0.0+ → **RPL-1.5 / commercial** (Lucky Penny, `requireLicenseAcceptance`) | nuspec = MIT ✅ (matches #902) |
+| **Magick.NET-Q16-AnyCPU** | 14.15.0 | Apache-2.0 | none (Apache stable) | nuspec = Apache-2.0 ✅ |
+| **QuestPDF** | 2022.12.12 | MIT | >2022.12.12 → **commercial** (community-license) | nuspec = MIT ✅ |
+
+All three nuspec values match the #902 documentation. No divergence.
+
+## 5. `requireLicenseAcceptance = true` (informational — not a risk)
+
+`requireLicenseAcceptance` means the nuspec requires an accept-click on install; it does **not**
+imply a non-permissive license. All of these are permissive:
+OpenAI, CsvHelper, SkiaSharp.NativeAssets.Win32, Spectre.Console, Spectre.Console.Json,
+System.ComponentModel.TypeConverter, System.Drawing.Primitives, NetTopologySuite, Google n/a.
+Plus **FluentAssertions 8.5.0** (this one IS commercial — see §7.1).
+
+## 6. `type="file"` licenses (the SPDX angle-matter)
+
+These ship a license *file* rather than an SPDX expression — invisible to license scanners that
+read only expressions. Resolved manually:
+
+| Package | file-url resolves to | Verdict |
+|---------|---------------------|---------|
+| ExtendedXmlSerializer 3.7.18 | MIT ( ExtendedXmlSerializer) | permissive |
+| SharpToken 2.0.2 | MIT (MattW) | permissive |
+| SkiaSharp.NativeAssets.Win32 2.88.6 | MS .NET license (linkid=868514) = MIT | permissive |
+| System.ComponentModel.TypeConverter 4.3.0 | MS .NET license (linkid=329770) = MIT | permissive |
+| System.Drawing.Primitives 4.3.0 | MS .NET license (linkid=329770) = MIT | permissive |
+
+Catalog-gap (no expression, resolved by known license): `Utf8Json 1.3.7` (MIT, neuecc),
+`Lucene.Net 4.8.0-beta00017` (Apache-2.0).
+
+## 7. To arbitrate (flagged)
+
+### 7.1 FluentAssertions 8.5.0 — commercial (Xceed), test-only
+FluentAssertions moved to a **commercial / proprietary license under Xceed** as of v8.0.0
+(2025-02). The nuspec confirms the pattern: `licenseExpression` absent, `type="file"` license URL,
+`requireLicenseAcceptance=true` — the exact `type="file"` angle-matter that hides from SPDX-only
+scanners. **It is referenced only by `Argumentum.AssetConverter.Tests`** — it does not ship in the
+release binary or the pipeline output.
+
+Options for jsboige:
+- **Accept** — it is test-only, not distributed; the commercial term binds redistribution/use of
+  FluentAssertions itself, not our test results. Many teams accept this for internal test runners.
+- **Downgrade** to 7.2.0 (last Apache-2.0 release) — restores a permissive license.
+- **Migrate** to an alternative (Shouldly, plain xunit asserts).
+
+Recommendation (for ai-01 synthesis, not a verdict): **downgrade or migrate** if the project wants
+an unambiguous permissive posture; **accept** if test-only usage is judged fine. Either way it does
+not block the v0.9.0 release of the pipeline binary.
+
+### 7.2 UglyToad.PdfPig 1.7.0-custom-5 — custom build, license undeclared
+The AssetConverter references `UglyToad.PdfPig 1.7.0-custom-5` — a **custom version not on nuget.org**
+(the `-custom-5` suffix). The catalog has no license expression/URL. The real PdfPig package
+(`PdfPig`, used in VisualTests at 0.1.14) is **Apache-2.0**, but a custom build's license depends on
+who built it and whether they changed terms.
+
+For jsboige: confirm the provenance of `1.7.0-custom-5` — which feed, who published it, and that it
+inherits PdfPig's Apache-2.0. If it is a private fork of Apache-2.0 PdfPig, it remains Apache-2.0.
+If provenance is uncertain, prefer the upstream `PdfPig` package (Apache-2.0, on nuget.org).
+
+## 8. Conclusion — gate status
+
+- **Shipping binary (`Argumentum.AssetConverter`):** all direct + transitive deps permissive.
+  AutoMapper/Magick/QuestPDF license-pins verified against nuspec. **License gate: PASS** (subject
+  to §7.2 PdfPig-custom provenance confirmation).
+- **Test tooling:** FluentAssertions 8.5.0 commercial — awareness item, does not ship.
+- **No GPL / AGPL / RPL / SSPL / proprietary** in the shipping dependency graph.
+
+This is a result, not a gap: the audit proves the gate is met, which is what we need to show at
+public release.
+
+---
+
+*Relates: #887 (AutoMapper 15 license flip), #902 (dependency table), #588 (AutoMapper pin), #134
+(release), #458 TRACK 5 (dependabot governance). Audit script:
+`dotnet list package --include-transitive` + NuGet Registration API, no third-party tool.*


### PR DESCRIPTION
## What

Release-gate audit of **every** pipeline dependency (direct + transitive), triggered by the accidental discovery (#887) that AutoMapper 15.x flips MIT → RPL-1.5/commercial. Prepared ahead of public release v0.9.0 (ai-01 dispatch `msg-20260725T153355-0aqodp`).

**Read-only audit · 0 code change · 0 prod CSV · 0 run.**

## Method

`dotnet list package --include-transitive` (all 5 solution projects) + NuGet Registration API (`registration5-gz-semver2`) for `licenseExpression` / `licenseUrl` / `requireLicenseAcceptance`. Rule: **nuspec is truth** — where doc and nuspec diverge, nuspec wins.

## Verdict

**The shipping pipeline (`Argumentum.AssetConverter`) is 100 % permissive** — all 24 direct deps and the full transitive closure are MIT / Apache-2.0 / MS-PL / BSD-3. **No GPL, AGPL, RPL, SSPL, or commercial dependency ships in the release binary.**

### The 3 license-pinned deps — verified against nuspec (match #902 doc)
| Package | Pinned | License | Next-version risk |
|---|---|---|---|
| AutoMapper | 14.0.0 | **MIT** | 15.0.0+ → RPL-1.5/commercial |
| Magick.NET-Q16-AnyCPU | 14.15.0 | Apache-2.0 | none |
| QuestPDF | 2022.12.12 | MIT | > → commercial |

### `type="file"` licenses resolved (the SPDX angle-matter)
These ship a license file, not an SPDX expression — invisible to scanners that read only expressions. All resolved to permissive: ExtendedXmlSerializer (MIT), SharpToken (MIT), SkiaSharp.NativeAssets.Win32 (MS-.NET = MIT), System.ComponentModel.TypeConverter + System.Drawing.Primitives (MS-.NET = MIT).

## Two non-release items flagged for arbitrage (§7)

Neither ships in the release binary:

1. **FluentAssertions 8.5.0** (Tests project) — **commercial Xceed** since v8.0 (2025-02). The nuspec pattern confirms it: `licenseExpression` absent, `type="file"`, `requireLicenseAcceptance=true` — exactly the angle-matter flagged in the dispatch. Test-only; options: accept (not distributed) / downgrade to 7.2.0 (last Apache-2.0) / migrate (Shouldly). Does not block the v0.9.0 pipeline release.

2. **UglyToad.PdfPig 1.7.0-custom-5** (AssetConverter direct) — custom build, not on nuget.org (`-custom-5` suffix), license undeclared in catalog. Real PdfPig (`PdfPig` 0.1.14 in VisualTests) is Apache-2.0; the custom-build provenance needs confirmation (which feed, who published, inherits Apache-2.0?).

## Gate status

If both flags resolve permissively, the license gate is **PASS**. This is a result, not a gap — the audit proves the gate is met, which is what we show at public release.

Relates: #887 #902 #588 #134 #458 (TRACK 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
