### PR TITLE
test(visual): VisualQaHarness fail loud on cold-start, not silent skip (#957 residu ii)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,11 @@ jobs:
         #      `dotnet test` builds it (loud failure on error) instead of silently no-op'ing.
         # Browser tests (HtmlToPngConverterTests, PdfAssemblerTests) self-install chromium in-test via
         # Microsoft.Playwright.Program.Main("install","chromium"); no separate install step needed.
+        #
+        # VisualTests (Argumentum.AssetConverter.VisualTests.csproj) is DELIBERATELY EXCLUDED from CI:
+        # it is a local QA harness that runs AFTER the pipeline, against a populated Target/ (9 000+ PNGs,
+        # 5.30 GB) that a fresh CI runner does not have. Adding it would fail every run (no Target/), and
+        # filtering it with continue-on-error would fabricate a green check over tests that ran zero
+        # assertions — the #909 vert-pour-mauvaise-raison, in a separate project. Its cold-start guards
+        # fail loudly (Assert.Fail) so the harness is never mistaken for coverage when run locally.
         run: dotnet test "Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj" -c ${{ matrix.configuration }} --verbosity normal

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/VisualQaHarness.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/VisualQaHarness.cs
@@ -114,10 +114,7 @@ namespace Argumentum.AssetConverter.VisualTests
         {
             var root = ResolveTargetRoot();
             if (root == null)
-            {
-                _output.WriteLine("SKIP: Target/ not found — run pipeline first");
-                return;
-            }
+                Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var missing = new List<string>();
             foreach (var lang in Languages)
@@ -141,10 +138,7 @@ namespace Argumentum.AssetConverter.VisualTests
         {
             var root = ResolveTargetRoot();
             if (root == null)
-            {
-                _output.WriteLine("SKIP: Target/ not found");
-                return;
-            }
+                Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var inventory = new List<string>();
             foreach (var lang in Languages)
@@ -169,7 +163,7 @@ namespace Argumentum.AssetConverter.VisualTests
         public void VisualQa_WhiteBand_NoFullWidthBandInCovers()
         {
             var root = ResolveTargetRoot();
-            if (root == null) { _output.WriteLine("SKIP"); return; }
+            if (root == null) Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var flags = new List<string>();
             int scanned = 0;
@@ -211,7 +205,7 @@ namespace Argumentum.AssetConverter.VisualTests
         public void VisualQa_BlankRatio_Rules_NotExcessivelyEmpty()
         {
             var root = ResolveTargetRoot();
-            if (root == null) { _output.WriteLine("SKIP"); return; }
+            if (root == null) Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var flags = new List<string>();
             int scanned = 0;
@@ -237,10 +231,7 @@ namespace Argumentum.AssetConverter.VisualTests
                 _output.WriteLine($"  FLAG: {f}");
 
             if (scanned == 0)
-            {
-                _output.WriteLine("No Rules images found — skip");
-                return;
-            }
+                Assert.Fail("Scanned 0 Rules images in Target/ — test verified nothing (check harvest output / CardSet filter)");
 
             // Informational: report but don't hard-fail (this is the data ai-01 needs for #250)
         }
@@ -251,7 +242,7 @@ namespace Argumentum.AssetConverter.VisualTests
         public void VisualQa_BottomSaturation_Rules_NotOverflowing()
         {
             var root = ResolveTargetRoot();
-            if (root == null) { _output.WriteLine("SKIP"); return; }
+            if (root == null) Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var flags = new List<string>();
             int scanned = 0;
@@ -283,7 +274,7 @@ namespace Argumentum.AssetConverter.VisualTests
         public void VisualQa_FooterCollision_Rules_NoBodyFooterOverlap()
         {
             var root = ResolveTargetRoot();
-            if (root == null) { _output.WriteLine("SKIP"); return; }
+            if (root == null) Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var flags = new List<string>();
             int scanned = 0;
@@ -319,10 +310,7 @@ namespace Argumentum.AssetConverter.VisualTests
                 _output.WriteLine($"  FLAG: {f}");
 
             if (scanned == 0)
-            {
-                _output.WriteLine("No non-cover Rules images found — skip");
-                return;
-            }
+                Assert.Fail("Scanned 0 non-cover Rules images in Target/ — test verified nothing (check harvest output / CardSet filter)");
 
             // Informational: report but don't hard-fail
         }
@@ -333,7 +321,7 @@ namespace Argumentum.AssetConverter.VisualTests
         public void VisualQa_FullGrid_AllCards_AllDetectors()
         {
             var root = ResolveTargetRoot();
-            if (root == null) { _output.WriteLine("SKIP"); return; }
+            if (root == null) Assert.Fail("VisualTests require a generated Target/ — run the pipeline first");
 
             var results = new List<CardCheckResult>();
             int totalImages = 0;


### PR DESCRIPTION
## What

Closes the **residu (ii)** of #957 for `VisualQaHarness`: two classes of faux-vert where tests PASSED while verifying nothing, now converted to loud `Assert.Fail`. Verdict ai-01 (`msg-d84c4t`) — which **reversed** an earlier `[Fact(Skip="…")]` instruction on the nuance below.

## The defect — faux-vert cold-start

`VisualQaHarness` is a **local QA harness** that runs *after* the pipeline against a populated `Target/` (9 000+ PNGs). It had two silent-skip patterns that produced green over zero assertions:

**(1) `root == null` → silent return** (7 sites)
```csharp
var root = ResolveTargetRoot();
if (root == null) { _output.WriteLine("SKIP"); return; }   // ← passed, verified nothing
```
On a cold runner with no `Target/`, these passed having run **zero assertions** — the #909 *vert-pour-mauvaise-raison*, in a separate project.

**(2) `scanned == 0` → silent return** (2 sites: `BlankRatio`, `FooterCollision`)
```csharp
if (scanned == 0) { _output.WriteLine("No Rules images found — skip"); return; }   // ← same
```
`Target/` present but 0 images found → also passed having verified nothing.

## The fix — `Assert.Fail` (a subtraction, not a counterweight)

Each silent `return;` → `Assert.Fail(...)`. The `return;` is **removed**; no coverage is fabricated; **no `continue-on-error`**. A developer running VisualTests without pipeline output now sees RED — which is the truth.

| Site | Before | After |
|---|---|---|
| `root == null` ×7 (Inventory×2, WhiteBand, BlankRatio, BottomSat, FooterCollision, FullGrid) | `_output.WriteLine("SKIP"); return;` | `Assert.Fail("VisualTests require a generated Target/ — run the pipeline first")` |
| `scanned == 0` ×2 (BlankRatio, FooterCollision) | `"No Rules images found — skip"; return;` | `Assert.Fail("Scanned 0 … images in Target/ — test verified nothing")` |
| `build.yml` | (no comment) | documents VisualTests is **deliberately excluded** from CI + why |

## Why `Assert.Fail` and not `[Fact(Skip="…")]`

The guard is **CONDITIONAL** (Target/ absent) and the harness runs **for real** on a populated `Target/`. `[Fact(Skip)]` is **STATIC** in xUnit 2.9.3 (v2 — no runtime skip) — it would kill the tests **everywhere**, including where they work. That is the pendulum this project denounces: *faux-vert → dead-everywhere* is the same defect at the other end.

ai-01's verdict (`msg-d84c4t`) reversed an earlier `[Fact(Skip)]` instruction on exactly this nuance: *"passer de « faux vert silencieux » à « mort partout » n'est pas un correctif, c'est le même défaut à l'autre extrémité."* → retained `Assert.Fail`.

## Verified

- Build: **0 warn / 0 err**.
- `VisualQaHarness` run on po-2024's `Target/` (exists but **0 rendered PNGs** — structure only): **4 pass / 3 fail**. The 2 `scanned==0` Assert.Fail fire correctly (no Rules images → "verified nothing", **as designed**), and 1 pre-existing `Assert.NotEmpty` in `Inventory_CountImages` (line 157 — **not** touched by this PR, unrelated). The 7 `root==null` Assert.Fail do **not** fire (Target/ dir exists). On a fully-rendered `Target/` (ai-01, 9 319 PNGs) the `scanned > 0` path is exercised and these pass.

## Out of scope (flagged, not done)

- **`EnsureTarget()`** in `PdfDimensionTests` / `PdfSnapshotTests` / `PdfContentTests` (~20 tests) is the **identical** faux-vert pattern and would take the same `Assert.Fail` fix. ai-01's verdict scoped this PR to `VisualQaHarness`; a follow-up can extend if desired.
- **"Informational: report but don't hard-fail"** blocks (~202-205, ~245, ~327) are a separate **design** question (tests that structurally cannot fail), not CI discipline — left as-is per ai-01.

## Scope

2 files, +16/−21 (net subtraction — the silent skips are shorter than the Assert.Fail lines but the `return;` removals compress the blocks). **0 prod write, 0 CSV, 0 OWL.** Test-discipline follow-up, in-lane po-2024.

🤖 po-2024
