### PR TITLE
chore(ci): close two pin gaps found by #945 — Playwright ignore was a no-op, OWLSharp major breaks the build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@
 # only packages whose pin is an ALREADY-RECORDED decision — licence (#588, #905) or a documented
 # runtime coupling (CLAUDE.md "Stable Dependency Versions"). Everything else keeps flowing and gets
 # triaged on its merits. To add an entry, cite the decision; do not add one to silence a red build.
+#
+# The `labels:` below reference nuget / npm / vendored, which did NOT exist in the repo until
+# 2026-07-27 — dependabot posted a "labels could not be found" comment on every PR it opened
+# (#941, #945 and the 26 npm ones). The labels now exist; do not delete them without also
+# editing this file, or the noise comes back on every future PR.
 
 version: 2
 enable-beta-ecosystems: false
@@ -62,7 +67,10 @@ updates:
       # SkiaSharp is QuestPDF's native rendering backend and is pinned in CLAUDE.md as
       # "Required for QuestPDF". With QuestPDF frozen at 2022.12.12, a major Skia bump
       # (2.88.6 -> 4.150.1 was proposed in #941) moves one half of a matched pair.
-      # Minor/patch stay allowed.
+      # Minor/patch stay allowed -- DELIBERATELY. #945 delivered 2.88.6 -> 2.88.9, a patch
+      # inside the 2.88.x line QuestPDF 2022.12.12 links against; that is the pin working as
+      # intended, not a leak. Do not widen this entry to all update types by analogy with
+      # Playwright below: the two cases differ in the package's versioning, not in our intent.
       - dependency-name: "SkiaSharp.NativeAssets.Win32"
         update-types: ["version-update:semver-major"]
       # Playwright 1.43.0 is pinned in CLAUDE.md. Since #911 the CI Test step actually
@@ -70,8 +78,39 @@ updates:
       # browser); 1.43.0 also carries the mirror-fallback chain that survives the
       # playwright.azureedge.net 400s observed in CI. A major bump is a deliberate,
       # tested operation, not a grouped drive-by.
+      #
+      # ALL update types, and the reason is MEASURED, not stylistic: this entry used to read
+      # `update-types: ["version-update:semver-major"]`, which is a NO-OP for this package.
+      # Microsoft.Playwright has never left the 1.x line (1.0 -> 1.61 as of 2026-07), so a
+      # semver-major update cannot fire, ever. #945 duly proposed 1.43.0 -> 1.61.0 as a MINOR
+      # and the filter let it through -- the pin was decorative. Found by po-2024's review on
+      # #945 and confirmed firsthand against the PR's package delta.
+      # Lesson worth keeping: an ignore entry is only as strong as the package's versioning
+      # scheme. "Ignore majors" protects nothing on a project that never bumps its major.
       - dependency-name: "Microsoft.Playwright"
+      # OWLSharp / OWLSharp.Extensions 4.x -> 5.x breaks the build, MEASURED on #945:
+      # 10 compile errors, all in Ontology/OwlAdapter.cs, all of the shape
+      #   CS1503: cannot convert from 'RDFSharp.Model.RDFResource'
+      #                           to 'OWLSharp.Ontology.OWLNamedIndividual'
+      # SKOSHelper (from `using OWLSharp.Extensions.SKOS`) changed its signatures in 5.0.0.
+      # The five call sites are wrapped in try/catch with annotation-scan fallbacks, but those
+      # guard RUNTIME, not COMPILE -- the build never reaches the 638 tests.
+      #
+      # This entry is NOT "silencing a red build" (the bar at the top of this file forbids
+      # that): OWLSharp was deliberately left unpinned in #942/#943 as "a major to test on its
+      # merits after the tag". #945 ran that test. The result is "needs an API migration",
+      # recorded as issue #946 with its DoD (regenerate the OWL and match 1408 concepts /
+      # 59.9% crosslinks / 5.07 MB; keep the fallbacks; drop this ignore in the same PR).
+      # The pin is the corollary of that scheduled work, not a substitute for it.
+      - dependency-name: "OWLSharp"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "OWLSharp.Extensions"
+        update-types: ["version-update:semver-major"]
+      # NOT pinned, on purpose: dotNetRdf. The #945 review first attributed the OwlAdapter
+      # break to dotNetRdf 3.3.2 -> 3.5.2; re-measured, that is wrong. dotNetRdf supplies
+      # VDS.RDF (parsing, used elsewhere in the same file), its bump is a MINOR, and
+      # RDFSharp.RDFResource is the type our code PASSES, not the one that moved. Pinning it
+      # would have been an over-pin bought on a mis-attribution.
     commit-message:
       prefix: "chore(deps)"
       include: "scope"


### PR DESCRIPTION
## Ce que #945 a mesuré sur la politique elle-même

#941 (le premier groupe nuget) a été **superseded par dependabot lui-même** — `Superseded by #944`, puis #945. Ma note « ne la fermez pas pour faire propre » a été postée **3 minutes après** que dependabot l'avait déjà fermée : j'ai écrit une consigne de procédure sans re-vérifier l'état de la PR. La règle « lire avant d'agir » vaut aussi pour l'**état**, pas seulement pour le corps.

#945 régénère le groupe, et il est utile pour une raison qui n'était pas prévue : **il traverse deux épingles que #943 croyait avoir posées.**

### 1. L'épingle Playwright était décorative — trouvée par po-2024, confirmée firsthand

```yaml
- dependency-name: "Microsoft.Playwright"
  update-types: ["version-update:semver-major"]   # ne peut JAMAIS se déclencher
```

`Microsoft.Playwright` n'a jamais quitté la ligne **1.x** (1.0 → 1.61 en juillet 2026). Un `semver-major` n'existe pas pour ce paquet. #945 a donc proposé **1.43.0 → 1.61.0 en tant que MINOR**, et le filtre l'a laissé passer — exactement le bump que l'épingle prétendait empêcher.

La leçon est réutilisable, et elle vaut plus que le correctif : **une entrée `ignore` ne vaut que le schéma de versionnage du paquet.** « Ignorer les majeures » ne protège de rien sur un projet qui ne bumpe jamais sa majeure. Le crédit va à la review po-2024 sur #945 ; j'ai vérifié contre le delta de paquets de la PR avant de corriger.

→ Playwright passe en **ALL update types**, comme QuestPDF.

### 2. OWLSharp 4→5 casse le build — et c'est le « merit test » que j'avais différé

#942/#943 laissait OWLSharp **délibérément non épinglé** : « Apache-2.0, aucun risque licence, un major à tester sur ses mérites après le tag ». #945 a fait le test.

**10 erreurs de compilation, toutes dans `Ontology/OwlAdapter.cs`** (run `30212821456`) :

```
CS1503: cannot convert from 'RDFSharp.Model.RDFResource'
                        to 'OWLSharp.Ontology.OWLNamedIndividual'
```

`SKOSHelper` (`using OWLSharp.Extensions.SKOS`) a changé ses signatures en 5.0.0. Les cinq points de contact sont enveloppés de `try/catch` avec fallback par scan d'annotations — mais ces `catch` gardent l'**exécution**, pas la **compilation** : le build n'atteint jamais les 638 tests.

→ **Épinglé en `semver-major`, et la migration est ouverte comme #946** avec son DoD (régénérer l'OWL et retrouver 1 408 concepts / 59,9 % crosslinks / 5,07 Mo ; **conserver les fallbacks** ; retirer l'`ignore` dans la même PR). L'épingle est le corollaire du travail planifié, **pas** un moyen d'éteindre un build rouge — la barre d'admission en tête du fichier reste respectée : la décision est citée, et elle est datée d'aujourd'hui.

### 3. Deux choses délibérément **non** modifiées

**`dotNetRdf` reste non épinglé.** La review de po-2024 attribuait le blocage à `dotNetRdf 3.3.2 → 3.5.2`. Re-mesuré : c'est faux. `dotNetRdf` fournit `VDS.RDF` (parsing, utilisé ailleurs dans le même fichier), son bump est un **minor**, et `RDFSharp.RDFResource` est le type que **notre code passe**, pas celui qui a bougé. L'épingler aurait été un sur-épinglage acheté sur une mauvaise attribution.

**`SkiaSharp` garde `semver-major` seulement.** #945 a livré 2.88.6 → 2.88.9, un **patch dans la ligne 2.88.x** contre laquelle QuestPDF 2022.12.12 se lie. C'est l'épingle qui fonctionne, pas une fuite. Un commentaire le dit dans le fichier, pour que personne ne « corrige » ce cas par analogie avec Playwright : les deux diffèrent par le versionnage du paquet, pas par notre intention.

### 4. Les labels `nuget` / `npm` / `vendored` n'existaient pas

Ce fichier les référence depuis #910 ; ils n'existaient pas dans le dépôt. Dependabot postait donc *« The following labels could not be found »* sur **chacune** des 27 PR ouvertes. Les trois labels sont créés ; noté dans l'en-tête pour qu'on ne les supprime pas sans éditer la config.

## Vérifications

- `yaml.safe_load` : **29** blocs `updates` préservés (aucun bloc npm touché)
- Liste `ignore` nuget résultante : AutoMapper (majeures) · QuestPDF (**ALL**) · SkiaSharp (majeures) · **Playwright (ALL)** · **OWLSharp (majeures)** · **OWLSharp.Extensions (majeures)**
- schemastore `dependabot-2.0` : **valid**
- Diff = **1 fichier, +40/−1**. Aucun code, aucun CSV, aucun workflow.

## Disposition de #945

**Ne pas merger** : build rouge, et la cause est #946. Laissée ouverte — dependabot régénérera le groupe sans OWLSharp ni Playwright au prochain passage, et le tout-venant sain (Newtonsoft 13.0.4, PdfPig 0.1.15, CsvHelper 33, Spectre 0.57, xunit 2.9.3…) redeviendra mergeable une fois le major hors du lot.

Refs #942, #945, #946

🤖 Coordinator ai-01
