### PR TITLE
chore(tools): 812 audit script detects _csv_note marker -> risk NONE (#812 close)

### DIFF
--- a/tools/812-template-stale-csv-audit.py
+++ b/tools/812-template-stale-csv-audit.py
@@ -70,6 +70,23 @@ def read_template_csv(path):
     csd = doc.get("CardSetDocument") or doc
     return csd.get("csv")
 
+def read_template_csv_note(path):
+    """Return the '_csv_note' sibling marker if present, else None.
+
+    Code=truth (HarvestManager.cs:342-363): for any Face (DataSet != None and
+    SkipDataUpdate != true) the embedded 'csv' is overridden at render by the
+    DataSet source CSV, so the embedded copy is stale-by-design. The _csv_note
+    marker (subtractive, ignored by CardPen which reads 'csv'/'mustache'/'css')
+    acknowledges that staleness — its presence downgrades the audit risk to NONE.
+    See issue #812 + PRs #813 (audit) / #815 (markers landed on master)."""
+    try:
+        with open(path, encoding="utf-8-sig") as f:
+            doc = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    csd = doc.get("CardSetDocument") or doc
+    return csd.get("_csv_note")
+
 def read_source_csv(path):
     """Read raw CSV file content as text (preserve encoding BOM + CRLF)."""
     try:
@@ -230,6 +247,16 @@ def main():
                     "risk": "REVIEW",
                     "note": "template sans clé 'csv' (non-CardPen ?)",
                     "reason": "no csv key"})
+                continue
+            csv_note = read_template_csv_note(tmpl_path)
+            if csv_note:
+                counts["risk-NONE"] += 1
+                findings.append({**base,
+                    "risk": "NONE",
+                    "reason": "ignored via _csv_note marker (STALE acknowledged, overridden at runtime by DataSet)",
+                    "note": f"_csv_note present — render truth = DataSet CSV (HarvestManager.cs:363); embedded csv is dead at render",
+                    "csv_note": csv_note,
+                })
                 continue
             summary = diff_samples(src_text, tmpl_csv)
             src_stats = stats_for_csv(src_text)


### PR DESCRIPTION
Closes #812 — last open item of the documented tick-23 plan.

## What

The #812 stale-embedded-csv audit script (`tools/812-template-stale-csv-audit.py`, PR #813) was written in tick 23 **before** the `_csv_note` markers landed on master (via #815). It therefore still reported **risk-HIGH** on all 10 Face templates — a false alarm: the embedded `csv` IS stale-by-design (overridden at render by the DataSet source CSV, `HarvestManager.cs:342-363`), and the `_csv_note` marker already acknowledges that (#812 step 2 — subtractive, ignored by CardPen which reads `csv`/`mustache`/`css`).

This closes the last open item of issue #812's documented plan (po-2024 tick-23 comment on #812):

> *"Re-run du script → vérifier risk-HIGH devient risk-NONE avec message 'ignored via _csv_note marker'."*

## Changes (read-only tool, 0 prod write, 0 test impact)

- **New `read_template_csv_note(path)`** — reads the `_csv_note` sibling marker from the template JSON (same `CardSetDocument`-aware path as `read_template_csv`).
- **Main loop** — when `_csv_note` is present, emit `risk=NONE` with reason *"ignored via _csv_note marker (STALE acknowledged, overridden at runtime by DataSet)"* and skip the HIGH-prone `classify()` path. The `csv_note` text is captured in the finding for traceability.

## Verification (code=truth)

Re-run before patch: **10 HIGH** + 5 N/A (false alarms on every Face).
Re-run after patch:

| CardSets scoped | templates analysed | NONE | LOW | MEDIUM | HIGH | REVIEW | skip |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 15 | 15 | **15** | 0 | 0 | **0** | 0 | 0 |

The 10 Face templates (Rules, Fallacies Face/_2/_3/Web, Virtues, Scenarii Face/Back, Memo Face/Back) all downgrade cleanly via the marker; the 5 Back/DataSet=None templates stay N/A as before. The 2 orphan templates (`Rules_Back_fr`, `Rules_…_Print_and_Play`) are not in the active config registry, so out of scope.

## Scope / safety

- **0 production write** — this is an audit/CI-guard script only. No CSV, no template, no config touched.
- **Lane:** po-2024 (content/hygiene). Post-tag-safe.
- **No new test** — the script is itself the guard; a re-run producing `0 HIGH` is the proof (the summary line above).
- Not touched: `tools/812-csv-note-marker-apply.py` (the markers are already on master via #815; the apply script is retained for archival/reproducibility but not re-run).

## Issue #812 status after merge

Both documented steps are complete on master:
1. ✅ Audit doc — PR #813 (merged `16a7ef14`)
2. ✅ `_csv_note` markers on 10 Face templates — landed via #815 (`34819ecd`); PR #814 was closed but its content entered through #815
3. ✅ **Audit script recognizes the markers** (this PR) → re-run is green (0 HIGH)

→ #812 can be closed.

Refs #812 #813 #814 #815. Dispatched by ai-01 (`vmwfb6` tertiaire, continuation of `3ukdoj` tick 23).

🤖 po-2024
