### PR TITLE
fix(ci): #909 make the Test step actually run tests (Tests.csproj was missing from the .sln)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,13 @@ jobs:
         run: dotnet build "Argumentum Converters.sln" --no-restore -c ${{ matrix.configuration }}
 
       - name: Test
-        run: dotnet test "Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj" --no-build -c ${{ matrix.configuration }} --verbosity normal
+        # #909: the Test step was a silent no-op — Argumentum.AssetConverter.Tests.csproj was NOT in
+        # Argumentum Converters.sln, so the Build step never built it, and `--no-build` then found no
+        # assembly and exited 0 having run zero tests. Two fixes, both needed:
+        #  (1) Tests.csproj is now in the .sln (Restore/Build cover it, and the #587 NuGet audit now
+        #      scans test deps too — FluentAssertions, Playwright, xunit).
+        #  (2) `--no-build` dropped so the step is self-sufficient: if Tests is ever not built upstream,
+        #      `dotnet test` builds it (loud failure on error) instead of silently no-op'ing.
+        # Browser tests (HtmlToPngConverterTests, PdfAssemblerTests) self-install chromium in-test via
+        # Microsoft.Playwright.Program.Main("install","chromium"); no separate install step needed.
+        run: dotnet test "Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj" -c ${{ matrix.configuration }} --verbosity normal

--- a/Argumentum Converters.sln
+++ b/Argumentum Converters.sln
@@ -50,6 +50,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Converters", "Converters", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Argumentum.AssetConverter.VisualTests", "Generation\Converters\Argumentum.AssetConverter.VisualTests\Argumentum.AssetConverter.VisualTests.csproj", "{F777878A-1E32-4393-9CB1-1D7F98965DEE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Argumentum.AssetConverter.Tests", "Generation\Converters\Argumentum.AssetConverter.Tests\Argumentum.AssetConverter.Tests.csproj", "{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,18 @@ Global
 		{F777878A-1E32-4393-9CB1-1D7F98965DEE}.Release|x64.Build.0 = Release|Any CPU
 		{F777878A-1E32-4393-9CB1-1D7F98965DEE}.Release|x86.ActiveCfg = Release|Any CPU
 		{F777878A-1E32-4393-9CB1-1D7F98965DEE}.Release|x86.Build.0 = Release|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Debug|x64.Build.0 = Debug|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Debug|x86.Build.0 = Debug|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Release|x64.ActiveCfg = Release|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Release|x64.Build.0 = Release|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Release|x86.ActiveCfg = Release|Any CPU
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +110,7 @@ Global
 		{1A7077BC-7CA9-4D76-9D96-C674564283F9} = {A3188815-F9CE-4FAD-8E43-3D216DA51E5D}
 		{22204A79-A715-187C-1CCC-42730285228E} = {36912121-518A-D096-DAD0-E6C5A9AF61AB}
 		{F777878A-1E32-4393-9CB1-1D7F98965DEE} = {22204A79-A715-187C-1CCC-42730285228E}
+		{C712CED0-1E3F-41B5-8D99-15CFB7CD9513} = {22204A79-A715-187C-1CCC-42730285228E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C0667D66-974C-44D8-AAF8-3DB41AADBBF5}

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/PdfCmykPostProcess/PdfCmykPostProcessTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/PdfCmykPostProcess/PdfCmykPostProcessTests.cs
@@ -34,8 +34,14 @@ namespace Argumentum.AssetConverter.Tests.PdfCmykPostProcess
         [Fact]
         public void GetEnabled_is_release_only_by_default()
         {
+            // Force the build mode explicitly instead of relying on the compiled #if DEBUG flag
+            // (AssetConverterConfig.isInDebugMode). The CI Test matrix runs BOTH Debug and Release
+            // configurations (#909), so a test that depends on the assembly being Debug-built would
+            // pass in one matrix leg and fail in the other. Forcing ForceDebugParams/ForceReleaseParams
+            // makes the assertion deterministic under both — the contract under test is the DEFAULT
+            // pair (EnabledDebug=false, EnabledRelease=true), not which way the test host compiled.
             var config = new PdfCmykPostProcessConfig();
-            var debugConfig = new AssetConverterConfig(); // isInDebugMode=true under Debug tests
+            var debugConfig = new AssetConverterConfig { ForceDebugParams = true };
             var releaseConfig = new AssetConverterConfig { ForceReleaseParams = true };
 
             // Default pair: EnabledDebug=false, EnabledRelease=true → OFF in Debug, ON in Release.


### PR DESCRIPTION
Closes #909 — the CI `Test` step has never run a single test in this repo. Dispatched by ai-01 (`vmwfb6`, PRIMARY).

## Finding (confirmed firsthand)

The `Test` step in `build.yml` was a **silent no-op**. Run `30171875373` (cited by ai-01): 0.59 s, "Build succeeded", zero tests discovered/executed, exit 0. Locally the same suite takes ~10 s and reports **638 passed**.

Root cause (two parts):
1. **`Argumentum.AssetConverter.Tests.csproj` was not in `Argumentum Converters.sln`** — `VisualTests` was, `Tests` was not (verified: 0 occurrences vs 1). So `dotnet restore`/`build` of the .sln never touched Tests.
2. The Test step used **`--no-build`** → `dotnet test Tests.csproj` found no built assembly and exited 0 having run nothing. Silent, not a failure.

**Blast radius beyond "no test signal":**
- The **#587 NuGet audit didn't cover test deps** — FluentAssertions 8.5.0 (commercial Xceed, jsboige arbitration), Microsoft.Playwright, xunit were in no scan.
- Every prior "CI green" check certified **build only**, never tests — including #908's "638/0/5 verified" (correct, but local-only; not CI-validated until this lands).

## Fix (2 changes, both needed)

1. **`dotnet sln add` Tests.csproj** → Restore/Build now cover it; #587 NuGet audit now scans test deps.
2. **Drop `--no-build`** from the Test step → it becomes self-sufficient (builds Tests if not built upstream; **loud failure** on error instead of silent no-op). Removes the silent-regression mode entirely.

## Verification (local — the summary line, not the check colour)

Per ai-01's DoD: cite the execution summary, don't trust the green check.

```
dotnet build "Argumentum Converters.sln" -c Debug   →  0 warning, 0 error (Tests now builds)
dotnet test Tests.csproj -c Debug                    →  échec: 0, réussite: 638, ignorée(s): 5, total: 643
```

Baseline **638/0/5** reproduced, 0 regression.

## ⚠️ This PR's own CI run IS the proof

This is the first PR where the Test step will actually execute in GitHub Actions. Two things it will validate that I could **not** verify locally:

- **Does the Playwright self-install work on `windows-latest`?** Two test classes launch real browsers (`HtmlToPngConverterTests`, `PdfAssemblerTests`). Both self-install chromium in-test via `Microsoft.Playwright.Program.Main(new[] { "install", "chromium" })` and assert exit==0. No separate CI install step is added — the in-test install runs in the correct output-directory context. If the runner can't download/run chromium (network, system deps), these tests fail loudly. **Per #909 DoD: I did NOT disable them and added no `continue-on-error`/`|| true`.** If CI goes red on Playwright, that is the expected escalation surface — surface it, don't silence it.
- **Does the Release matrix config pass too?** Verified Debug; Release should be config-agnostic.

If CI is green → the fix is complete and every future PR finally has real test coverage. If CI is red on Playwright → arbitrate: add a dedicated `pwsh ...\playwright.ps1 install chromium` step (path-dependent on build output) vs. mark the 2 browser tests `[Trait("Category","Integration")]`-style and exclude them from CI with a documented reason (NOT a silent skip).

## DoD #909 checklist

- [x] Tests.csproj added to `Argumentum Converters.sln`
- [x] Test step no longer a silent no-op (verified 638/0/5 summary line locally)
- [x] No test disabled; no `continue-on-error` / `|| true` — the step can fail
- [x] Baseline 638/0/5 reproduced locally
- [x] NuGet audit (#587) now covers test deps (Tests is in the restored/built .sln)

## Out of scope

- FluentAssertions 8.5.0 commercial-license arbitration — separate (now at least *visible* to the audit).
- VisualTests CI coverage (it's in the .sln; not targeted by the Test step, which stays scoped to Tests).

Refs #909 #587 #908 (baseline source). Dispatched by ai-01 (`vmwfb6`).

🤖 po-2024
