### PR TITLE
chore(ci): pin Humanizer against majors — v3 renames the OWL IRIs we publish (#951)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,32 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "OWLSharp.Extensions"
         update-types: ["version-update:semver-major"]
+      # Humanizer 2.14.1 -> 3.0.10 changes the OWL IRI fragments we PUBLISH. MEASURED on #949
+      # (run 89854763158, `build (Release)`): 643 tests, 636 passed, 2 failed, both of them the
+      # GetId contract tests, and nothing else --
+      #   VirtueOwlGenerationContractTests.GetId_StripsApostrophesHyphensCommas        [40 ms]
+      #   OwlGetIdPureContractTests.FrenchFallacyName_ProducesFragment_AccentsPreserved [1 ms]
+      # Both assert GetId("Appel à l'autorité") == "appelÀLautorité"; both pass on master
+      # (verified locally 2026-07-27, 10/10 on the filtered run). `GetId` is `Camelize` plus a
+      # Replace chain, i.e. Humanizer IS the transform -- and v3 is a declared breaking major
+      # (its own release notes ship a Roslyn analyzer for the "v3 namespace migration").
+      #
+      # Why this is more than a red test: those fragments are the IDENTITY of the published
+      # ontology -- 1 408 fallacy IRIs in docs/ontology/argumentum.owl and 223 virtue IRIs in
+      # argumentum_virtues.owl are built by this function. A silent Camelize change renames
+      # every accented term's IRI on the next regeneration, breaking external consumers
+      # (#133 publication, the CoursIA import) with a green build and no diff in our own code.
+      # Same shape as the licence findings above, one axis over: a package can change
+      # identity-bearing OUTPUT without any tool announcing it.
+      #
+      # Majors only -- and here that filter is NOT the no-op it was for Playwright: Humanizer's
+      # break IS at the major boundary (2.x -> 3.x). The general rule the two cases share is
+      # that the right filter depends on where the package puts its break, so measure the
+      # package's versioning before choosing the update-types.
+      # Deferred work this pin accompanies: issue #951 (deliberate v3 migration + an explicit
+      # decision on whether published IRIs may change, which is jsboige's, not ours).
+      - dependency-name: "Humanizer"
+        update-types: ["version-update:semver-major"]
       # NOT pinned, on purpose: dotNetRdf. The #945 review first attributed the OwlAdapter
       # break to dotNetRdf 3.3.2 -> 3.5.2; re-measured, that is wrong. dotNetRdf supplies
       # VDS.RDF (parsing, used elsewhere in the same file), its bump is a MINOR, and


### PR DESCRIPTION
## Constat — mesuré, et il vaut mieux que « deux tests rouges »

`Humanizer 2.14.1 → 3.0.10` (majeure **déclarée cassante** : l'amont livre un analyseur Roslyn pour sa propre « v3 namespace migration ») fait échouer **exactement deux** tests dans #949, et pas un de plus :

| Test | Durée |
|---|---:|
| `VirtueOwlGenerationContractTests.GetId_StripsApostrophesHyphensCommas` | 40 ms |
| `OwlGetIdPureContractTests.FrenchFallacyName_ProducesFragment_AccentsPreserved` | 1 ms |

Run `89854763158`, `build (Release)` → `Total tests: 643 / Passed: 636 / Failed: 2 / Skipped: 5`. Les deux **passent sur master** (vérifié en local 2026-07-27 : run filtré **10/10**, 629 ms).

Les deux assertent la même chose : `GetId("Appel à l'autorité") == "appelÀLautorité"` — apostrophe retirée, **accent préservé**. Or `GetId` = `Camelize` + une chaîne de `Replace` : **Humanizer *est* la transformation.**

## Pourquoi c'est un pin et pas un ticket de test

Ces fragments sont l'**identité de l'ontologie publiée** : **1 408** IRI de sophismes dans `docs/ontology/argumentum.owl` et **223** IRI de vertus dans `argumentum_virtues.owl` sont construits par cette fonction. Un changement silencieux de `Camelize` **renomme l'IRI de chaque terme accentué à la prochaine régénération** — build vert, aucun diff dans notre code, et les consommateurs externes cassent (publication #133, import CoursIA).

C'est le motif déjà nommé deux fois dans ce fichier (QuestPDF, FluentAssertions), décalé d'un axe : *un paquet peut cesser d'être permissif sans qu'aucun outil ne l'annonce* → **un paquet peut changer une sortie porteuse d'identité sans qu'aucun outil ne l'annonce.** Ce qui l'a attrapé, ce sont deux tests de contrat écrits exprès — et ils ne tournent en CI que depuis #911.

## Majeures seulement — et ici ce n'est PAS le no-op de Playwright

#947 a retenu qu'un `ignore` « majeures » ne protège rien sur un paquet qui ne bouge jamais sa majeure (Playwright, jamais sorti de 1.x). Le cas d'Humanizer est l'inverse : **sa rupture est précisément à la frontière majeure** (2.x → 3.x). La règle commune aux deux, écrite dans le fichier : *le bon `update-types` dépend de l'endroit où le paquet met sa rupture — mesurer, ne pas recopier.*

## Le pin porte son travail différé

C'est la barre d'admission que ce fichier s'impose (« citer la décision ; ne pas ajouter une entrée pour éteindre un build rouge »). Issue **#951** porte :

1. **une question préalable qui n'est pas technique et n'est pas la nôtre** — les IRI publiées *peuvent-elles* changer ? (a) figer et internaliser `GetId` ; (b) renommage **versionné** + `owl:sameAs` ; (c) statu quo. **Arbitrage jsboige.**
2. la migration v3 elle-même, **sans affaiblir les deux tests** (s'ils doivent changer, c'est que l'identité change, donc que (b) a été choisi) ;
3. le retrait de cette entrée `ignore` **dans la même PR** que la migration.

## Périmètre

**1 fichier, +26/-0**, uniquement des commentaires + une entrée `ignore`. Aucun paquet touché, aucun code touché. Schéma `dependabot-2.0` respecté (même forme que les 5 entrées existantes). Zéro effet sur la release : le statu quo 2.14.1 est exactement ce qui a produit les `.owl` committées et validées.

Refs #951, #949, #911, #133

🤖 Coordinator ai-01
