### PR TITLE
test(pdf): force ForceDebugParams on the vacuous brother test (#911 follow-up)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.Tests/PdfCmykPostProcess/PdfCmykPostProcessTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.Tests/PdfCmykPostProcess/PdfCmykPostProcessTests.cs
@@ -58,7 +58,12 @@ namespace Argumentum.AssetConverter.Tests.PdfCmykPostProcess
             offEverywhere.GetEnabled(releaseConfig).Should().BeFalse("EnabledRelease=false overrides build mode");
 
             var onInDebug = new PdfCmykPostProcessConfig { EnabledDebug = true };
-            var debugConfig = new AssetConverterConfig();
+            // Force Debug build mode explicitly (see GetEnabled_is_release_only_by_default above):
+            // a bare `new AssetConverterConfig()` resolves to Release under a Release-built assembly,
+            // so GetEnabled returns EnabledRelease (default true) and the assertion passes vacuously —
+            // never exercising the EnabledDebug path the test name promises. ForceDebugParams makes
+            // the assertion actually assert on the Debug/EnabledDebug contract under both matrix legs.
+            var debugConfig = new AssetConverterConfig { ForceDebugParams = true };
             onInDebug.GetEnabled(debugConfig).Should().BeTrue("EnabledDebug=true enables it in Debug");
         }
 


### PR DESCRIPTION
## What

One-line fix to `PdfCmykPostProcessTests.GetEnabled_respects_master_toggle_and_explicit_overrides`: add `ForceDebugParams = true` to its bare `debugConfig`. This is the **vacuous-brother-test follow-up** to #911 (`e7470d07`), dispatched by ai-01 (dispatch `qv4olc` item 2, addendum `4a928x` §4 item 2) to ride alongside the FluentAssertions PR. That PR (#955) landed separately, so this is its own small PR.

## The defect — passes for the wrong reason under Release

The test asserts `EnabledDebug=true enables it in Debug`, but its config was bare:

```csharp
var onInDebug = new PdfCmykPostProcessConfig { EnabledDebug = true };
var debugConfig = new AssetConverterConfig();   // ← bare, no force
onInDebug.GetEnabled(debugConfig).Should().BeTrue("EnabledDebug=true enables it in Debug");
```

Under a **Release-built** assembly, `isInDebugMode=false` (`#if DEBUG` at `AssetConverterConfig.cs:447`), so `UseReleaseParams=true`, so `GetEnabled` returns `EnabledRelease` (default `true`). The `BeTrue()` **passes without ever exercising the `EnabledDebug` path the test name promises** — vacuously true. Same class of defect #909/#911 treated, left in the very file #911 just corrected.

## The fix (strengthens, does not weaken)

```csharp
var debugConfig = new AssetConverterConfig { ForceDebugParams = true };
```

The idiom applied to the sibling test in #911 (`GetEnabled_is_release_only_by_default`, `e7470d07`). With `ForceDebugParams=true`, under Release the config resolves to Debug mode, and `GetEnabled` returns `EnabledDebug` (set explicitly to `true`) — so the assertion now exercises the **actual Debug/EnabledDebug contract** under both matrix legs. Comment cites the sibling. No assertion relaxed; the test is green for the right reason now.

## Verification (post-#909: the summary line, not the check color)

| matrix | build | test summary |
|---|---|---|
| Debug | 0 warn / 0 err | «échec: 0, réussite: 638, ignorée(s): 5, total: 643» |
| Release | 0 warn / 0 err | «échec: 0, réussite: 638, ignorée(s): 5, total: 643» |
| `PdfCmykPostProcessTests` under Release | — | **8 passed / 0 failed / 0 skipped** (brother test ran, not vacuous) |

Baseline **638/0/5 held** across both legs.

## Scope

- 1 test file, +6 lines (1 code + 5-line comment citing the sibling pattern). 0 prod write, 0 OWL path touched.
- Test-determinism follow-up, in-lane po-2024.

🤖 po-2024
