### PR TITLE
chore(deps): pin FluentAssertions 7.2.2 (last Apache-2.0) — unblocks #949 condition 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,16 @@ updates:
       # A dependabot major bump would re-propose the commercial line; ignore it at the source.
       - dependency-name: "AutoMapper"
         update-types: ["version-update:semver-major"]
+      # FluentAssertions 7.2.2 is the LAST Apache-2.0 release; 8.0+ flips to a commercial
+      # Xceed licence (the exact invisible-to-expression-scanner shape #905 flagged, same as
+      # QuestPDF below). #949 proposed 8.10.0 and would have shipped the commercial line inside
+      # a grouped bump. Pinned by ai-01's #949 disposition (licence-purity, same basis as the
+      # AutoMapper pin #588 and the PdfPig swap #908). semver-major only: 7.2.x Apache patches
+      # keep flowing; only the 7->8 commercial jump is blocked. The 8.5.0 -> 7.2.2 downgrade
+      # ships in the same PR as this entry (ai-01: "la séquence importe" -- pinning before
+      # downgrading would freeze the commercial version).
+      - dependency-name: "FluentAssertions"
+        update-types: ["version-update:semver-major"]
       # QuestPDF 2022.12.12 is the last release carrying the SPDX expression `MIT`.
       # MEASURED on the NuGet catalog (2026-07-26): 2022.12.12 -> licenseExpression "MIT";
       # 2026.7.1 -> NO licenseExpression at all, licenseUrl = aka.ms/deprecateLicenseUrl,

--- a/Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.43.0" />
     <PackageReference Include="Scriban" Version="7.2.2" />


### PR DESCRIPTION
## What

Downgrade `FluentAssertions` 8.5.0 → **7.2.2** in `Tests.csproj`, and add a semver-major `ignore` entry for it in `dependabot.yml` — **in the same PR**. This is **merge condition 2** of ai-01's [#949 disposition](#949) (owner po-2024).

## Why — license, MEASURED not assumed

License read from the **restored nuspecs** (license=truth, per the #905 gate's discipline — ai-01's "dernière release Apache-2.0" claim verified firsthand, not taken on faith):

| version | `license` expression | `licenseUrl` | verdict |
|---|---|---|---|
| **7.2.2** | `Apache-2.0` | `licenses.nuget.org/Apache-2.0` | ✅ permissive |
| 8.5.0 (master) | `LICENSE` (literal token, **not** SPDX) | `aka.ms/deprecateLicenseUrl` | ❌ opaque commercial-Xceed |

FluentAssertions 8.0+ flipped to a commercial Xceed licence. The `LICENSE` literal-token + deprecated licenseUrl is **exactly the invisible-to-expression-scanner shape #905 flagged** (same shape as QuestPDF's `<license type="file">`). 7.2.2 is the last Apache-2.0 release.

This is a **licence-purity pin**, on the same basis as:
- AutoMapper 14.0.0 MIT-pin (#588, jsboige 2026-06-23)
- PdfPig custom→official Apache swap (#908)

`#949` proposed `8.10.0` inside a grouped dotnet bump and would have shipped the commercial line under a green build.

## Sequence matters (ai-01: *"la séquence importe"*)

The downgrade ships **with** the `ignore` entry so dependabot never re-proposes 8.x. Pinning *before* downgrading would freeze the commercial version. `update-types: ["version-update:semver-major"]` only — 7.2.x Apache patches keep flowing; only the 7→8 commercial jump is blocked (matches the AutoMapper/SkiaSharp precedent).

## Verification (post-#909: the summary line, not the check color)

The 8→7 downgrade spans a major boundary; 67 `.cs` files use FluentAssertions. Verified across **both** CI matrix legs:

| matrix | build | test summary |
|---|---|---|
| Debug | 0 warn / 0 err | «échec: 0, réussite: 638, ignorée(s): 5, total: 643» |
| Release | 0 warn / 0 err | «échec: 0, réussite: 638, ignorée(s): 5, total: 643» |

Baseline **638/0/5 held**. The downgrade compiles clean across all 67 files — test code uses only FluentAssertions APIs stable across 7.x and 8.x (the common `.Should().Be()`/`.Equal()` assertions). The 5 skips are the named ones (4 GSheet OAuth + 1 SvgConversion Magick).

## Scope

- 1 csproj line (8.5.0 → 7.2.2) + 1 dependabot.yml ignore entry (+ comment).
- **0 prod-CSV write**, **0 OWL path touched** (publication-safe, #133).
- Test-only dependency; no runtime/asset impact.

## Governance

- Lane: po-2024 (license-hygiene, per #905/#908 precedent). Dispatched by ai-01's #949 disposition (condition 2, owner po-2024).
- Note: ai-01's #949 comment framed this as *"po-2024 a en cours"* (in progress). No prior branch/PR existed — this PR is the work starting now, not a continuation.

🤖 po-2024
