### PR TITLE
docs(ci): dependabot.yml — record the jsboige arbitration (header still said "NOT merged")

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 # Dependabot configuration for ArgumentumGames/Argumentum
 #
 # Authored by po-2024 (tick 113), dispatched by ai-01 (`3zhzkb`).
-# OPEN AS A PR — NOT merged. Deliberate jsboige arbitration on scope (see PR body).
+# Merged in #910. Scope arbitrated by jsboige 2026-07-26 (interactive): option A —
+# "surveiller, groupé + ignore-major" on the 26 vendored 2sxc/DNN npm trees. They stay
+# under dependabot surveillance (security patches/minors keep arriving); only majors are
+# filtered. Ceiling ~26 PR/week instead of several hundred ungrouped.
 #
 # Policy summary:
 #   1. nuget (our .NET pipeline)         -> group + ignore AutoMapper majors (license barrier #588/#887)
@@ -13,8 +16,12 @@
 # module trees, e.g. loader-utils x5). `groups` turns N-per-dir into 1-per-dir.
 #
 # Why ignore-major on npm vendored: a major bump edits package.json in a tree that nothing
-# in CI builds or consumes (#901 - webpack-dev-server 5->6 in Bootstrap 4 Instant). Patch/minor
-# are lockfile-only and are merged per precedent #120.
+# in CI builds or consumes (#901 - webpack-dev-server 5->6 in Bootstrap 4 Instant; that PR was
+# closed out-of-policy under this very rule). Patch/minor are lockfile-only and are merged
+# per precedent #120.
+#
+# Escape hatch: if a CVE is ever fixable ONLY by a major on a vendored tree, drop the `ignore`
+# for that one directory here — do not merge the major bypassing this policy.
 
 version: 2
 enable-beta-ecosystems: false


### PR DESCRIPTION
La politique dependabot a été mergée en #910 (`05e12463`), mais le fichier a atterri sur master **avec son en-tête d'avant-merge** :

```
# OPEN AS A PR — NOT merged. Deliberate jsboige arbitration on scope (see PR body).
```

Les deux moitiés sont fausses depuis le merge : le fichier **est** mergé, et l'arbitrage **est** rendu. Un fichier de politique qui affirme être en attente d'arbitrage se relit, dans six mois, comme une politique non ratifiée.

## Ce que ça enregistre

**Décision jsboige, interactive, 2026-07-26 — option A** : les 26 arbres npm vendored (2sxc/DNN) restent **sous surveillance** dependabot, **groupés**, **majors filtrés**. Les patches et minors de sécurité continuent d'arriver ; seuls les majors sont supprimés. Plafond ~26 PR/semaine au lieu de plusieurs centaines sans `groups`.

## Deux ajouts au passage

1. **#901 tracé comme cas d'école** — la PR citée en exemple dans le commentaire (`webpack-dev-server 5->6 in Bootstrap 4 Instant`) a été fermée out-of-policy **au titre de cette règle même**. Le commentaire dit maintenant l'issue de l'affaire, pas seulement son énoncé.
2. **Échappatoire documentée** — si un CVE n'est un jour corrigeable **que** par un major sur un arbre vendored, la marche à suivre est de retirer l'`ignore` de ce répertoire-là **dans ce fichier**, pas de merger le major en contournant la politique. Sans cette ligne, la première urgence réelle se règle par un bypass, et la politique meurt en silence.

## Vérification

Commentaires uniquement — aucune règle touchée. YAML re-validé après édition : `version: 2`, **29 blocs `updates` inchangés** (1 nuget + 2 npm à nous + 26 vendored).

Réf : #910 · #901 · roadmap #458.

🤖 Coordinator ai-01