### PR TITLE
chore(deps): swap UglyToad.PdfPig 1.7.0-custom-5 → official PdfPig 0.1.14 (#906, release licence gate)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/PdfAssembly/PdfAssemblerTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/PdfAssembly/PdfAssemblerTests.cs
@@ -85,6 +85,51 @@ namespace Argumentum.AssetConverter.Tests.PdfAssembly
             return pngPaths;
         }
 
+        [Fact]
+        // Regression guard for #906 (UglyToad.PdfPig 1.7.0-custom-5 → official PdfPig 0.1.14 swap):
+        // PdfAuditor's PdfPig read path — PdfDocument.Open → GetPages → GetImages → RawBytes — must
+        // still execute against a real, generated PDF on the official package. A compile-only check
+        // would miss a runtime API divergence (e.g. GetImages renamed/removed); this generates a real
+        // PDF with embedded card images and runs the auditor end-to-end.
+        public async Task AuditPdf_WithGeneratedPdf_ShouldReadEmbeddedImagesViaPdfPig()
+        {
+            // ARRANGE — generate a real PDF with embedded PNG images (same path as the assembly test)
+            var generatedPngPaths = await GeneratePngsFromHtmlFiles();
+            var outputPdfPath = Path.Combine(_testOutputDir, "audited.pdf");
+            var cardImages = generatedPngPaths.Select(p => new CardImages { Front = p }).ToList();
+
+            var docConfig = new CardSetDocumentConfig
+            {
+                DocumentFormat = CardDocumentFormat.PrintAndPlay,
+                PageSize = "A4",
+                NbColumns = 3,
+                NoBack = true,
+                CardSets = new List<DocumentCardSet>
+                {
+                    new DocumentCardSet
+                    {
+                        FrontCards = new DocumentCard { WidthMM = 63, HeigthMM = 88 }
+                    }
+                }
+            };
+
+            new PdfManager().GeneratePrintAndPlay(outputPdfPath, docConfig, cardImages, true);
+            File.Exists(outputPdfPath).Should().BeTrue("the PDF must exist before auditing");
+
+            // ACT — run PdfAuditor (exercises GetPages/GetImages/RawBytes on official PdfPig 0.1.14)
+            var result = global::Argumentum.AssetConverter.PdfAuditor.PdfAuditor.AuditPdf(outputPdfPath, docConfig, cardImages);
+
+            // ASSERT — the PdfPig read path ran without an API-divergence exception, and GetImages
+            // returned the embedded card images (so RawBytes hashing was actually exercised). A clean
+            // PASS or a count mismatch are both acceptable — both prove images were read; an
+            // "unexpected error" or "found 0" would signal PdfPig 0.1.14 divergence and fail the swap.
+            var messages = string.Join("\n", result.Messages);
+            messages.Should().NotContain("unexpected error occurred during PDF audit",
+                "PdfPig 0.1.14 must support the GetImages/RawBytes path PdfAuditor relies on");
+            messages.Should().NotContain("found 0 images",
+                "PdfPig GetImages must surface the embedded card images so RawBytes is exercised");
+        }
+
         public void Dispose()
         {
             if (Directory.Exists(_testOutputDir))

--- a/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
+++ b/Generation/Converters/Argumentum.AssetConverter/Argumentum.AssetConverter.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageReference Include="System.Management" Version="8.0.0" />
-    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+    <PackageReference Include="PdfPig" Version="0.1.14" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="xunit.extensibility.core" Version="2.8.1" />
   </ItemGroup>


### PR DESCRIPTION
Closes #906 — surfaced by the release licence audit (#905, po-2024) and hardened by ai-01's provenance check.

## Change

One `PackageReference` swap in `Argumentum.AssetConverter.csproj`:

```xml
-    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+    <PackageReference Include="PdfPig" Version="0.1.14" />
```

The shipping project depended directly on `UglyToad.PdfPig 1.7.0-custom-5` — a third-party republish (owner `grinay`, invented `1.7.0` version above every real upstream release, `dotnet pack` placeholder description, **no declared licence**). It was the single item preventing the licence gate from reading as PASS.

Replaced with the **official `PdfPig` 0.1.14** — the version `Argumentum.AssetConverter.VisualTests` already builds against in this solution. Verified licence from the nuspec (nuspec = truth):

- `<license type="expression">Apache-2.0</license>`
- `<licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>`
- `<projectUrl>https://github.com/UglyToad/PdfPig</projectUrl>`

The official package shares the identical `UglyToad.PdfPig` namespace, so no `using` lines change. Official PdfPig has no stable ≥1.0 release (0.1.16-alpha is newest as of July 2026), so 0.1.14 is the proven-in-solution choice rather than chasing a non-existent "newer stable".

## DoD — issue #906 checklist

- [x] `UglyToad.PdfPig 1.7.0-custom-5` replaced by official `PdfPig 0.1.14` (aligned on the VisualTests version) in `Argumentum.AssetConverter.csproj`
- [x] Solution builds clean, **zero new warnings** (#587) — forced `restore` + build = `0 Avertissement(s) / 0 Erreur(s)`
- [x] `dotnet test` on `Argumentum.AssetConverter.Tests` — **638 pass / 0 fail / 5 skip** (no regression vs the 637/0/5 current baseline; +1 is the new guard below). *(Note: the issue body's "578/1/5" baseline is stale — the #133 OWL test passes now and the suite grew to 642; 637/0/5 is the authoritative current baseline per ai-01's last tick.)*
- [x] **PdfAuditor runs on a real generated PDF** (not just compiles) — new regression test `AuditPdf_WithGeneratedPdf_ShouldReadEmbeddedImagesViaPdfPig` generates a Print&Play PDF and exercises `PdfDocument.Open → GetPages → GetImages → RawBytes` end-to-end on 0.1.14
- [ ] `docs/licensing/dependency-license-inventory.md` (#905) updated — **next**, on the #905 branch: PdfPig entry → Apache-2.0, §Verdict headline → clean PASS. (Done as a separate push to #905 so this PR stays a clean licence swap.)
- [x] Old package not left as a dangling transitive — `UglyToad.PdfPig` is no longer referenced anywhere in the solution; both consumers (AssetConverter + Tests via project ref) resolve to official PdfPig 0.1.14, matching VisualTests

## Added regression guard

`PdfAssemblerTests.AuditPdf_WithGeneratedPdf_ShouldReadEmbeddedImagesViaPdfPig` — guards exactly the regression this swap could introduce: a future PdfPig API change silently breaking `PdfAuditor`'s read path. It asserts the PdfPig read runs without an API-divergence exception AND that `GetImages` surfaces the embedded card images (so `RawBytes` hashing is exercised). It deliberately does **not** assert the audit verdict — the documented latent geometry divergence in `ComputeAuditPageGeometry` (hardcoded A4 vs renderer's resolved page size) is a separate, pre-existing behavior-change concern unrelated to this licence swap. Aligns with open #212 (Playwright/PDF regression coverage).

## Verification detail

- `dotnet list package --vulnerable`: only the known, deliberately-suppressed AutoMapper 14.0.0 advisory (GHSA-rvv3-g6hj-g44x, `NuGetAuditSuppress` + `MaxDepth(1)` guard, decision jsboige 2026-06-23). **0 advisory on PdfPig.**
- No API divergence encountered — escalation clause not triggered.

## Out of scope (per issue #906)

FluentAssertions 8.5.0 (commercial Xceed since v8.0) — test-only, not distributed, separate jsboige arbitration (accept / downgrade 7.2.0 Apache-2.0 / migrate Shouldly).

Refs #905 #887 #902 #588 #134 #458 (TRACK 5).

🤖 po-2024 — dispatched by ai-01 (`3zhzkb`)
