### PR TITLE
chore(ci): add .github/dependabot.yml — group + ignore-major policy (vendored npm + AutoMapper) [DRAFT for jsboige scope arbitration]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,609 @@
+# Dependabot configuration for ArgumentumGames/Argumentum
+#
+# Authored by po-2024 (tick 113), dispatched by ai-01 (`3zhzkb`).
+# OPEN AS A PR — NOT merged. Deliberate jsboige arbitration on scope (see PR body).
+#
+# Policy summary:
+#   1. nuget (our .NET pipeline)         -> group + ignore AutoMapper majors (license barrier #588/#887)
+#   2. npm vendored DNNPlatform trees     -> group + ignore majors (unvalidated in CI, #901)
+#   3. npm our trees (CardPen, pdf-val)   -> group + ignore majors
+#
+# Why groups: collapses multiple same-directory bumps into ONE pull request. The repo saw
+# ~34 dependabot PRs in a single cycle (mostly the same package bumped across many 2sxc
+# module trees, e.g. loader-utils x5). `groups` turns N-per-dir into 1-per-dir.
+#
+# Why ignore-major on npm vendored: a major bump edits package.json in a tree that nothing
+# in CI builds or consumes (#901 - webpack-dev-server 5->6 in Bootstrap 4 Instant). Patch/minor
+# are lockfile-only and are merged per precedent #120.
+
+version: 2
+enable-beta-ecosystems: false
+
+updates:
+  # --- 1. NuGet: the .NET pipeline (our code) ---
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      dotnet:
+        patterns: ["*"]
+    ignore:
+      # AutoMapper 14.0.0 is the LAST MIT release; 15.0.0+ flips to RPL-1.5 / commercial
+      # (Lucky Penny, requireLicenseAcceptance). Pinned by decision jsboige 2026-06-23 (#588).
+      # A dependabot major bump would re-propose the commercial line; ignore it at the source.
+      - dependency-name: "AutoMapper"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "nuget"
+
+  # --- 2. npm: our own trees (customized CardPen fork + pdf-validation tooling) ---
+  - package-ecosystem: "npm"
+    directory: "/Generation/CardPen"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+
+
+  - package-ecosystem: "npm"
+    directory: "/docs/investigations/pdf-validation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+
+
+  # --- 3. npm: vendored DNNPlatform / 2sxc trees (upstream templates, NOT built by our CI) ---
+  # Each block targets exactly one directory (dependabot does not glob directories).
+  # Patch/minor = lockfile-only no-ops, merged per precedent #120; majors are ignored (#901).
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1-System/Skins/Bootstrap 4 Instant"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Accordion4"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/AddSearch3"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Blog5"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/CTA3"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Content"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Content/bs5"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Counter2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/EventsAndCourses6"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Faq4"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Gallery7"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Glossary3"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/ImageCompare2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/ImageHotspots3"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Jobs2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/MobiusForms5"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/News5"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/PeopleDirectory4"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/PodCast2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/PopupMessage3"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/QrCode2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Swiper2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/Timeline3"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/1/2sxc/TimelineJs2"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/_default/Skins/2shineBS5"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+
+  - package-ecosystem: "npm"
+    directory: "/DNNPlatform/Portals/_default/Skins/Bootstrap 4 Instant"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "vendored"
+


### PR DESCRIPTION
Adds the repo's first `dependabot.yml`, encoding the policy ai-01 dispatched (`3zhzkb`). **Not for merge as-is** — scope is a deliberate jsboige arbitration (option A vs B below). Dispatched by ai-01; authored by po-2024 (tick 113).

## Why now

No `dependabot.yml` existed in the repo. Dependabot was running on GitHub's auto-detected config and produced **~34 PRs in a single cycle** — almost entirely the *same* package bumped across many vendored 2sxc module trees (loader-utils ×5, json5 ×4, braces ×2, svgo ×3, postcss ×3…). The coordinator triaged all 34 last cycle and extracted two real signals (#871 Magick.NET, #887 AutoMapper) from the noise. This config makes that triage structural instead of ad-hoc.

## The policy (3 sections)

| # | Ecosystem / scope | Directory | `groups` | `ignore` |
|---|-------------------|-----------|----------|----------|
| 1 | **nuget** — our .NET pipeline | `/` | `patterns: ["*"]` (batch) | AutoMapper **majors** (license barrier, #588) |
| 2 | **npm** — our trees (CardPen fork, pdf-validation) | `/Generation/CardPen`, `/docs/investigations/pdf-validation` | `patterns: ["*"]` | majors |
| 3 | **npm** — vendored DNNPlatform / 2sxc trees (26 dirs) | one block each under `/DNNPlatform/...` | `patterns: ["*"]` | majors |

- **`groups`** collapses multiple same-directory bumps into ONE PR (N-per-dir → 1-per-dir).
- **`ignore` majors on npm vendored**: a major edits `package.json` in a tree that nothing in CI builds or consumes — **#901** (webpack-dev-server 5→6 in `Bootstrap 4 Instant`) is the canonical case ai-01 held for exactly this reason. Patch/minor stay lockfile-only no-ops, merged per precedent #120.
- **`ignore` AutoMapper majors**: 14.0.0 is the LAST MIT release; 15.0.0+ flips to RPL-1.5/commercial (Lucky Penny). Pinned by decision jsboige 2026-06-23 (#588). Ignoring the major at the source stops dependabot re-proposing the commercial line (#887).

## Validation

- ✅ Passes the official **schemastore dependabot-2.0** JSON schema (validated with `jsonschema`, `$ref` resolved).
- ✅ Valid YAML (`yaml.safe_load`).
- ✅ 29 update blocks discovered programmatically (`find package-lock.json`, not hand-typed) — 1 nuget + 2 our-npm + 26 vendored-npm.

## 🔀 jsboige arbitration — option A vs B

Section 3 (26 vendored blocks) is the decision. Two defensible policies:

- **Option A — keep monitoring, grouped + ignore-major** *(embodied in this PR; ai-01's "batcher les lockfiles vendorés" intent)*. Preserves the security signal from vendored deps; `groups` cuts the volume from ~34 PRs/cycle to ≤26 (one per tree, weekly). Precedent #120 (merge no-op vendored bumps) treats the signal as worth keeping. **Cost**: 26 near-identical blocks; new 2sxc modules aren't auto-covered (must add a block); file is 609 lines.

- **Option B — stop monitoring the vendored trees** *(leaner)*. They are upstream DNN/2sxc vendor templates — not our code, not built or consumed by any CI workflow, and ai-01's #901 reasoning ("rien en CI ne la valide ni consomme") argues they shouldn't generate work for us at all. Security of vendored deps is the upstream's responsibility. **Cost**: lose the transitive-vuln signal on vendored deps (mitigation: rely on the upstream DNN/2sxc advisories, and the real pipeline — nuget — stays monitored).

My recommendation: **Option B** is the more honest fit for the repo's actual build surface, but **Option A** is shipped here because ai-01's dispatch named the "batcher" policy. If jsboige picks B, section 3 is the **tail** of the file — delete from the `# --- 3. npm: vendored` marker to EOF and the config is correct (1 nuget + 2 our-npm). One command:

```bash
sed -i '' '/# --- 3\. npm: vendored/,$d' .github/dependabot.yml   # macOS/BSD
sed -i    '/# --- 3\. npm: vendored/,$d' .github/dependabot.yml   # GNU
```

Either way, sections 1–2 (nuget pipeline + our own npm trees) are unambiguous and should land.

## Schedule / limits

- All sections: **weekly, Monday**; `open-pull-requests-limit` 10 (nuget) / 5 (our npm) / 3 (vendored).
- `commit-message` prefix `chore(deps)` with scope; labels `dependencies` + ecosystem (+ `vendored` for section 3).

## Out of scope

- **FluentAssertions 8.5.0** (commercial Xceed, #905) — separate jsboige arbitration.
- **#415 git history rewrite** — unrelated.
- Per-tree npm dependency upgrades themselves — dependabot will propose them once enabled.

Refs #901 (vendored major hold), #887/#588 (AutoMapper license pin), #120 (vendored no-op precedent), #458 TRACK 5.

🤖 po-2024 — dispatched by ai-01 (`3zhzkb`)
