### PR TITLE
test(harvest): drop the wall-clock upper bound that made BackoffPositive flaky in real CI

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/HarvestManagerRetryAsyncTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/WebBasedGenerator/HarvestManagerRetryAsyncTests.cs
@@ -105,6 +105,16 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 		//       backoff (fast path, no accidental stall);
 		//   (b) backoff > 0 with 3 attempts (2 inter-attempt delays) → elapsed >= 2*backoff.
 		//   The margin is generous to stay robust on a loaded CI box.
+		//
+		//   (b) asserts a LOWER bound only, deliberately. An upper bound on wall-clock is not
+		//   the contract of a backoff — "the delay was applied" is. It used to also assert
+		//   elapsed <= 2*backoff + 2000ms, which made the test flaky the moment CI began
+		//   running tests for real (#911): measured 2026-07-26, this test took 3 s and failed
+		//   the 2 240 ms bound on PRs #928/#935 while 24 sibling runs passed — 26 dependabot
+		//   runs firing inside 5 minutes contend for the runner, and the diffs in question
+		//   touched only vendored npm lockfiles, so no production code could be implicated.
+		//   Do not restore an upper bound here: a bigger number only moves the load level at
+		//   which it lies. The lower bound still fails hard if the backoff is skipped.
 		// ─────────────────────────────────────────────────────────────────────────────
 		[Fact]
 		public async Task BackoffZero_DoesNotDelay()
@@ -143,8 +153,8 @@ namespace Argumentum.AssetConverter.Tests.WebBasedGenerator
 			// 3 attempts => 2 inter-attempt delays => >= 2 * backoff.
 			sw.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(2 * 120 - 30),
 				"two inter-attempt delays of {0} must be applied", backoff);
-			// Generous upper bound to stay robust on a loaded box.
-			sw.Elapsed.Should().BeLessThanOrEqualTo(TimeSpan.FromMilliseconds(2 * 120 + 2000));
+			// No upper bound: see the note above (a) / (b). Runner contention is not a defect
+			// of RetryAsync, and an upper bound cannot distinguish the two.
 		}
 
 		// ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Constat

Depuis #911, l'étape `Test` de la CI exécute réellement les tests. Un test est apparu **intermittent** : `HarvestManagerRetryAsyncTests.BackoffPositive_AppliesDelayBetweenAttempts`.

**Mesure (2026-07-26)** — sur les 26 PRs npm groupées ouvertes par dependabot en 5 minutes :

| Runs | Résultat | Test en échec |
|---|---|---|
| 24 | ✅ vert | — |
| **#928**, **#935** | ❌ `build (Debug)` | **`BackoffPositive_AppliesDelayBetweenAttempts` [3 s]**, `Total tests: 643 / Passed: 637 / Failed: 1 / Skipped: 5` |

Les diffs de #928 et #935 ne touchent **que** des lockfiles npm vendorés sous `DNNPlatform/Portals/1/2sxc/**` — **aucun code .NET ne peut être en cause**. La variable réelle est la **contention du runner** : 26 jobs déclenchés dans la même fenêtre de 5 minutes.

L'assertion qui casse :

```csharp
sw.Elapsed.Should().BeLessThanOrEqualTo(TimeSpan.FromMilliseconds(2 * 120 + 2000));  // ≤ 2 240 ms
```

Le test a mis **3 s** pour une opération dont le délai attendu est **240 ms**.

## Correctif : soustraire, pas élargir

La borne **supérieure** n'est pas le contrat d'un backoff — « le délai a bien été appliqué » l'est, et c'est la borne **inférieure**, qui reste dure :

```csharp
sw.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(2 * 120 - 30), …);  // conservée
```

Passer `2000` à `10000` aurait été le réflexe de contrepoids : ça ne fait que **déplacer le niveau de charge** auquel la borne ment, et ça ne teste toujours rien. Le commentaire du fichier enregistre la mesure pour que la borne ne soit pas « restaurée » plus tard.

**Rien n'est affaibli** : si le backoff cessait d'être appliqué, la borne inférieure échoue. C'est bien la seule chose que ce test peut observer de l'extérieur.

## Traitement asymétrique de son voisin, délibéré

`BackoffZero_DoesNotDelay` (même fichier) garde sa borne supérieure `< 500 ms` — **elle est son contrat** : « `TimeSpan.Zero` n'introduit aucun délai » ne s'observe que par le haut. Elle est du même genre de fragilité en principe, elle n'a pas été observée en échec, et la retirer supprimerait la seule garde du chemin rapide. Noté plutôt que masqué.

## Vérification

`643 total / 638 réussis / 0 échec / 5 ignorés` en 24 s, local (`dotnet test`, Debug). Aucun `continue-on-error`, aucun test désactivé, aucun `Skip`.

## Ce que ça ne corrige pas

Le rouge de **#949** est un **autre** défaut, sur d'autres tests, et il est réel — voir la correction postée sur #949 et l'issue **#951** (Humanizer v3 renomme les IRI publiées).

Refs #911, #928, #935

🤖 Coordinator ai-01
