### PR TITLE
test(visual): fail loud on cold-start across Pdf*Tests (#957 residu ii)

### DIFF
--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfContentTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfContentTests.cs
@@ -15,7 +15,7 @@ namespace Argumentum.AssetConverter.VisualTests
     /// (TarotCards/PokerCards) or uses font encodings without ToUnicode mappings
     /// (FallaciesWeb). Structural checks catch the same regressions (empty cards,
     /// broken generation) more reliably.
-    /// Tests pass silently if Target/ doesn't exist (CI cold-start).
+    /// Fails LOUD if Target/ doesn't exist (#957 residu ii) — was a silent faux-vert (pass-on-nothing).
     /// </summary>
     public class PdfContentTests : IDisposable
     {
@@ -38,14 +38,15 @@ namespace Argumentum.AssetConverter.VisualTests
         private static string GetPdfDir(string lang) =>
             Path.Combine(TargetRoot, lang, "Documents", "density-0");
 
-        private bool EnsureTarget()
+        private void EnsureTarget()
         {
+            // #957 residu ii: cold-start faux-vert. A missing Target/ must FAIL LOUD, not pass silently —
+            // these tests verify generated PDFs and assert nothing without them. Assert.Fail is a subtraction
+            // (removes the silent `return;`), not a counterweight: no [Fact(Skip)] (static, would kill the
+            // tests where they work), no continue-on-error. VisualTests is NOT run by CI (build.yml targets
+            // only Argumentum.AssetConverter.Tests.csproj), so this fails locally, not in the release gate.
             if (!Directory.Exists(TargetRoot))
-            {
-                _output.WriteLine("Skipped: Target/ not found — run pipeline first");
-                return false;
-            }
-            return true;
+                Assert.Fail("PdfContentTests require a generated Target/ — run the pipeline first (bin/Debug/net9.0-windows/Target not found). This test verified nothing.");
         }
 
         // --- File size sanity checks ---
@@ -57,11 +58,11 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void All_Pdfs_Have_Minimum_Size(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var dir = GetPdfDir(lang);
-            if (!Directory.Exists(dir)) return;
+            if (!Directory.Exists(dir)) Assert.Fail($"Language directory not found: {dir} — test verified nothing (Target/ exists but this language produced no Documents/density-0/; check pipeline output).");
             var pdfs = Directory.GetFiles(dir, "*.pdf");
-            if (pdfs.Length == 0) return;
+            if (pdfs.Length == 0) Assert.Fail($"No PDFs found for {lang} in Target/ — test verified nothing (check pipeline output).");
 
             var failures = new List<string>();
             foreach (var pdf in pdfs)
@@ -80,7 +81,7 @@ namespace Argumentum.AssetConverter.VisualTests
         [Fact]
         public void A0_Pdf_Sizes_Are_Consistent_Across_Languages()
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
 
             var sizes = new Dictionary<string, long>();
             foreach (var lang in Languages)
@@ -90,7 +91,7 @@ namespace Argumentum.AssetConverter.VisualTests
                     sizes[lang] = new FileInfo(pdfs[0]).Length;
             }
 
-            if (sizes.Count < 2) return;
+            if (sizes.Count < 2) Assert.Fail($"Only {sizes.Count} language(s) with A0 PDFs found in Target/ — test verified nothing (expected >= 2 languages to compare; check pipeline output for missing languages).");
 
             var avgSize = sizes.Values.Average();
             var minSize = sizes.Values.Min();
@@ -117,13 +118,13 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void FallaciesWeb_A4_Has_Reasonable_Page_Count(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var dir = GetPdfDir(lang);
-            if (!Directory.Exists(dir)) return;
+            if (!Directory.Exists(dir)) Assert.Fail($"Language directory not found: {dir} — test verified nothing (Target/ exists but this language produced no Documents/density-0/; check pipeline output).");
             var pdfs = Directory.GetFiles(dir, "*_Fallacies_Web_A4_*.pdf")
                 .Where(p => !Path.GetFileName(p).Contains("Thumbnails"))
                 .ToArray();
-            if (pdfs.Length == 0) return;
+            if (pdfs.Length == 0) Assert.Fail($"No PDFs found for {lang} in Target/ — test verified nothing (check pipeline output).");
 
             foreach (var pdf in pdfs)
             {
@@ -145,16 +146,16 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void TarotCards_Has_Multiple_Pages(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var dir = GetPdfDir(lang);
-            if (!Directory.Exists(dir)) return;
+            if (!Directory.Exists(dir)) Assert.Fail($"Language directory not found: {dir} — test verified nothing (Target/ exists but this language produced no Documents/density-0/; check pipeline output).");
             // Main TarotCards PDF (not split, not FacesOnly, not Virtues)
             var pdf = Directory.GetFiles(dir, "Argumentum_TarotCards_*.pdf")
                 .FirstOrDefault(p => !Path.GetFileName(p).Contains("-")
                     && !Path.GetFileName(p).Contains("Virtues")
                     && !Path.GetFileName(p).Contains("FacesOnly")
                     && !Path.GetFileName(p).Contains("Print"));
-            if (pdf == null) return;
+            if (pdf == null) Assert.Fail($"No matching PDF found for {lang} in Target/ — test verified nothing (Target/ exists but the expected CardSet PDF is missing; check pipeline output).");
 
             using var doc = PdfDocument.Open(pdf);
             var pages = doc.NumberOfPages;
@@ -172,14 +173,14 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void PokerCards_Has_Multiple_Pages(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var dir = GetPdfDir(lang);
-            if (!Directory.Exists(dir)) return;
+            if (!Directory.Exists(dir)) Assert.Fail($"Language directory not found: {dir} — test verified nothing (Target/ exists but this language produced no Documents/density-0/; check pipeline output).");
             // Main PokerCards PDF (not split, not Print&Play)
             var pdf = Directory.GetFiles(dir, "Argumentum_PokerCards_*.pdf")
                 .FirstOrDefault(p => !Path.GetFileName(p).Contains("-")
                     && !Path.GetFileName(p).Contains("Print"));
-            if (pdf == null) return;
+            if (pdf == null) Assert.Fail($"No matching PDF found for {lang} in Target/ — test verified nothing (Target/ exists but the expected CardSet PDF is missing; check pipeline output).");
 
             using var doc = PdfDocument.Open(pdf);
             var pages = doc.NumberOfPages;
@@ -197,9 +198,9 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void Each_Language_Has_Multiple_Pdf_Types(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var dir = GetPdfDir(lang);
-            if (!Directory.Exists(dir)) return;
+            if (!Directory.Exists(dir)) Assert.Fail($"Language directory not found: {dir} — test verified nothing (Target/ exists but this language produced no Documents/density-0/; check pipeline output).");
             var pdfs = Directory.GetFiles(dir, "*.pdf");
 
             // Each language should have at least: A0, A4, Thumbnails, Print&Play,

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfDimensionTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfDimensionTests.cs
@@ -11,7 +11,7 @@ namespace Argumentum.AssetConverter.VisualTests
     /// <summary>
     /// Stage 1 of #212: PDF dimension and page count regression tests.
     /// Validates that generated PDFs have correct page sizes and reasonable page counts.
-    /// Tests pass silently if Target/ doesn't exist (CI cold-start).
+    /// Fails LOUD if Target/ doesn't exist (#957 residu ii) — was a silent faux-vert (pass-on-nothing).
     /// </summary>
     public class PdfDimensionTests : IDisposable
     {
@@ -52,14 +52,15 @@ namespace Argumentum.AssetConverter.VisualTests
             return doc.NumberOfPages;
         }
 
-        private bool EnsureTarget()
+        private void EnsureTarget()
         {
+            // #957 residu ii: cold-start faux-vert. A missing Target/ must FAIL LOUD, not pass silently —
+            // these tests verify generated PDFs and assert nothing without them. Assert.Fail is a subtraction
+            // (removes the silent `return;`), not a counterweight: no [Fact(Skip)] (static, would kill the
+            // tests where they work), no continue-on-error. VisualTests is NOT run by CI (build.yml targets
+            // only Argumentum.AssetConverter.Tests.csproj), so this fails locally, not in the release gate.
             if (!Directory.Exists(TargetRoot))
-            {
-                _output.WriteLine("Skipped: Target/ not found — run pipeline first");
-                return false;
-            }
-            return true;
+                Assert.Fail("PdfDimensionTests require a generated Target/ — run the pipeline first (bin/Debug/net9.0-windows/Target not found). This test verified nothing.");
         }
 
         // --- A0 Format Tests ---
@@ -71,9 +72,9 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void A0_Pdf_Has_Correct_Dimensions(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var pdfs = GetPdfs(lang, "*_A0_*.pdf").ToList();
-            if (pdfs.Count == 0) { _output.WriteLine($"No A0 PDFs for {lang}"); return; }
+            if (pdfs.Count == 0) Assert.Fail($"No A0 PDFs for {lang} in Target/ — test verified nothing (check pipeline output).");
 
             foreach (var pdf in pdfs)
             {
@@ -91,9 +92,9 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void A0_Pdf_Has_Exactly_One_Page(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var pdfs = GetPdfs(lang, "*_A0_*.pdf").ToList();
-            if (pdfs.Count == 0) return;
+            if (pdfs.Count == 0) Assert.Fail($"No matching PDFs found for {lang} in Target/ — test verified nothing (Target/ exists but this CardSet pattern produced no files; check pipeline output).");
 
             foreach (var pdf in pdfs)
                 Assert.Equal(1, GetPageCount(pdf));
@@ -108,9 +109,9 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void A4_Pdf_Has_Correct_Dimensions(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var pdfs = GetPdfs(lang, "*_A4_*.pdf").ToList();
-            if (pdfs.Count == 0) { _output.WriteLine($"No A4 PDFs for {lang}"); return; }
+            if (pdfs.Count == 0) Assert.Fail($"No A4 PDFs for {lang} in Target/ — test verified nothing (check pipeline output).");
 
             foreach (var pdf in pdfs)
             {
@@ -128,9 +129,9 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void A4_Pdf_Has_At_Least_One_Page(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var pdfs = GetPdfs(lang, "*_A4_*.pdf").ToList();
-            if (pdfs.Count == 0) return;
+            if (pdfs.Count == 0) Assert.Fail($"No matching PDFs found for {lang} in Target/ — test verified nothing (Target/ exists but this CardSet pattern produced no files; check pipeline output).");
 
             foreach (var pdf in pdfs)
                 Assert.True(GetPageCount(pdf) >= 1, $"{Path.GetFileName(pdf)} has 0 pages");
@@ -145,9 +146,9 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void PrintAndPlay_Pdf_Is_A4_Format(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var pdfs = GetPdfs(lang, "*_Print&Play_*.pdf").ToList();
-            if (pdfs.Count == 0) return;
+            if (pdfs.Count == 0) Assert.Fail($"No matching PDFs found for {lang} in Target/ — test verified nothing (Target/ exists but this CardSet pattern produced no files; check pipeline output).");
 
             foreach (var pdf in pdfs)
             {
@@ -167,11 +168,11 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public void All_Pdfs_Have_NonZero_Pages(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             var dir = GetPdfDir(lang);
-            if (!Directory.Exists(dir)) return;
+            if (!Directory.Exists(dir)) Assert.Fail($"Language directory not found: {dir} — test verified nothing (Target/ exists but this language produced no Documents/density-0/; check pipeline output).");
             var pdfs = Directory.GetFiles(dir, "*.pdf");
-            if (pdfs.Length == 0) return;
+            if (pdfs.Length == 0) Assert.Fail($"No PDFs at all for {lang} in {dir} — test verified nothing.");
 
             foreach (var pdf in pdfs)
                 Assert.True(GetPageCount(pdf) > 0, $"{Path.GetFileName(pdf)} has 0 pages");
@@ -182,7 +183,7 @@ namespace Argumentum.AssetConverter.VisualTests
         [Fact]
         public void All_Languages_Have_FallaciesWeb_A0()
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             foreach (var lang in Languages)
             {
                 var pdfs = GetPdfs(lang, "*_Fallacies_Web_A0_*.pdf").ToList();
@@ -194,7 +195,7 @@ namespace Argumentum.AssetConverter.VisualTests
         [Fact]
         public void All_Languages_Have_FallaciesWeb_A4()
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             foreach (var lang in Languages)
             {
                 var pdfs = GetPdfs(lang, "*_Fallacies_Web_A4_*.pdf").ToList();
@@ -205,7 +206,7 @@ namespace Argumentum.AssetConverter.VisualTests
         [Fact]
         public void All_Languages_Have_TarotCards()
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             foreach (var lang in Languages)
             {
                 var pdfs = GetPdfs(lang, "*_TarotCards_*.pdf")
@@ -219,7 +220,7 @@ namespace Argumentum.AssetConverter.VisualTests
         [Fact]
         public void All_Languages_Have_PokerCards()
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             foreach (var lang in Languages)
             {
                 var pdfs = GetPdfs(lang, "*_PokerCards_*.pdf").ToList();
@@ -231,7 +232,7 @@ namespace Argumentum.AssetConverter.VisualTests
         [Fact]
         public void All_Languages_Have_PrintAndPlay()
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
             foreach (var lang in Languages)
             {
                 var pdfs = GetPdfs(lang, "*_Print&Play_*.pdf").ToList();

--- a/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfSnapshotTests.cs
+++ b/Generation/Converters/Argumentum.AssetConverter.VisualTests/PdfSnapshotTests.cs
@@ -11,7 +11,7 @@ namespace Argumentum.AssetConverter.VisualTests
     /// <summary>
     /// Stage 2 of #212: PDF structural regression via Verify snapshot comparison.
     /// Captures page dimensions, page count, text length, and letter count.
-    /// Tests pass silently if Target/ doesn't exist (CI cold-start).
+    /// Fails LOUD if Target/ doesn't exist (#957 residu ii) — was a silent faux-vert (pass-on-nothing).
     /// </summary>
     public class PdfSnapshotTests : IDisposable
     {
@@ -30,14 +30,15 @@ namespace Argumentum.AssetConverter.VisualTests
         private static string GetPdfPath(string lang, string filename) =>
             Path.Combine(TargetRoot, lang, "Documents", "density-0", filename);
 
-        private bool EnsureTarget()
+        private void EnsureTarget()
         {
+            // #957 residu ii: cold-start faux-vert. A missing Target/ must FAIL LOUD, not pass silently —
+            // these tests verify generated PDFs and assert nothing without them. Assert.Fail is a subtraction
+            // (removes the silent `return;`), not a counterweight: no [Fact(Skip)] (static, would kill the
+            // tests where they work), no continue-on-error. VisualTests is NOT run by CI (build.yml targets
+            // only Argumentum.AssetConverter.Tests.csproj), so this fails locally, not in the release gate.
             if (!Directory.Exists(TargetRoot))
-            {
-                _output.WriteLine("Skipped: Target/ not found — run pipeline first");
-                return false;
-            }
-            return true;
+                Assert.Fail("PdfSnapshotTests require a generated Target/ — run the pipeline first (bin/Debug/net9.0-windows/Target not found). This test verified nothing.");
         }
 
         // --- FallaciesWeb A4 (all languages) ---
@@ -49,10 +50,10 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public async Task FallaciesWeb_A4_FirstPage_Structure(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
 
             var pdfPath = GetPdfPath(lang, $"Argumentum_Fallacies_Web_A4_{lang}.pdf");
-            if (!File.Exists(pdfPath)) { _output.WriteLine($"PDF not found: {pdfPath}"); return; }
+            if (!File.Exists(pdfPath)) Assert.Fail($"Expected PDF not found: {pdfPath} — Target/ exists but this file is missing (test verified nothing; check harvest/pipeline output).");
 
             using var doc = PdfDocument.Open(pdfPath);
             var page = doc.GetPage(1);
@@ -82,10 +83,10 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public async Task TarotCards_FirstPage_Structure(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
 
             var pdfPath = GetPdfPath(lang, $"Argumentum_TarotCards_{lang}.pdf");
-            if (!File.Exists(pdfPath)) { _output.WriteLine($"PDF not found: {pdfPath}"); return; }
+            if (!File.Exists(pdfPath)) Assert.Fail($"Expected PDF not found: {pdfPath} — Target/ exists but this file is missing (test verified nothing; check harvest/pipeline output).");
 
             using var doc = PdfDocument.Open(pdfPath);
             var page = doc.GetPage(1);
@@ -113,10 +114,10 @@ namespace Argumentum.AssetConverter.VisualTests
         [InlineData("pt")]
         public async Task PokerCards_FirstPage_Structure(string lang)
         {
-            if (!EnsureTarget()) return;
+            EnsureTarget();
 
             var pdfPath = GetPdfPath(lang, $"Argumentum_PokerCards_{lang}.pdf");
-            if (!File.Exists(pdfPath)) { _output.WriteLine($"PDF not found: {pdfPath}"); return; }
+            if (!File.Exists(pdfPath)) Assert.Fail($"Expected PDF not found: {pdfPath} — Target/ exists but this file is missing (test verified nothing; check harvest/pipeline output).");
 
             using var doc = PdfDocument.Open(pdfPath);
             var page = doc.GetPage(1);


### PR DESCRIPTION
## What

Closes the remainder of the **faux-vert class** that #963 (`f7875f68`) opened for one harness. ai-01's body in #963 notes that `EnsureTarget()` in `PdfDimensionTests` / `PdfSnapshotTests` / `PdfContentTests` (~20 tests) carries the **identical** cold-start pattern and calls for the **same** correctif. This PR de-gates it.

**The pattern:** every test began `if (!EnsureTarget()) return;` where `EnsureTarget()` returned `false` on a missing `Target/` with only an `_output.WriteLine("Skipped…")`. A missing `Target/` → the test returned green **without asserting anything**. Pass-on-nothing.

## The fix — a subtraction, not a counterweight

Identical to #963:

- `private bool EnsureTarget()` → `private void EnsureTarget()`; the silent `return false` body becomes `Assert.Fail("…require a generated Target/ — run the pipeline first. This test verified nothing.")`.
- Every `if (!EnsureTarget()) return;` call site → `EnsureTarget();`.
- Secondary guards that **also verified nothing** get the same treatment — a *partial* `Target/` (one language missing, a CardSet absent, the expected file not there) was passing silently too:
  - `if (pdfs.Count == 0) return;` → `Assert.Fail`
  - `if (!Directory.Exists(dir)) return;` → `Assert.Fail`
  - `if (pdfs.Length == 0) return;` → `Assert.Fail`
  - `if (pdf == null) return;` → `Assert.Fail`
  - `if (sizes.Count < 2) return;` → `Assert.Fail`
  - `if (!File.Exists(pdfPath)) { WriteLine; return; }` → `Assert.Fail` (PdfSnapshotTests)

**No `[Fact(Skip)]`** (static in xUnit 2.9.3 v2 — would kill the tests where they actually work). **No continue-on-error.** **No fabricated coverage.** Each `Assert.Fail` message names what was missing and ends "test verified nothing" so the intent is unmistakable in the runner output.

## CI scope — verified (the DoD ask)

> "Vérifie dans quel(s) leg(s) de CI ces tests tournent réellement avant de conclure sur l'impact."

- `Argumentum.AssetConverter.VisualTests.csproj` **is in** `Argumentum Converters.sln` → it is **compiled** by `dotnet build` (and by CI's build step).
- `.github/workflows/build.yml` Test step runs `dotnet test "Generation/Converters/Argumentum.AssetConverter.Tests/Argumentum.AssetConverter.Tests.csproj"` — targets **only** `Tests.csproj`, **not** VisualTests.

**Impact:** these `Assert.Fail`s fire **locally** (developer / po-2023 running the pipeline then the visual suite), **not in the release gate**. CI stays green regardless. This matches #963's finding.

## Files

| File | Tests | Sites converted |
|---|---|---|
| `PdfDimensionTests.cs` | 11 | EnsureTarget method + 11 call sites + 7 secondary guards |
| `PdfSnapshotTests.cs` | 3 | EnsureTarget method + 3 call sites + 3 File.Exists guards |
| `PdfContentTests.cs` | 6 | EnsureTarget method + 6 call sites + 10 secondary guards |

~20 tests total. Test code only.

## Build / test

**Build (compile proof):**
```
dotnet build Argumentum.AssetConverter.VisualTests.csproj
→ La génération a réussi. 0 Avertissement(s) 0 Erreur(s)
```

**Behaviour proof (one filtered test, `--no-build`):** this machine's `Target/` exists but has **no generated PDFs** (no `Documents/density-0/`) — the exact cold-start/partial state the fix targets.

```
dotnet test ...VisualTests.csproj --no-build --filter "FullyQualifiedName~A0_Pdf_Has_Correct_Dimensions"
→ Échoué! - échec: 4, réussite: 0, ignorée(s): 0, total: 4, durée: 13 ms
  Message: No A0 PDFs for fr in Target/ — test verified nothing (check pipeline output).
  at PdfDimensionTests.A0_Pdf_Has_Correct_Dimensions(...) line 77   ← the guard this PR added
```

**These 4 failures ARE the fix working**, not a regression. Before this PR, the same 4 variants passed **green and silent** (`Target/` present → `EnsureTarget()` returned true → `if (pdfs.Count == 0) return;` skipped quietly). After, they fail loud at the exact line added here (line 77) with a message ending "test verified nothing". The `EnsureTarget()` Assert path itself is the identical pattern already shipped in #963 (`f7875f68`, merged & working); on this machine `TargetRoot` exists so that branch isn't reached — the secondary guards are, and they fire correctly.

A fully-green `dotnet test` over the whole VisualTests suite is assertable only by a machine that has run the generation pipeline (a populated `Target/{lang}/Documents/density-0/` with PDFs) — a heavy lane run, out of scope for this test-code-only PR.

## Scope

Test code only (~+30/−10, 3 files). 0 prod write, 0 CSV, 0 OWL, 0 CardPen. Base: `ff80107b` (ai-01 dispatch).

## DoD (mirror #963)

- [x] Mute `return;` removed, replaced by explicit `Assert.Fail("…")` — all 3 files
- [x] A subtraction, not a counterweight — no `[Fact(Skip)]`, no continue-on-error, no fabricated coverage
- [x] CI legs verified — VisualTests compiled but NOT run by build.yml's Test step → fails locally, not in the release gate

🤖 po-2024
